### PR TITLE
Improve video toggle plugin: replace dual buttons with single eye icon toggle

### DIFF
--- a/src/plugins/touchbar/index.ts
+++ b/src/plugins/touchbar/index.ts
@@ -1,11 +1,12 @@
 import { nativeImage, type NativeImage, TouchBar } from 'electron';
 
+import youtubeMusicIcon from '@assets/youtube-music.png?asset&asarUnpack';
+
 import { createPlugin } from '@/utils';
 import { getSongControls } from '@/providers/song-controls';
 import { registerCallback, SongInfoEvent } from '@/providers/song-info';
 import { t } from '@/i18n';
 
-import youtubeMusicIcon from '@assets/youtube-music.png?asset&asarUnpack';
 import { Platform } from '@/types/plugins';
 
 export default createPlugin({

--- a/src/plugins/video-toggle/button-switcher.css
+++ b/src/plugins/video-toggle/button-switcher.css
@@ -9,84 +9,56 @@
 .video-toggle-custom-mode .video-switch-button {
   z-index: 999;
   box-sizing: border-box;
-  padding: 0;
-  margin-top: 20px;
-  margin-left: 10px;
-  background: rgba(33, 33, 33, 0.4);
-  border-radius: 30px;
+  padding: 12px;
+  margin: 20px 10px 0px 10px;
+  background: rgba(33, 33, 33, 0.7);
+  border-radius: 50%;
   overflow: hidden;
-  width: 20rem;
+  width: 48px;
+  height: 48px;
   text-align: center;
-  font-size: 18px;
-  letter-spacing: 1px;
   color: #fff;
-  padding-right: 10rem;
   position: absolute;
-}
-
-.video-toggle-custom-mode .video-switch-button:before {
-  content: attr(data-video-button-text);
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  right: 0;
-  width: 10rem;
+  cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 3;
+  transition: all 0.2s ease;
+}
+
+.video-toggle-custom-mode .video-switch-button:hover {
+  background: rgba(33, 33, 33, 0.9);
+  transform: scale(1.1);
+}
+
+.video-toggle-custom-mode .video-toggle-icon {
+  width: 20px;
+  height: 20px;
+  color: #fff;
+  stroke: currentColor;
+  fill: none;
   pointer-events: none;
 }
 
-.video-toggle-custom-mode .video-switch-button-checkbox {
-  cursor: pointer;
-  position: absolute;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  width: 100%;
-  height: 100%;
-  opacity: 0;
-  z-index: 2;
-}
-
-.video-toggle-custom-mode .video-switch-button-label-span {
-  position: relative;
-}
-
-.video-toggle-custom-mode
-  .video-switch-button-checkbox:checked
-  + .video-switch-button-label:before {
-  transform: translateX(10rem);
-  transition: transform 300ms linear;
-}
-
-.video-toggle-custom-mode
-  .video-switch-button-checkbox
-  + .video-switch-button-label {
-  position: relative;
-  padding: 15px 0;
-  display: block;
-  user-select: none;
-  pointer-events: none;
-}
-
-.video-toggle-custom-mode
-  .video-switch-button-checkbox
-  + .video-switch-button-label:before {
-  content: '';
-  background: rgba(60, 60, 60, 0.4);
-  height: 100%;
-  width: 100%;
-  position: absolute;
-  left: 0;
-  top: 0;
-  border-radius: 30px;
-  transform: translateX(0);
-  transition: transform 300ms;
-}
-
-/* disable the native toggler */
 .video-toggle-custom-mode #av-id {
   display: none;
+}
+
+.video-toggle-custom-mode #song-video.ytmusic-player,
+.video-toggle-custom-mode #song-image {
+  position: relative !important;
+  margin: auto !important;
+  transition: none !important;
+}
+
+.video-toggle-custom-mode ytmusic-player {
+  margin: auto 0px !important;
+}
+
+.video-toggle-custom-mode #song-image img {
+  max-width: 100% !important;
+  max-height: 100% !important;
+  object-fit: cover !important;
+  display: block !important;
+  margin: auto !important;
 }

--- a/src/plugins/video-toggle/index.tsx
+++ b/src/plugins/video-toggle/index.tsx
@@ -213,7 +213,9 @@ export default createPlugin({
             showVideo ? 'OMV_PREFERRED' : 'ATV_PREFERRED',
           );
 
-          const videoElement = document.querySelector<HTMLElement>('#song-video.ytmusic-player');
+          const videoElement = document.querySelector<HTMLElement>(
+            '#song-video.ytmusic-player',
+          );
           const imageElement = document.querySelector<HTMLElement>('#song-image');
           
           if (videoElement && imageElement) {

--- a/src/plugins/video-toggle/index.tsx
+++ b/src/plugins/video-toggle/index.tsx
@@ -160,9 +160,9 @@ export default createPlugin({
 
       const config = await getConfig();
       this.config = config;
-      
+
       setVideoVisible(!config.hideVideo);
-      
+
       this.setVideoVisible = setVideoVisible;
 
       const moveVolumeHud = (await window.mainConfig.plugins.isEnabled(
@@ -215,9 +215,12 @@ export default createPlugin({
             showVideo ? 'OMV_PREFERRED' : 'ATV_PREFERRED',
           );
 
-          const videoElement = document.querySelector<HTMLElement>('#song-video.ytmusic-player');
-          const imageElement = document.querySelector<HTMLElement>('#song-image');
-          
+          const videoElement = document.querySelector<HTMLElement>(
+            '#song-video.ytmusic-player',
+          );
+          const imageElement =
+            document.querySelector<HTMLElement>('#song-image');
+
           if (videoElement && imageElement) {
             if (showVideo) {
               videoElement.style.display = 'block';

--- a/src/plugins/video-toggle/index.tsx
+++ b/src/plugins/video-toggle/index.tsx
@@ -218,7 +218,6 @@ export default createPlugin({
           );
           const imageElement =
             document.querySelector<HTMLElement>('#song-image');
-          
           if (videoElement && imageElement) {
             if (showVideo) {
               videoElement.style.display = 'block';

--- a/src/plugins/video-toggle/index.tsx
+++ b/src/plugins/video-toggle/index.tsx
@@ -160,9 +160,9 @@ export default createPlugin({
 
       const config = await getConfig();
       this.config = config;
-      
+
       setVideoVisible(!config.hideVideo);
-      
+
       this.setVideoVisible = setVideoVisible;
 
       const moveVolumeHud = (await window.mainConfig.plugins.isEnabled(
@@ -215,21 +215,24 @@ export default createPlugin({
             showVideo ? 'OMV_PREFERRED' : 'ATV_PREFERRED',
           );
 
-          const videoElement = document.querySelector<HTMLElement>('#song-video.ytmusic-player');
-          const imageElement = document.querySelector<HTMLElement>('#song-image');
-          
+          const videoElement = document.querySelector<HTMLElement>(
+            '#song-video.ytmusic-player',
+          );
+          const imageElement =
+            document.querySelector<HTMLElement>('#song-image');
+
           if (videoElement && imageElement) {
             if (showVideo) {
               videoElement.style.display = 'block';
               imageElement.style.display = 'none';
-              
+
               if (video && !video.style.top) {
                 video.style.top = `${(player.clientHeight - video.clientHeight) / 2}px`;
               }
             } else {
               videoElement.style.display = 'none';
               imageElement.style.display = 'block';
-              
+
               imageElement.style.position = 'relative';
               imageElement.style.width = '100%';
               imageElement.style.height = '100%';
@@ -326,9 +329,12 @@ export default createPlugin({
         if (!playerSelector) return;
 
         const initializeConsistentStyling = () => {
-          const videoElement = document.querySelector<HTMLElement>('#song-video.ytmusic-player');
-          const imageElement = document.querySelector<HTMLElement>('#song-image');
-          
+          const videoElement = document.querySelector<HTMLElement>(
+            '#song-video.ytmusic-player',
+          );
+          const imageElement =
+            document.querySelector<HTMLElement>('#song-image');
+
           if (videoElement && imageElement) {
             videoElement.style.position = 'relative';
             videoElement.style.margin = 'auto';
@@ -347,14 +353,16 @@ export default createPlugin({
         video?.addEventListener('ytmd:src-changed', videoStarted);
         observeThumbnail();
         videoStarted();
-        
+
         if (this.config) {
-          const container = document.getElementById('ytmd-video-toggle-switch-button-container');
+          const container = document.getElementById(
+            'ytmd-video-toggle-switch-button-container',
+          );
           if (container) {
             const alignmentMap = {
               right: 'flex-end',
               middle: 'center',
-              left: 'flex-start'
+              left: 'flex-start',
             };
             container.style.justifyContent = alignmentMap[this.config.align];
           }
@@ -364,17 +372,19 @@ export default createPlugin({
     onConfigChange(newConfig) {
       this.config = newConfig;
       this.applyStyleClass(newConfig);
-      
-      const container = document.getElementById('ytmd-video-toggle-switch-button-container');
+
+      const container = document.getElementById(
+        'ytmd-video-toggle-switch-button-container',
+      );
       if (container) {
         const alignmentMap = {
           right: 'flex-end',
           middle: 'center',
-          left: 'flex-start'
+          left: 'flex-start',
         };
         container.style.justifyContent = alignmentMap[newConfig.align];
       }
-      
+
       if (this.setVideoVisible) {
         this.setVideoVisible(!newConfig.hideVideo);
       }

--- a/src/plugins/video-toggle/index.tsx
+++ b/src/plugins/video-toggle/index.tsx
@@ -160,7 +160,6 @@ export default createPlugin({
 
       const config = await getConfig();
       this.config = config;
-      
       setVideoVisible(!config.hideVideo);
       this.setVideoVisible = setVideoVisible;
 

--- a/src/plugins/video-toggle/index.tsx
+++ b/src/plugins/video-toggle/index.tsx
@@ -216,7 +216,8 @@ export default createPlugin({
           const videoElement = document.querySelector<HTMLElement>(
             '#song-video.ytmusic-player',
           );
-          const imageElement = document.querySelector<HTMLElement>('#song-image');
+          const imageElement =
+            document.querySelector<HTMLElement>('#song-image');
           
           if (videoElement && imageElement) {
             if (showVideo) {

--- a/src/plugins/video-toggle/index.tsx
+++ b/src/plugins/video-toggle/index.tsx
@@ -162,7 +162,6 @@ export default createPlugin({
       this.config = config;
       
       setVideoVisible(!config.hideVideo);
-      
       this.setVideoVisible = setVideoVisible;
 
       const moveVolumeHud = (await window.mainConfig.plugins.isEnabled(

--- a/src/plugins/video-toggle/templates/video-switch-button.tsx
+++ b/src/plugins/video-toggle/templates/video-switch-button.tsx
@@ -1,28 +1,51 @@
-export interface VideoSwitchButtonProps {
-  onClick?: (event: MouseEvent) => void;
-  onChange?: (event: Event) => void;
-  songButtonText: string;
-  videoButtonText: string;
+import { createSignal, createEffect } from 'solid-js';
+
+interface VideoSwitchButtonProps {
+  initialVideoVisible?: boolean;
+  onVideoToggle?: (showVideo: boolean) => void;
 }
 
-export const VideoSwitchButton = (props: VideoSwitchButtonProps) => (
-  <div
-    class="video-switch-button"
-    data-video-button-text={props.videoButtonText}
-    on:click={(e) => props.onClick?.(e)}
-    onChange={(e) => props.onChange?.(e)}
-  >
-    <input
-      checked={true}
-      class="video-switch-button-checkbox"
-      id="video-toggle-video-switch-button-checkbox"
-      type="checkbox"
-    />
-    <label
-      class="video-switch-button-label"
-      for="video-toggle-video-switch-button-checkbox"
-    >
-      <span class="video-switch-button-label-span">{props.songButtonText}</span>
-    </label>
-  </div>
-);
+export const VideoSwitchButton = (props: VideoSwitchButtonProps) => {
+  const [isVideoVisible, setIsVideoVisible] = createSignal(props.initialVideoVisible ?? true);
+
+  createEffect(() => {
+    if (props.initialVideoVisible !== undefined) {
+      setIsVideoVisible(props.initialVideoVisible);
+    }
+  });
+
+  const toggleVideo = (e: MouseEvent) => {
+    const newState = !isVideoVisible();
+    setIsVideoVisible(newState);
+    props.onVideoToggle?.(newState);
+    e.stopPropagation();
+  };
+
+  return (
+    <div class="video-switch-button" on:click={toggleVideo}>
+      <svg 
+        class="video-toggle-icon"
+        style={{ display: isVideoVisible() ? 'block' : 'none' }}
+        xmlns="http://www.w3.org/2000/svg" 
+        width="24" 
+        height="24" 
+        viewBox="0 0 24 24" 
+        fill="none"
+      >
+        <path d="M15.0007 12C15.0007 13.6569 13.6576 15 12.0007 15C10.3439 15 9.00073 13.6569 9.00073 12C9.00073 10.3431 10.3439 9 12.0007 9C13.6576 9 15.0007 10.3431 15.0007 12Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M12.0012 5C7.52354 5 3.73326 7.94288 2.45898 12C3.73324 16.0571 7.52354 19 12.0012 19C16.4788 19 20.2691 16.0571 21.5434 12C20.2691 7.94291 16.4788 5 12.0012 5Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+      <svg 
+        class="video-toggle-icon"
+        style={{ display: isVideoVisible() ? 'none' : 'block' }}
+        xmlns="http://www.w3.org/2000/svg" 
+        width="24" 
+        height="24" 
+        viewBox="0 0 24 24" 
+        fill="none"
+      >
+        <path d="M2.99902 3L20.999 21M9.8433 9.91364C9.32066 10.4536 8.99902 11.1892 8.99902 12C8.99902 13.6569 10.3422 15 11.999 15C12.8215 15 13.5667 14.669 14.1086 14.133M6.49902 6.64715C4.59972 7.90034 3.15305 9.78394 2.45703 12C3.73128 16.0571 7.52159 19 11.9992 19C13.9881 19 15.8414 18.4194 17.3988 17.4184M10.999 5.04939C11.328 5.01673 11.6617 5 11.9992 5C16.4769 5 20.2672 7.94291 21.5414 12C21.2607 12.894 20.8577 13.7338 20.3522 14.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+    </div>
+  );
+};

--- a/src/plugins/video-toggle/templates/video-switch-button.tsx
+++ b/src/plugins/video-toggle/templates/video-switch-button.tsx
@@ -29,7 +29,7 @@ export const VideoSwitchButton = (props: VideoSwitchButtonProps) => {
         xmlns="http://www.w3.org/2000/svg" 
         width="24" 
         height="24" 
-        viewBox="0 0 24 24" 
+        viewBox="0 0 24 24"
         fill="none"
       >
         <path d="M15.0007 12C15.0007 13.6569 13.6576 15 12.0007 15C10.3439 15 9.00073 13.6569 9.00073 12C9.00073 10.3431 10.3439 9 12.0007 9C13.6576 9 15.0007 10.3431 15.0007 12Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>

--- a/src/plugins/video-toggle/templates/video-switch-button.tsx
+++ b/src/plugins/video-toggle/templates/video-switch-button.tsx
@@ -6,7 +6,9 @@ interface VideoSwitchButtonProps {
 }
 
 export const VideoSwitchButton = (props: VideoSwitchButtonProps) => {
-  const [isVideoVisible, setIsVideoVisible] = createSignal(props.initialVideoVisible ?? true);
+  const [isVideoVisible, setIsVideoVisible] = createSignal(
+    props.initialVideoVisible ?? true,
+  );
 
   createEffect(() => {
     if (props.initialVideoVisible !== undefined) {
@@ -23,28 +25,46 @@ export const VideoSwitchButton = (props: VideoSwitchButtonProps) => {
 
   return (
     <div class="video-switch-button" on:click={toggleVideo}>
-      <svg 
+      <svg
         class="video-toggle-icon"
+        fill="none"
+        height="24"
         style={{ display: isVideoVisible() ? 'block' : 'none' }}
-        xmlns="http://www.w3.org/2000/svg" 
-        width="24" 
-        height="24" 
-        viewBox="0 0 24 24" 
-        fill="none"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
       >
-        <path d="M15.0007 12C15.0007 13.6569 13.6576 15 12.0007 15C10.3439 15 9.00073 13.6569 9.00073 12C9.00073 10.3431 10.3439 9 12.0007 9C13.6576 9 15.0007 10.3431 15.0007 12Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-        <path d="M12.0012 5C7.52354 5 3.73326 7.94288 2.45898 12C3.73324 16.0571 7.52354 19 12.0012 19C16.4788 19 20.2691 16.0571 21.5434 12C20.2691 7.94291 16.4788 5 12.0012 5Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        <path
+          d="M15.0007 12C15.0007 13.6569 13.6576 15 12.0007 15C10.3439 15 9.00073 13.6569 9.00073 12C9.00073 10.3431 10.3439 9 12.0007 9C13.6576 9 15.0007 10.3431 15.0007 12Z"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+        />
+        <path
+          d="M12.0012 5C7.52354 5 3.73326 7.94288 2.45898 12C3.73324 16.0571 7.52354 19 12.0012 19C16.4788 19 20.2691 16.0571 21.5434 12C20.2691 7.94291 16.4788 5 12.0012 5Z"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+        />
       </svg>
-      <svg 
+      <svg
         class="video-toggle-icon"
-        style={{ display: isVideoVisible() ? 'none' : 'block' }}
-        xmlns="http://www.w3.org/2000/svg" 
-        width="24" 
-        height="24" 
-        viewBox="0 0 24 24" 
         fill="none"
+        height="24"
+        style={{ display: isVideoVisible() ? 'none' : 'block' }}
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
       >
-        <path d="M2.99902 3L20.999 21M9.8433 9.91364C9.32066 10.4536 8.99902 11.1892 8.99902 12C8.99902 13.6569 10.3422 15 11.999 15C12.8215 15 13.5667 14.669 14.1086 14.133M6.49902 6.64715C4.59972 7.90034 3.15305 9.78394 2.45703 12C3.73128 16.0571 7.52159 19 11.9992 19C13.9881 19 15.8414 18.4194 17.3988 17.4184M10.999 5.04939C11.328 5.01673 11.6617 5 11.9992 5C16.4769 5 20.2672 7.94291 21.5414 12C21.2607 12.894 20.8577 13.7338 20.3522 14.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        <path
+          d="M2.99902 3L20.999 21M9.8433 9.91364C9.32066 10.4536 8.99902 11.1892 8.99902 12C8.99902 13.6569 10.3422 15 11.999 15C12.8215 15 13.5667 14.669 14.1086 14.133M6.49902 6.64715C4.59972 7.90034 3.15305 9.78394 2.45703 12C3.73128 16.0571 7.52159 19 11.9992 19C13.9881 19 15.8414 18.4194 17.3988 17.4184M10.999 5.04939C11.328 5.01673 11.6617 5 11.9992 5C16.4769 5 20.2672 7.94291 21.5414 12C21.2607 12.894 20.8577 13.7338 20.3522 14.5"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+        />
       </svg>
     </div>
   );

--- a/src/plugins/video-toggle/templates/video-switch-button.tsx
+++ b/src/plugins/video-toggle/templates/video-switch-button.tsx
@@ -25,7 +25,7 @@ export const VideoSwitchButton = (props: VideoSwitchButtonProps) => {
 
   return (
     <div class="video-switch-button" on:click={toggleVideo}>
-      <svg 
+      <svg
         class="video-toggle-icon"
         fill="none"
         height="24"
@@ -34,8 +34,20 @@ export const VideoSwitchButton = (props: VideoSwitchButtonProps) => {
         width="24"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <path d="M15.0007 12C15.0007 13.6569 13.6576 15 12.0007 15C10.3439 15 9.00073 13.6569 9.00073 12C9.00073 10.3431 10.3439 9 12.0007 9C13.6576 9 15.0007 10.3431 15.0007 12Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-        <path d="M12.0012 5C7.52354 5 3.73326 7.94288 2.45898 12C3.73324 16.0571 7.52354 19 12.0012 19C16.4788 19 20.2691 16.0571 21.5434 12C20.2691 7.94291 16.4788 5 12.0012 5Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        <path
+          d="M15.0007 12C15.0007 13.6569 13.6576 15 12.0007 15C10.3439 15 9.00073 13.6569 9.00073 12C9.00073 10.3431 10.3439 9 12.0007 9C13.6576 9 15.0007 10.3431 15.0007 12Z"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+        />
+        <path
+          d="M12.0012 5C7.52354 5 3.73326 7.94288 2.45898 12C3.73324 16.0571 7.52354 19 12.0012 19C16.4788 19 20.2691 16.0571 21.5434 12C20.2691 7.94291 16.4788 5 12.0012 5Z"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+        />
       </svg>
       <svg
         class="video-toggle-icon"


### PR DESCRIPTION
Hello! I had an issue with the design of the toggle-video plugin, so I changed it to a simple icon, and the configuration is now applied correctly. I haven't seen the modes because I haven't focused on that, haha. The position of the thumbnail has also been improved because it used to move when hidden.

<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/b774a981-aefd-426d-8cb9-9183a2836ebf" />
<img width="858" height="521" alt="image" src="https://github.com/user-attachments/assets/b8e57f25-00dc-4387-ad1f-a42608aba9a1" />
<img width="968" height="684" alt="image" src="https://github.com/user-attachments/assets/47d18c58-5595-41ff-9640-3b5afdb53dcf" />
<img width="983" height="727" alt="image" src="https://github.com/user-attachments/assets/e1cd1a4b-265e-4e66-9f6a-a4c2f4e6b77c" />
