### PR TITLE
feat(plugin): Skip Live Songs - Automatically skip most non-studio recordings

### DIFF
--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -802,6 +802,10 @@
       "description": "Automatically skip silences sections in songs",
       "name": "Skip Silences"
     },
+    "skip-live-songs": {
+      "description": "Automatically tries to skip renditions of songs",
+      "name": "Skip Live Songs"
+    },
     "sponsorblock": {
       "description": "Automatically Skips non-music parts like intro/outro or parts of music videos where the song isn't playing",
       "name": "SponsorBlock"

--- a/src/plugins/skip-live-songs/index.ts
+++ b/src/plugins/skip-live-songs/index.ts
@@ -80,7 +80,9 @@ export default createPlugin({
       if (this._skipLiveHandler) {
         ipc.removeAllListeners('peard:update-song-info');
         this._skipLiveHandler = undefined;
-        console.debug('[Skip Live Songs] Renderer stopped and listeners removed');
+        console.debug(
+          '[Skip Live Songs] Renderer stopped and listeners removed',
+        );
       }
     },
   },

--- a/src/plugins/skip-live-songs/index.ts
+++ b/src/plugins/skip-live-songs/index.ts
@@ -2,6 +2,7 @@ import { t } from '@/i18n';
 import { createPlugin } from '@/utils';
 
 import type { SongInfo } from '@/providers/song-info';
+
 import { nonStudioPatterns } from './patterns';
 import type { SongInfo } from '@/providers/song-info';
 

--- a/src/plugins/skip-live-songs/index.ts
+++ b/src/plugins/skip-live-songs/index.ts
@@ -4,6 +4,7 @@ import { createPlugin } from '@/utils';
 import type { SongInfo } from '@/providers/song-info';
 
 import { nonStudioPatterns } from './patterns';
+
 import type { SongInfo } from '@/providers/song-info';
 
 export default createPlugin({

--- a/src/plugins/skip-live-songs/index.ts
+++ b/src/plugins/skip-live-songs/index.ts
@@ -2,6 +2,7 @@ import { t } from '@/i18n';
 import { createPlugin } from '@/utils';
 
 import type { SongInfo } from '@/providers/song-info';
+
 import { nonStudioPatterns } from './patterns';
 
 export default createPlugin({

--- a/src/plugins/skip-live-songs/index.ts
+++ b/src/plugins/skip-live-songs/index.ts
@@ -39,7 +39,9 @@ export default createPlugin({
         // Skip if we've already attempted this video id
         if (songInfo.videoId === this.lastSkippedVideoId) return;
 
-        const isNonStudio = nonStudioPatterns.some(pattern => pattern.test(titleToCheck));
+        const isNonStudio = nonStudioPatterns.some((pattern) =>
+          pattern.test(titleToCheck),
+        );
 
         if (!isNonStudio) return; // studio version — nothing to do
 

--- a/src/plugins/skip-live-songs/index.ts
+++ b/src/plugins/skip-live-songs/index.ts
@@ -4,7 +4,6 @@ import { createPlugin } from '@/utils';
 import type { SongInfo } from '@/providers/song-info';
 import { nonStudioPatterns } from './patterns';
 
-
 export default createPlugin({
   name: () => t('plugins.skip-live-songs.name'),
   description: () => t('plugins.skip-live-songs.description'),

--- a/src/plugins/skip-live-songs/index.ts
+++ b/src/plugins/skip-live-songs/index.ts
@@ -47,7 +47,9 @@ export default createPlugin({
 
         // Mark as attempted so we don't loop repeatedly
         this.lastSkippedVideoId = songInfo.videoId;
-        console.info(`[Skip Live Songs] Skipping non-studio song: "${titleToCheck}" (id: ${songInfo.videoId})`);
+        console.info(
+          `[Skip Live Songs] Skipping non-studio song: "${titleToCheck}" (id: ${songInfo.videoId})`,
+        );
 
         let clicked = false;
         for (const sel of SELECTORS) {

--- a/src/plugins/skip-live-songs/index.ts
+++ b/src/plugins/skip-live-songs/index.ts
@@ -4,7 +4,6 @@ import { createPlugin } from '@/utils';
 import type { SongInfo } from '@/providers/song-info';
 import { nonStudioPatterns } from './patterns';
 
-import type { SongInfo } from '@/providers/song-info';
 
 export default createPlugin({
   name: () => t('plugins.skip-live-songs.name'),

--- a/src/plugins/skip-live-songs/index.ts
+++ b/src/plugins/skip-live-songs/index.ts
@@ -1,0 +1,75 @@
+import { t } from '@/i18n';
+import { createPlugin } from '@/utils';
+import type { SongInfo } from '@/providers/song-info';
+import { nonStudioPatterns } from './patterns';
+
+export default createPlugin({
+  name: () => t('plugins.skip-live-songs.name'),
+  description: () => t('plugins.skip-live-songs.description'),
+  restartNeeded: false,
+  config: {
+    enabled: false,
+  },
+  renderer: {
+    lastSkippedVideoId: '',
+
+    _skipLiveHandler: undefined as unknown as ((songInfo: SongInfo) => void) | undefined,
+
+    start({ ipc }) {
+      console.debug('[Skip Live Songs] Renderer started');
+
+      const SELECTORS = [
+        'yt-icon-button.next-button',
+        '.next-button',
+        'button[aria-label*="Next"]',
+        'button[aria-label*="next"]',
+        '#player-bar-next-button',
+        'ytmusic-player-bar .next-button',
+        '.player-bar .next-button',
+      ];
+
+      const handler = (songInfo: SongInfo) => {
+        const titleToCheck = songInfo.alternativeTitle || songInfo.title;
+        if (!titleToCheck) return;
+
+        // Skip if we've already attempted this video id
+        if (songInfo.videoId === this.lastSkippedVideoId) return;
+
+        const isNonStudio = nonStudioPatterns.some(pattern => pattern.test(titleToCheck));
+
+        if (!isNonStudio) return; // studio version — nothing to do
+
+        // Mark as attempted so we don't loop repeatedly
+        this.lastSkippedVideoId = songInfo.videoId;
+        console.info(`[Skip Live Songs] Skipping non-studio song: "${titleToCheck}" (id: ${songInfo.videoId})`);
+
+        let clicked = false;
+        for (const sel of SELECTORS) {
+          const button = document.querySelector<HTMLElement>(sel);
+          if (button) {
+            button.click();
+            console.debug(`[Skip Live Songs] Clicked next button using selector: ${sel}`);
+            clicked = true;
+            break;
+          }
+        }
+
+        if (!clicked) {
+          console.warn('[Skip Live Songs] Could not find next button with any configured selector');
+        }
+      };
+
+      this._skipLiveHandler = handler;
+      ipc.on('peard:update-song-info', handler);
+    },
+
+    // Unregister the ipc handler on plugin stop to avoid duplicate listeners on hot reload
+    stop({ ipc }) {
+      if (this._skipLiveHandler) {
+        ipc.removeAllListeners('peard:update-song-info');
+        this._skipLiveHandler = undefined;
+        console.debug('[Skip Live Songs] Renderer stopped and listeners removed');
+      }
+    },
+  },
+});

--- a/src/plugins/skip-live-songs/index.ts
+++ b/src/plugins/skip-live-songs/index.ts
@@ -2,8 +2,8 @@ import { t } from '@/i18n';
 import { createPlugin } from '@/utils';
 
 import type { SongInfo } from '@/providers/song-info';
-
 import { nonStudioPatterns } from './patterns';
+import type { SongInfo } from '@/providers/song-info';
 
 export default createPlugin({
   name: () => t('plugins.skip-live-songs.name'),

--- a/src/plugins/skip-live-songs/index.ts
+++ b/src/plugins/skip-live-songs/index.ts
@@ -3,7 +3,6 @@ import { createPlugin } from '@/utils';
 
 import type { SongInfo } from '@/providers/song-info';
 import { nonStudioPatterns } from './patterns';
-import type { SongInfo } from '@/providers/song-info';
 
 import type { SongInfo } from '@/providers/song-info';
 

--- a/src/plugins/skip-live-songs/index.ts
+++ b/src/plugins/skip-live-songs/index.ts
@@ -65,7 +65,9 @@ export default createPlugin({
         }
 
         if (!clicked) {
-          console.warn('[Skip Live Songs] Could not find next button with any configured selector');
+          console.warn(
+            '[Skip Live Songs] Could not find next button with any configured selector',
+          );
         }
       };
 

--- a/src/plugins/skip-live-songs/index.ts
+++ b/src/plugins/skip-live-songs/index.ts
@@ -15,7 +15,9 @@ export default createPlugin({
   renderer: {
     lastSkippedVideoId: '',
 
-    _skipLiveHandler: undefined as unknown as ((songInfo: SongInfo) => void) | undefined,
+    _skipLiveHandler: undefined as unknown as
+      | ((songInfo: SongInfo) => void)
+      | undefined,
 
     start({ ipc }) {
       console.debug('[Skip Live Songs] Renderer started');

--- a/src/plugins/skip-live-songs/index.ts
+++ b/src/plugins/skip-live-songs/index.ts
@@ -2,8 +2,8 @@ import { t } from '@/i18n';
 import { createPlugin } from '@/utils';
 
 import type { SongInfo } from '@/providers/song-info';
-
 import { nonStudioPatterns } from './patterns';
+import type { SongInfo } from '@/providers/song-info';
 
 import type { SongInfo } from '@/providers/song-info';
 

--- a/src/plugins/skip-live-songs/index.ts
+++ b/src/plugins/skip-live-songs/index.ts
@@ -54,7 +54,9 @@ export default createPlugin({
           const button = document.querySelector<HTMLElement>(sel);
           if (button) {
             button.click();
-            console.debug(`[Skip Live Songs] Clicked next button using selector: ${sel}`);
+            console.debug(
+              `[Skip Live Songs] Clicked next button using selector: ${sel}`,
+            );
             clicked = true;
             break;
           }

--- a/src/plugins/skip-live-songs/index.ts
+++ b/src/plugins/skip-live-songs/index.ts
@@ -1,5 +1,6 @@
 import { t } from '@/i18n';
 import { createPlugin } from '@/utils';
+
 import type { SongInfo } from '@/providers/song-info';
 import { nonStudioPatterns } from './patterns';
 

--- a/src/plugins/skip-live-songs/patterns.ts
+++ b/src/plugins/skip-live-songs/patterns.ts
@@ -8,7 +8,7 @@
 export const nonStudioPatterns = [
   // "Live" in specific contexts (not as part of song title)
   /[\(\[]live[\)\]]/i, // "(Live)" or "[Live]" in parentheses/brackets
-  /live\s+(at|from|in|on|with|@)/i,                    // "Live at", "Live from", "Live in", etc.
+  /live\s+(at|from|in|on|with|@)/i, // "Live at", "Live from", "Live in", etc.
   /live\s+with\b/i,                              // "Live with" (e.g. "Live with the SFSO")
   /-\s*live\s*$/i,                                // "- Live" at the end of title
   /:\s*live\s*$/i,                                // ": Live" at the end of title

--- a/src/plugins/skip-live-songs/patterns.ts
+++ b/src/plugins/skip-live-songs/patterns.ts
@@ -10,7 +10,7 @@ export const nonStudioPatterns = [
   /[\(\[]live[\)\]]/i, // "(Live)" or "[Live]" in parentheses/brackets
   /live\s+(at|from|in|on|with|@)/i, // "Live at", "Live from", "Live in", etc.
   /live\s+with\b/i, // "Live with" (e.g. "Live with the SFSO")
-  /-\s*live\s*$/i,                                // "- Live" at the end of title
+  /-\s*live\s*$/i, // "- Live" at the end of title
   /:\s*live\s*$/i,                                // ": Live" at the end of title
   
   // Concert/Performance indicators

--- a/src/plugins/skip-live-songs/patterns.ts
+++ b/src/plugins/skip-live-songs/patterns.ts
@@ -23,7 +23,7 @@ export const nonStudioPatterns = [
   // Venues
   /\b(arena|stadium|center|centre|hall)\b/i,      // Arena, Stadium, Center, Hall
   /\bmadison\s+square\s+garden\b/i, // Madison Square Garden
-  /day\s+on\s+the\s+green/i,                      // Day on the Green
+  /day\s+on\s+the\s+green/i, // Day on the Green
   
   // Famous venues/festivals
   /\b(wembley|glastonbury|woodstock|coachella)\b/i, // Wembley, Glastonbury, Woodstock, Coachella

--- a/src/plugins/skip-live-songs/patterns.ts
+++ b/src/plugins/skip-live-songs/patterns.ts
@@ -22,7 +22,7 @@ export const nonStudioPatterns = [
   
   // Venues
   /\b(arena|stadium|center|centre|hall)\b/i,      // Arena, Stadium, Center, Hall
-  /\bmadison\s+square\s+garden\b/i,               // Madison Square Garden
+  /\bmadison\s+square\s+garden\b/i, // Madison Square Garden
   /day\s+on\s+the\s+green/i,                      // Day on the Green
   
   // Famous venues/festivals

--- a/src/plugins/skip-live-songs/patterns.ts
+++ b/src/plugins/skip-live-songs/patterns.ts
@@ -11,15 +11,12 @@ export const nonStudioPatterns = [
   /live\s+(at|from|in|on|with|@)/i, // "Live at", "Live from", "Live in", etc.
   /live\s+with\b/i, // "Live with" (e.g. "Live with the SFSO")
   /-\s*live\s*$/i, // "- Live" at the end of title
-  /:\s*live\s*$/i,                                // ": Live" at the end of title
-  
+  /:\s*live\s*$/i, // ": Live" at the end of title
   // Concert/Performance indicators
-  /\b(concert|festival|tour)\b/i,                 // Concert, Festival, Tour
+  /\b(concert|festival|tour)\b/i, // Concert, Festival, Tour
   /\(.*?(concert|live performance|live recording).*?(19|20)\d{2}\)/i, // (Live 1985), (Concert 2024)
-  
   // Recording types
-  /\b(acoustic|unplugged|rehearsal|demo)\b/i,     // Acoustic, Unplugged, Rehearsal, Demo
-  
+  /\b(acoustic|unplugged|rehearsal|demo)\b/i, // Acoustic, Unplugged, Rehearsal, Demo
   // Venues
   /\b(arena|stadium|center|centre|hall)\b/i, // Arena, Stadium, Center, Hall
   /\bmadison\s+square\s+garden\b/i, // Madison Square Garden
@@ -29,9 +26,9 @@ export const nonStudioPatterns = [
   // Dates and locations
   /\b(january|february|march|april|may|june|july|august|september|october|november|december)\s+\d+/i, // "September 22", "August 31"
   /\b\d{1,2}[/-]\d{1,2}[/-]\d{2,4}\b/, // Date formats: 09/22/2024, 9-22-24
-  /\b[A-Z][a-z]+,\s*[A-Z]{2}\b/,                 // Locations: "Oakland, CA", "London, UK"
-  /\b[A-Z][a-z]+\s+City\b/i,                      // Cities: "Mexico City", "New York City"
-  /\b(tokyo|paris|berlin|sydney)\b/i,             // More cities
-  /\b(bbc|radio|session)\b/i,                      // Radio sessions
+  /\b[A-Z][a-z]+,\s*[A-Z]{2}\b/, // Locations: "Oakland, CA", "London, UK"
+  /\b[A-Z][a-z]+\s+City\b/i, // Cities: "Mexico City", "New York City"
+  /\b(tokyo|paris|berlin|sydney)\b/i, // More cities
+  /\b(bbc|radio|session)\b/i, // Radio sessions
 ];
 

--- a/src/plugins/skip-live-songs/patterns.ts
+++ b/src/plugins/skip-live-songs/patterns.ts
@@ -28,7 +28,7 @@ export const nonStudioPatterns = [
   /\b(wembley|glastonbury|woodstock|coachella)\b/i, // Wembley, Glastonbury, Woodstock, Coachella
   // Dates and locations
   /\b(january|february|march|april|may|june|july|august|september|october|november|december)\s+\d+/i, // "September 22", "August 31"
-  /\b\d{1,2}[/-]\d{1,2}[/-]\d{2,4}\b/,           // Date formats: 09/22/2024, 9-22-24
+  /\b\d{1,2}[/-]\d{1,2}[/-]\d{2,4}\b/, // Date formats: 09/22/2024, 9-22-24
   /\b[A-Z][a-z]+,\s*[A-Z]{2}\b/,                 // Locations: "Oakland, CA", "London, UK"
   /\b[A-Z][a-z]+\s+City\b/i,                      // Cities: "Mexico City", "New York City"
   /\b(tokyo|paris|berlin|sydney)\b/i,             // More cities

--- a/src/plugins/skip-live-songs/patterns.ts
+++ b/src/plugins/skip-live-songs/patterns.ts
@@ -1,6 +1,6 @@
 /**
  * Patterns to detect non-studio recordings
- * 
+ *
  * Add or modify patterns here to customize what gets skipped.
  * All patterns are not case-sensitive.
  */

--- a/src/plugins/skip-live-songs/patterns.ts
+++ b/src/plugins/skip-live-songs/patterns.ts
@@ -24,7 +24,6 @@ export const nonStudioPatterns = [
   /\b(arena|stadium|center|centre|hall)\b/i,      // Arena, Stadium, Center, Hall
   /\bmadison\s+square\s+garden\b/i, // Madison Square Garden
   /day\s+on\s+the\s+green/i, // Day on the Green
-  
   // Famous venues/festivals
   /\b(wembley|glastonbury|woodstock|coachella)\b/i, // Wembley, Glastonbury, Woodstock, Coachella
   

--- a/src/plugins/skip-live-songs/patterns.ts
+++ b/src/plugins/skip-live-songs/patterns.ts
@@ -9,7 +9,7 @@ export const nonStudioPatterns = [
   // "Live" in specific contexts (not as part of song title)
   /[\(\[]live[\)\]]/i, // "(Live)" or "[Live]" in parentheses/brackets
   /live\s+(at|from|in|on|with|@)/i, // "Live at", "Live from", "Live in", etc.
-  /live\s+with\b/i,                              // "Live with" (e.g. "Live with the SFSO")
+  /live\s+with\b/i, // "Live with" (e.g. "Live with the SFSO")
   /-\s*live\s*$/i,                                // "- Live" at the end of title
   /:\s*live\s*$/i,                                // ": Live" at the end of title
   

--- a/src/plugins/skip-live-songs/patterns.ts
+++ b/src/plugins/skip-live-songs/patterns.ts
@@ -21,7 +21,7 @@ export const nonStudioPatterns = [
   /\b(acoustic|unplugged|rehearsal|demo)\b/i,     // Acoustic, Unplugged, Rehearsal, Demo
   
   // Venues
-  /\b(arena|stadium|center|centre|hall)\b/i,      // Arena, Stadium, Center, Hall
+  /\b(arena|stadium|center|centre|hall)\b/i, // Arena, Stadium, Center, Hall
   /\bmadison\s+square\s+garden\b/i, // Madison Square Garden
   /day\s+on\s+the\s+green/i, // Day on the Green
   // Famous venues/festivals

--- a/src/plugins/skip-live-songs/patterns.ts
+++ b/src/plugins/skip-live-songs/patterns.ts
@@ -1,0 +1,39 @@
+/**
+ * Patterns to detect non-studio recordings
+ * 
+ * Add or modify patterns here to customize what gets skipped.
+ * All patterns are not case-sensitive.
+ */
+
+export const nonStudioPatterns = [
+  // "Live" in specific contexts (not as part of song title)
+  /[\(\[]live[\)\]]/i,                            // "(Live)" or "[Live]" in parentheses/brackets
+  /live\s+(at|from|in|on|with|@)/i,                    // "Live at", "Live from", "Live in", etc.
+  /live\s+with\b/i,                              // "Live with" (e.g. "Live with the SFSO")
+  /-\s*live\s*$/i,                                // "- Live" at the end of title
+  /:\s*live\s*$/i,                                // ": Live" at the end of title
+  
+  // Concert/Performance indicators
+  /\b(concert|festival|tour)\b/i,                 // Concert, Festival, Tour
+  /\(.*?(concert|live performance|live recording).*?(19|20)\d{2}\)/i, // (Live 1985), (Concert 2024)
+  
+  // Recording types
+  /\b(acoustic|unplugged|rehearsal|demo)\b/i,     // Acoustic, Unplugged, Rehearsal, Demo
+  
+  // Venues
+  /\b(arena|stadium|center|centre|hall)\b/i,      // Arena, Stadium, Center, Hall
+  /\bmadison\s+square\s+garden\b/i,               // Madison Square Garden
+  /day\s+on\s+the\s+green/i,                      // Day on the Green
+  
+  // Famous venues/festivals
+  /\b(wembley|glastonbury|woodstock|coachella)\b/i, // Wembley, Glastonbury, Woodstock, Coachella
+  
+  // Dates and locations
+  /\b(january|february|march|april|may|june|july|august|september|october|november|december)\s+\d+/i, // "September 22", "August 31"
+  /\b\d{1,2}[/-]\d{1,2}[/-]\d{2,4}\b/,           // Date formats: 09/22/2024, 9-22-24
+  /\b[A-Z][a-z]+,\s*[A-Z]{2}\b/,                 // Locations: "Oakland, CA", "London, UK"
+  /\b[A-Z][a-z]+\s+City\b/i,                      // Cities: "Mexico City", "New York City"
+  /\b(tokyo|paris|berlin|sydney)\b/i,             // More cities
+  /\b(bbc|radio|session)\b/i,                      // Radio sessions
+];
+

--- a/src/plugins/skip-live-songs/patterns.ts
+++ b/src/plugins/skip-live-songs/patterns.ts
@@ -26,7 +26,6 @@ export const nonStudioPatterns = [
   /day\s+on\s+the\s+green/i, // Day on the Green
   // Famous venues/festivals
   /\b(wembley|glastonbury|woodstock|coachella)\b/i, // Wembley, Glastonbury, Woodstock, Coachella
-  
   // Dates and locations
   /\b(january|february|march|april|may|june|july|august|september|october|november|december)\s+\d+/i, // "September 22", "August 31"
   /\b\d{1,2}[/-]\d{1,2}[/-]\d{2,4}\b/,           // Date formats: 09/22/2024, 9-22-24

--- a/src/plugins/skip-live-songs/patterns.ts
+++ b/src/plugins/skip-live-songs/patterns.ts
@@ -7,7 +7,7 @@
 
 export const nonStudioPatterns = [
   // "Live" in specific contexts (not as part of song title)
-  /[\(\[]live[\)\]]/i,                            // "(Live)" or "[Live]" in parentheses/brackets
+  /[\(\[]live[\)\]]/i, // "(Live)" or "[Live]" in parentheses/brackets
   /live\s+(at|from|in|on|with|@)/i,                    // "Live at", "Live from", "Live in", etc.
   /live\s+with\b/i,                              // "Live with" (e.g. "Live with the SFSO")
   /-\s*live\s*$/i,                                // "- Live" at the end of title


### PR DESCRIPTION
## Description
Adds a new plugin that automatically tries to skip most non-studio recordings, live performances, and concert versions of songs to ensure users only listen to studio recordings.

## What does this plugin do?
The **Skip Live Songs** plugin monitors song titles and automatically skips to the next track when it detects patterns indicating a non-studio recording, such as:
- Live performances (e.g., "Song Title (Live)", "Live at Wembley")
- Concert recordings and festival performances
- Acoustic/unplugged versions
- Radio sessions and rehearsals
- Songs with venue names (e.g., "Madison Square Garden", "Glastonbury")
- Recordings with dates or location markers

## Implementation Details
- The plugin listens to the `peard:update-song-info` event
- Checks song titles against a comprehensive set of regex patterns defined in `patterns.ts`
- Automatically clicks the next button when a non-studio version is detected
- Includes debug logging for troubleshooting
- Properly cleans up event listeners on stop to prevent memory leaks

## Files Changed
- `src/plugins/skip-live-songs/index.ts` - Main plugin logic
- `src/plugins/skip-live-songs/patterns.ts` - Pattern definitions for detecting live/non-studio recordings using regex
- `src/i18n/resources/en.json` - English translations for plugin name and description
- (Additional language files if translated)

## Related Plugins
Similar to the existing "Skip Disliked Songs" plugin, but focuses on filtering out live performances and non-studio recordings instead of user-marked dislikes.
