### PR TITLE
Improve track title and author display for Discord RPC.

### DIFF
--- a/src/plugins/discord/discord-service.ts
+++ b/src/plugins/discord/discord-service.ts
@@ -118,7 +118,7 @@ export class DiscordService {
         songInfo.alternativeTitle ?? songInfo.title,
       ), // Song title
       detailsUrl: songInfo.url ?? undefined,
-      state: sanitizeActivityText(songInfo.tags?.at(0) ?? songInfo.artist), // Artist name
+      state: sanitizeActivityText(songInfo.artist), // Artist name
       stateUrl: songInfo.artistUrl,
       largeImageKey: songInfo.imageSrc ?? undefined,
       largeImageText: songInfo.album

--- a/src/providers/song-info.ts
+++ b/src/providers/song-info.ts
@@ -100,9 +100,7 @@ const handleData = async (
     }
     // Used for options.resumeOnStart
     config.set('url', microformat.urlCanonical);
-    songInfo.alternativeTitle = microformat.linkAlternates.find(
-      (link) => link.title,
-    )?.title;
+    songInfo.alternativeTitle = microformat.title;
     songInfo.tags = Array.isArray(microformat.tags) ? microformat.tags : [];
   }
 
@@ -116,6 +114,11 @@ const handleData = async (
     songInfo.isPaused = videoDetails.isPaused;
     songInfo.videoId = videoDetails.videoId;
     songInfo.album = videoDetails.album; // Will be undefined if video exist
+
+    // Prefer YouTube Music metadata title when available
+    if (songInfo.alternativeTitle) {
+      songInfo.title = songInfo.alternativeTitle;
+    }
 
     switch (videoDetails?.musicVideoType) {
       case 'MUSIC_VIDEO_TYPE_ATV':


### PR DESCRIPTION
This PR fixes an issue where the Discord RPC shows track title and author from YT videos rather than using metadata from YTM which is more suitable and a clean approach.

More detailed explanation is available here: 
https://github.com/pear-devs/pear-desktop/issues/4413

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Discord Rich Presence status to consistently display artist information, providing clearer presence indicators
  * Enhanced song metadata handling to prioritize YouTube Music titles, ensuring more accurate and reliable track information throughout the application

<!-- end of auto-generated comment: release notes by coderabbit.ai -->