### PR TITLE
fix(synced-lyrics): korean romanization

### DIFF
--- a/src/plugins/synced-lyrics/renderer/utils.tsx
+++ b/src/plugins/synced-lyrics/renderer/utils.tsx
@@ -184,8 +184,17 @@ export const romanizeJapanese = async (line: string) =>
     mode: 'spaced',
   }) ?? line;
 
+type HanjaApi = {
+  translate: (text: string, mode: 'SUBSTITUTION') => string;
+};
+
+const hanjaModule = hanja as HanjaApi | { default: HanjaApi };
+const hanjaTranslate = (
+  'translate' in hanjaModule ? hanjaModule : hanjaModule.default
+).translate;
+
 export const romanizeHangul = (line: string) =>
-  esHangulRomanize(hanja.translate(line, 'SUBSTITUTION'));
+  esHangulRomanize(hanjaTranslate(line, 'SUBSTITUTION'));
 
 export const romanizeChinese = (line: string) => {
   return line.replaceAll(/[\u4E00-\u9FFF]+/g, (match) => {


### PR DESCRIPTION
Fixes #4526
Vibe coded

Edit:
Screenshot of the fix
<img width="1281" height="1410" alt="image" src="https://github.com/user-attachments/assets/d31af463-7aa2-4d60-97b3-144b23adc97c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synced lyrics romanization so Hangul-to-Latin conversion works more reliably across different module setups.
  * Fixed an issue where the lyric translation step could fail if the Hanja translation helper was exposed in a different format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->