### PR TITLE
fix(build): ship production node_modules in the asar

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -5,10 +5,9 @@ files:
   - dist
   - assets
   - license
-  - '!node_modules'
-  - 'node_modules/custom-electron-prompt/**'
-  - 'node_modules/@ghostery/adblocker-electron-preload/**'
-  - 'node_modules/@ffmpeg.wasm/core-mt/**'
+  # electron-vite externalizes most npm deps from the main/preload bundles, so
+  # they have to be shipped via node_modules. Let electron-builder include
+  # production deps by default; just trim out source maps and TypeScript.
   - '!node_modules/**/*.map'
   - '!node_modules/**/*.ts'
 asarUnpack:


### PR DESCRIPTION
## Summary

After the Vite v8 migration (b1c880f3), electron-vite's default `externalizeDeps: true` strips most npm dependencies out of the main and preload bundles, leaving runtime `require()` calls for `electron-store`, `electron-is`, `deepmerge-ts`, `i18next`, and their transitive deps. The previous `electron-builder.yml` excluded `node_modules` from the asar with only a 3-package allowlist, so those requires failed at runtime in packaged builds.

`pnpm start` worked because electron-vite preview serves the built code from the project tree. Only `pnpm dist:*` produced the failure.

## Fix

Drop `!node_modules` and the manual allowlist; let electron-builder ship production deps from `package.json` by default. The asar grows by some MB but every externalized `require` resolves.

Closes #4446

## Test plan

- `pnpm dist:win` produces a launchable build that opens past the renderer init phase
- No regressions for `pnpm start` / `pnpm dev` flows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined application packaging configuration to adjust how production dependencies and build artifacts are included in distribution builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pear-devs/pear-desktop/pull/4462)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->