### PR TITLE
Make YTM proxy optional in synced-lyrics-plugin

### DIFF
--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -892,6 +892,10 @@
           "label": "Show time codes",
           "tooltip": "Show the time codes next to the lyrics"
         },
+        "use-ytm-lyrics-without-proxy": {
+          "label": "Use YTM lyrics with no proxy",
+          "tooltip": "Skip the YTM browse proxy and call YouTube Music directly using the app's authenticated session. Useful if you trust your network/region to allow direct browse calls."
+        },
         "convert-chinese-character": {
           "label": "Convert Chinese character",
           "submenu": {

--- a/src/plugins/synced-lyrics/index.ts
+++ b/src/plugins/synced-lyrics/index.ts
@@ -22,6 +22,7 @@ export default createPlugin({
     defaultTextString: '♪',
     lineEffect: 'fancy',
     romanization: true,
+    useYTMLyricsWithoutProxy: false,
   } satisfies SyncedLyricsPluginConfig as SyncedLyricsPluginConfig,
 
   menu,

--- a/src/plugins/synced-lyrics/menu.ts
+++ b/src/plugins/synced-lyrics/menu.ts
@@ -233,5 +233,20 @@ export const menu = async (
         });
       },
     },
+    {
+      label: t(
+        'plugins.synced-lyrics.menu.use-ytm-lyrics-without-proxy.label',
+      ),
+      toolTip: t(
+        'plugins.synced-lyrics.menu.use-ytm-lyrics-without-proxy.tooltip',
+      ),
+      type: 'checkbox',
+      checked: config.useYTMLyricsWithoutProxy,
+      click(item) {
+        ctx.setConfig({
+          useYTMLyricsWithoutProxy: item.checked,
+        });
+      },
+    },
   ];
 };

--- a/src/plugins/synced-lyrics/providers/YTMusic.ts
+++ b/src/plugins/synced-lyrics/providers/YTMusic.ts
@@ -41,7 +41,9 @@ export class YTMusic implements LyricProvider {
     const { browseId } = lyricsTab?.tabRenderer?.endpoint?.browseEndpoint ?? {};
     if (!browseId) return null;
 
-    const { contents } = await this.fetchBrowse(browseId);
+    const browseData = await this.fetchBrowse(browseId);
+    if (!browseData) return null;
+    const { contents } = browseData;
     if (!contents) return null;
 
     /*
@@ -124,7 +126,7 @@ export class YTMusic implements LyricProvider {
     });
   }
 
-  private fetchBrowse(browseId: string): Promise<BrowseData> {
+  private fetchBrowse(browseId: string): Promise<BrowseData | null> {
     if (config()?.useYTMLyricsWithoutProxy) {
       return this.fetchBrowseDirect(browseId);
     }
@@ -143,10 +145,10 @@ export class YTMusic implements LyricProvider {
   // network manager, which injects the visitor/auth tokens that the request
   // would otherwise be missing when called from regions where the unauthenticated
   // call is geo-restricted.
-  private async fetchBrowseDirect(browseId: string): Promise<BrowseData> {
+  private async fetchBrowseDirect(browseId: string): Promise<BrowseData | null> {
     const app = document.querySelector<MusicPlayerAppElement>('ytmusic-app');
     if (!app) {
-      throw new Error('ytmusic-app element not found');
+      return null;
     }
 
     return await app.networkManager.fetch<BrowseData, { browseId: string }>(

--- a/src/plugins/synced-lyrics/providers/YTMusic.ts
+++ b/src/plugins/synced-lyrics/providers/YTMusic.ts
@@ -1,3 +1,5 @@
+import { config } from '../renderer/renderer';
+
 import type { LyricProvider, LyricResult, SearchSongInfo } from '../types';
 import type { MusicPlayerAppElement } from '@/types/music-player-app-element';
 
@@ -122,7 +124,11 @@ export class YTMusic implements LyricProvider {
     });
   }
 
-  private fetchBrowse(browseId: string) {
+  private fetchBrowse(browseId: string): Promise<BrowseData> {
+    if (config()?.useYTMLyricsWithoutProxy) {
+      return this.fetchBrowseDirect(browseId);
+    }
+
     return fetch(this.PROXIED_ENDPOINT + 'browse?prettyPrint=false', {
       headers,
       method: 'POST',
@@ -131,6 +137,22 @@ export class YTMusic implements LyricProvider {
         context: { client },
       }),
     }).then((res) => res.json()) as Promise<BrowseData>;
+  }
+
+  // Calls YouTube Music's browse endpoint directly via the app's authenticated
+  // network manager, which injects the visitor/auth tokens that the request
+  // would otherwise be missing when called from regions where the unauthenticated
+  // call is geo-restricted.
+  private async fetchBrowseDirect(browseId: string): Promise<BrowseData> {
+    const app = document.querySelector<MusicPlayerAppElement>('ytmusic-app');
+    if (!app) {
+      throw new Error('ytmusic-app element not found');
+    }
+
+    return await app.networkManager.fetch<BrowseData, { browseId: string }>(
+      '/browse?prettyPrint=false',
+      { browseId },
+    );
   }
 }
 

--- a/src/plugins/synced-lyrics/types.ts
+++ b/src/plugins/synced-lyrics/types.ts
@@ -10,6 +10,7 @@ export type SyncedLyricsPluginConfig = {
   showLyricsEvenIfInexact: boolean;
   lineEffect: LineEffect;
   romanization: boolean;
+  useYTMLyricsWithoutProxy: boolean;
   convertChineseCharacter?:
     | 'simplifiedToTraditional'
     | 'traditionalToSimplified'


### PR DESCRIPTION
For the jurisdictions the YTM proxy is not needed there's now an option to go directly to the "/browse" API skipping the proxy. Also helps a recent downtime on the proxy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new toggle in the Synced Lyrics settings to fetch lyrics directly from YouTube Music (bypassing the external proxy). The option is off by default and includes a label and tooltip in the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->