### PR TITLE
[DEPRECATED] Feature: Adds integration of topik/youtube-music-obs-widget as plugin

### DIFF
--- a/plugins/obs-widget/back.js
+++ b/plugins/obs-widget/back.js
@@ -10,7 +10,7 @@ const data = {
 		seekbarCurrentPosition: 0,
 	},
 	track: {
-		author: "",
+		author: [],
 		title: "",
 		album: "",
 		cover: "",
@@ -31,14 +31,20 @@ module.exports = async (win) => {
 			res.end(JSON.stringify({}));
 			return;
 		}
-		data.player.hasSong = true;
-		data.player.isPaused = currentSongInfo.isPaused;
-		data.player.seekbarCurrentPosition = currentSongInfo.elapsedSeconds;
-		data.track.author = [currentSongInfo.artist];
-		data.track.title = currentSongInfo.title;
-		data.track.album = currentSongInfo.album;
-		data.track.cover = currentSongInfo.imageSrc;
-		data.track.duration = currentSongInfo.songDuration;
+                Object.assign(data, {
+                    player: {
+                        hasSong: true,
+                        isPaused: currentSongInfo.isPaused,
+                        seekbarCurrentPosition: currentSongInfo.elapsedSeconds
+                    },
+                    track: {
+                        author: [currentSongInfo.artist],
+                        title: currentSongInfo.title,
+                        album: currentSongInfo.album,
+                        cover: currentSongInfo.cover,
+                        duration: currentSongInfo.duration
+                    }
+                });
 		res.end(JSON.stringify(data));
 	};
 	const server = http.createServer(requestListener);

--- a/plugins/obs-widget/back.js
+++ b/plugins/obs-widget/back.js
@@ -1,0 +1,56 @@
+const {ipcMain} = require("electron");
+const http = require("http");
+const registerCallback = require("../../providers/song-info");
+
+let currentSongInfo;
+const data = {
+	player: {
+		hasSong: false,
+		isPaused: true,
+		seekbarCurrentPosition: 0,
+	},
+	track: {
+		author: "",
+		title: "",
+		album: "",
+		cover: "",
+		duration: 0,
+	}
+};
+
+/** @param {Electron.BrowserWindow} win */
+module.exports = async (win) => {
+	const requestListener = function (req, res) {
+		if(req.url !== '/query'){
+			res.writeHead(404);
+			res.end("404 Not found!");
+		}
+		res.setHeader("Access-Control-Allow-Origin", "*");
+		res.writeHead(200);
+		if (currentSongInfo !== undefined && !currentSongInfo.title && !currentSongInfo.artist) {
+			res.end(JSON.stringify({}));
+			return;
+		}
+		data.player.hasSong = true;
+		data.player.isPaused = currentSongInfo.isPaused;
+		data.player.seekbarCurrentPosition = currentSongInfo.elapsedSeconds;
+		data.track.author = [currentSongInfo.artist];
+		data.track.title = currentSongInfo.title;
+		data.track.album = currentSongInfo.album;
+		data.track.cover = currentSongInfo.imageSrc;
+		data.track.duration = currentSongInfo.songDuration;
+		res.end(JSON.stringify(data));
+	};
+	const server = http.createServer(requestListener);
+	server.listen(9863, "localhost", () => {
+	});
+	ipcMain.on('apiLoaded', () => win.webContents.send('setupTimeChangedListener'));
+	ipcMain.on('timeChanged', async (_, t) => {
+		if (!currentSongInfo.title || currentSongInfo.isPaused) return;
+		currentSongInfo.elapsedSeconds = t;
+	});
+
+	registerCallback((songInfo) => {
+		currentSongInfo = songInfo;
+	});
+};


### PR DESCRIPTION
Hello,

I got a [request](https://github.com/topik/youtube-music-obs-widget/issues/4) to add a plugin for my [obs widget](https://github.com/topik/youtube-music-obs-widget) so here it is. 

Plugin makes a simple http server and give a info about current song in JSON. The JSON structure is the same as in other YT music software that is being used so the obs widget is compatible.

Feel free to rename the plugin.

Thanks