### PR TITLE
Fix repeat mode resetting to off when switching tracks

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -28,6 +28,7 @@ import type { QueueElement } from '@/types/queue';
 import type { QueueResponse } from '@/types/music-player-desktop-internal';
 import type { MusicPlayerAppElement } from '@/types/music-player-app-element';
 import type { SearchBoxElement } from '@/types/search-box-element';
+import type { RepeatMode } from '@/types/datahost-get-state';
 
 setTheme('dark');
 
@@ -50,6 +51,15 @@ async function listenForApiLoad() {
 }
 
 async function onApiLoaded() {
+  type RepeatController = HTMLElement & {
+    getState: () => {
+      queue: {
+        repeatMode: RepeatMode;
+      };
+    };
+    onRepeatButtonClick: () => void;
+  };
+
   // Workaround for macOS traffic lights
   {
     let osType = 'Unknown';
@@ -113,6 +123,72 @@ async function onApiLoaded() {
     window.ipcRenderer.send('peard:get-shuffle-response', isShuffled());
   });
 
+  const repeatModeOrder: RepeatMode[] = ['NONE', 'ALL', 'ONE'];
+
+  const getRepeatController = () =>
+    document.querySelector<RepeatController>('ytmusic-player-bar');
+
+  const getRepeatMode = () =>
+    getRepeatController()?.getState().queue.repeatMode;
+
+  let preferredRepeatMode = getRepeatMode();
+
+  const rememberPreferredRepeatMode = () => {
+    preferredRepeatMode = getRepeatMode() ?? preferredRepeatMode;
+  };
+
+  const switchRepeatToMode = (targetMode: RepeatMode) => {
+    const repeatController = getRepeatController();
+    if (!repeatController) {
+      return;
+    }
+
+    const currentMode = repeatController.getState().queue.repeatMode;
+    const currentIndex = repeatModeOrder.indexOf(currentMode);
+    const targetIndex = repeatModeOrder.indexOf(targetMode);
+    if (currentIndex < 0 || targetIndex < 0) {
+      return;
+    }
+
+    const repeatSwitches =
+      (targetIndex - currentIndex + repeatModeOrder.length) %
+      repeatModeOrder.length;
+    for (let i = 0; i < repeatSwitches; i++) {
+      repeatController.onRepeatButtonClick();
+    }
+  };
+
+  document.addEventListener(
+    'click',
+    (event) => {
+      if (
+        event.target instanceof Element &&
+        event.target.closest('#right-controls .repeat')
+      ) {
+        window.setTimeout(rememberPreferredRepeatMode, 0);
+      }
+    },
+    { capture: true },
+  );
+
+  document.addEventListener('videodatachange', (event) => {
+    const { detail } = event;
+    if (detail?.name !== 'dataloaded') {
+      return;
+    }
+
+    const modeToRestore = preferredRepeatMode;
+    if (!modeToRestore || modeToRestore === 'NONE') {
+      return;
+    }
+
+    window.setTimeout(() => {
+      if (getRepeatMode() === 'NONE') {
+        switchRepeatToMode(modeToRestore);
+      }
+    }, 350);
+  });
+
   window.ipcRenderer.on(
     'peard:update-like',
     (_, status: 'LIKE' | 'DISLIKE' = 'LIKE') => {
@@ -124,13 +200,16 @@ async function onApiLoaded() {
     },
   );
   window.ipcRenderer.on('peard:switch-repeat', (_, repeat = 1) => {
-    for (let i = 0; i < repeat; i++) {
-      document
-        .querySelector<
-          HTMLElement & { onRepeatButtonClick: () => void }
-        >('ytmusic-player-bar')
-        ?.onRepeatButtonClick();
+    const repeatController = getRepeatController();
+    if (!repeatController) {
+      return;
     }
+
+    for (let i = 0; i < repeat; i++) {
+      repeatController.onRepeatButtonClick();
+    }
+
+    rememberPreferredRepeatMode();
   });
   window.ipcRenderer.on('peard:update-volume', (_, volume: number) => {
     document


### PR DESCRIPTION
## Summary
This fixes a YouTube Music behavior where repeat mode was getting reset to **Repeat Off** whenever switching tracks.

The renderer now remembers the user-selected repeat mode (`ALL`/`ONE`) and restores it after track data loads if YouTube resets it to `NONE`.

## Why
I was facing this issue locally: each track switch could reset repeat to off, which broke expected playback behavior. This should improve experience for all users who rely on repeat mode.

## What changed
- Added repeat-mode state tracking in `src/renderer.ts`.
- Captured repeat-mode changes from UI and IPC (`peard:switch-repeat`).
- On `videodatachange` (`dataloaded`), restore preferred repeat mode if it was reset.
- Reused a typed repeat controller helper to avoid repeated DOM queries.

## Validation
- ✅ `pnpm build` (passes)
- ⚠️ `pnpm lint` fails due existing repository-wide issues unrelated to this change
- ⚠️ `pnpm typecheck` fails due existing repository-wide issues unrelated to this change
- ⚠️ `pnpm test` has 1 failing Playwright smoke test (`tests/index.test.js`) timing out in this environment; other tests pass
