### PR TITLE
fix: resolve volume API reporting 0/stale values

### DIFF
--- a/src/providers/song-info-front.ts
+++ b/src/providers/song-info-front.ts
@@ -207,7 +207,7 @@ export const setupFullScreenChangedListener = singleton(() => {
     window.ipcRenderer.send(
       'peard:fullscreen-changed',
       (playerBar?.attributes.getNamedItem('player-fullscreened') ?? null) !==
-      null,
+        null,
     );
   });
 

--- a/src/providers/song-info-front.ts
+++ b/src/providers/song-info-front.ts
@@ -231,7 +231,7 @@ export const setupFullScreenChangedListener = singleton(() => {
     window.ipcRenderer.send(
       'peard:fullscreen-changed',
       (playerBar?.attributes.getNamedItem('player-fullscreened') ?? null) !==
-      null,
+        null,
     );
   });
 


### PR DESCRIPTION
Fixes an issue where the API reports volume as 0 or stale values after navigation. This change dynamically queries the MusicPlayer API from the DOM to ensure the fresh instance is always used.

Fixes #4153

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Volume and mute state detection is now more reliable and responsive
* Improved tracking when switching between video playbacks
* Enhanced error handling for state synchronization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->