### PR TITLE
feat(api-server): add endpoint to play playlists

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,6 @@ name: Build Pear Desktop
 on:
   push:
     branches: [ master ]
-  workflow_dispatch:
 
 
 permissions: {}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@ name: Build Pear Desktop
 on:
   push:
     branches: [ master ]
+  workflow_dispatch:
+
 
 permissions: {}
 

--- a/src/plugins/api-server/backend/routes/control.ts
+++ b/src/plugins/api-server/backend/routes/control.ts
@@ -620,6 +620,13 @@ export const register = (
     ctx.status(204);
     return ctx.body(null);
   });
+  app.openapi(routes.playPlaylist, (ctx) => {
+    const { playlistId, videoId } = ctx.req.valid('json');
+    controller.playPlaylist(playlistId, videoId);
+
+    ctx.status(204);
+    return ctx.body(null);
+  });
   app.openapi(routes.pause, (ctx) => {
     controller.pause();
 

--- a/src/plugins/api-server/backend/routes/control.ts
+++ b/src/plugins/api-server/backend/routes/control.ts
@@ -66,6 +66,29 @@ const routes = {
       },
     },
   }),
+    playPlaylist: createRoute({
+    method: 'post',
+    path: `/api/${API_VERSION}/playPlaylist`,
+    summary: 'play playlist',
+    description: 'Plays a playlist given its ID and optionally a video ID',
+    request: {
+      body: {
+        content: {
+          'application/json': {
+            schema: z.object({
+              playlistId: z.string().describe('Playlist ID'),
+              videoId: z.string().optional().describe('Video ID (optional)'),
+            }),
+          },
+        },
+      },
+    },
+    responses: {
+      204: {
+        description: 'Success',
+      },
+    },
+  }),
   pause: createRoute({
     method: 'post',
     path: `/api/${API_VERSION}/pause`,

--- a/src/providers/song-controls.ts
+++ b/src/providers/song-controls.ts
@@ -146,5 +146,16 @@ export const getSongControls = (win: BrowserWindow) => {
         });
         win.webContents.send('peard:search', query, params, continuation);
       }),
+        playPlaylist: (playlistId: ArgsType<string>, videoId?: ArgsType<string>) => {
+      const pid = parseStringFromArgsType(playlistId);
+      const vid = videoId ? parseStringFromArgsType(videoId) : null;
+      if (pid) {
+        let url = `https://music.youtube.com/playlist?list=${pid}`;
+        if (vid) {
+          url += `&v=${vid}`;
+        }
+        win.webContents.loadURL(url);
+      }
+    },
   };
 };


### PR DESCRIPTION
This PR adds a new `/api/v1/playPlaylist` endpoint to the `api-server` plugin. 

Currently, third-party apps (like Macro Deck) can skip tracks and pause, but they can't launch a specific playlist. 

This update allows external controllers to pass a `playlistId` (and optional `videoId`) to instantly load and play a playlist.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new playlist playback action, letting you open a playlist directly and optionally start from a specific video.
  * Exposed a new API endpoint to trigger playlist playback from supported clients.

* **Bug Fixes**
  * Improved handling of playlist and video identifiers so playback only proceeds when valid values are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->