### PR TITLE
fix(downloader): Implement retry logic for download failures with fal…

### DIFF
--- a/src/plugins/downloader/main/index.ts
+++ b/src/plugins/downloader/main/index.ts
@@ -418,7 +418,55 @@ async function downloadSongUnsafe(
     return;
   }
 
-  const stream = await info.download(downloadOptions);
+  let stream;
+  let retryCount = 0;
+  const maxRetries = 3;
+
+  while (retryCount < maxRetries) {
+    try {
+      if (retryCount > 0) {
+        console.log(`Retry attempt ${retryCount} for download`);
+        yt.session.cookie = await getCookieFromWindow(win);
+        
+        await new Promise(resolve => setTimeout(resolve, 1000 * retryCount));
+        
+        try {
+          info = await yt.music.getInfo(id);
+        } catch (refreshError) {
+          console.warn('Failed to refresh info:', refreshError);
+        }
+      }
+
+      stream = await info.download(downloadOptions);
+      break;
+      
+    } catch (downloadError) {
+      retryCount++;
+      console.warn(`Download attempt ${retryCount} failed:`, downloadError);
+      
+      if (retryCount >= maxRetries) {
+        if (format.url) {
+          try {
+            const response = await fetch(format.url);
+            if (!response.ok) {
+              throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+            }
+            stream = response.body;
+            console.log('Using direct URL download as fallback');
+            break;
+          } catch (urlError) {
+            throw new Error(`All download methods failed. Last error: ${downloadError}`);
+          }
+        } else {
+          throw new Error(`Download failed after ${maxRetries} attempts: ${downloadError}`);
+        }
+      }
+    }
+  }
+
+  if (!stream) {
+    throw new Error('Failed to get download stream');
+  }
 
   console.info(
     t('plugins.downloader.backend.feedback.download-info', {


### PR DESCRIPTION
This pull request introduces a retry mechanism in the `downloadSongUnsafe` function to handle download failures more robustly. It includes retry logic with exponential backoff and a fallback to direct URL downloading if all retries fail.

### Enhancements to download handling:

* [`src/plugins/downloader/main/index.ts`](diffhunk://#diff-6d7898ec714b81a0a11f4c47a9df86f932d659b9af44355a9de4bfcc41692cdcL421-R469): Added a retry mechanism with a maximum of 3 attempts for downloading, including a delay between retries and a refresh of the session cookie. If all retries fail, the code attempts to download using the direct URL as a fallback. This ensures more reliable handling of intermittent failures during the download process.