### PR TITLE
Discord RPC artist name fixed

### DIFF
--- a/src/plugins/discord/discord-service.ts
+++ b/src/plugins/discord/discord-service.ts
@@ -119,7 +119,7 @@ export class DiscordService {
       ), // Song title
       detailsUrl: songInfo.url ?? undefined,
       state: sanitizeActivityText(
-        songInfo.tags?.at(0) ?? songInfo.artist
+        songInfo.artist ?? songInfo.tags?.at(0) 
       ), // Artist name
       stateUrl: songInfo.artistUrl,
       largeImageKey: songInfo.imageSrc ?? undefined,


### PR DESCRIPTION
The code `songInfo.tags?.at(0)` in `discord-service.ts 122:9` was retrieving the first tag of the video instead of finding the artist name, and if it couldn't find it, it was returning the `songInfo.artist` code.

When I rearranged the code in the opposite way, it now does the same thing for the `songInfo.artist` code. I've shown the before and after below.

<img width="850" height="400" alt="Untitled-3" src="https://github.com/user-attachments/assets/5fe742e5-fcd0-4fc2-8bfd-68e6307541b3" />
