### PR TITLE
fix: isolate configuration and data paths for windows portable builds

### DIFF
--- a/src/config/store.ts
+++ b/src/config/store.ts
@@ -1,3 +1,8 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { app } from 'electron';
+
 import { blockers } from '@/plugins/do-not-track/types';
 import { DefaultPresetList, type Preset } from '@/plugins/downloader/types';
 
@@ -6,22 +11,15 @@ import { defaultConfig as defaults } from './defaults';
 import type { TrackerBlockerConfig } from '@/plugins/do-not-track';
 import type { SyncedLyricsPluginConfig } from '@/plugins/synced-lyrics/types';
 
-// HACK: electron-store is ESM, but rolldown has a bug that prevents it from being imported properly in CommonJS context, so we have to use require here
-/* oxlint-disable typescript/no-require-imports */
-const Store = (
-  require('electron-store') as {
-    default: typeof import('electron-store').default;
-  }
-).default;
-/* oxlint-enable typescript/no-require-imports */
-
 export type IStore = InstanceType<
   typeof import('conf').default<Record<string, unknown>>
 >;
 
 const migrations = {
   '>=3.12.0'(store: IStore) {
-    const blockerConfig = store.get('plugins.adblocker') as TrackerBlockerConfig;
+    const blockerConfig = store.get(
+      'plugins.adblocker',
+    ) as TrackerBlockerConfig;
     if (blockerConfig) {
       if (!Object.values(blockers).includes(blockerConfig.blocker)) {
         blockerConfig.blocker = blockers.InPlayer;
@@ -278,6 +276,67 @@ const migrations = {
     store.set('plugins', plugins);
   },
 };
+
+if (process.env.PORTABLE_EXECUTABLE_DIR) {
+  try {
+    const portableDir = path.resolve(process.env.PORTABLE_EXECUTABLE_DIR);
+    const userDataPath = path.resolve(portableDir, 'user-data');
+
+    // Prevent path traversal (CWE-22) by ensuring userDataPath resolves inside portableDir
+    if (path.relative(portableDir, userDataPath).startsWith('..')) {
+      throw new Error('Path traversal detected');
+    }
+
+    // README: Test writability of the portable folder before overriding paths.
+    // If mkdirSync succeeds but write test fails (e.g. read-only disk/AV lock),
+    // it may leave an empty 'user-data' folder next to the exe. This is harmless.
+    if (!fs.existsSync(userDataPath)) {
+      fs.mkdirSync(userDataPath, { recursive: true });
+    }
+    const testFile = path.join(userDataPath, '.writable-test');
+    fs.writeFileSync(testFile, '');
+    try {
+      fs.unlinkSync(testFile);
+    } catch (cleanupError) {
+      console.warn('Could not remove writability test file:', cleanupError);
+    }
+
+    // README: Ensure required logs and crash-dumps directories exist before setPath.
+    // In Electron, app.setPath throws an error if the directory does not exist,
+    // which would leave us with a partially-applied path setup.
+    const logsPath = path.join(userDataPath, 'logs');
+    const crashDumpsPath = path.join(userDataPath, 'crash-dumps');
+    if (!fs.existsSync(logsPath)) {
+      fs.mkdirSync(logsPath, { recursive: true });
+    }
+    if (!fs.existsSync(crashDumpsPath)) {
+      fs.mkdirSync(crashDumpsPath, { recursive: true });
+    }
+
+    // README: Apply complete overrides to isolate all data inside the portable user-data folder.
+    // We intentionally collapse appData and userData to the identical folder to keep all
+    // configurations, caches, logs, and session data fully self-contained.
+    app.setPath('appData', userDataPath);
+    app.setPath('userData', userDataPath);
+    app.setPath('sessionData', userDataPath);
+    app.setPath('logs', logsPath);
+    app.setPath('crashDumps', crashDumpsPath);
+  } catch (error) {
+    console.error(
+      'Portable directory is not writable; falling back to default paths:',
+      error,
+    );
+  }
+}
+
+// HACK: electron-store is ESM, but rolldown has a bug that prevents it from being imported properly in CommonJS context, so we have to use require here
+/* oxlint-disable typescript/no-require-imports */
+const Store = (
+  require('electron-store') as {
+    default: typeof import('electron-store').default;
+  }
+).default;
+/* oxlint-enable typescript/no-require-imports */
 
 export const store = new Store({
   defaults: {


### PR DESCRIPTION
This PR resolves an issue where the Windows portable executable target writes settings, session files, cache, and logs to the host machine's system-wide `%APPDATA%/YouTube Music` directory. This leaks data to the host system and breaks the application's portability.
With this fix, when running in portable mode, all configurations and runtime caches are cleanly isolated into a `user-data` folder next to the executable.
### Implementation Details
1. **Execution Order**:
   - The path overrides are placed inside `src/config/store.ts` right before the `Store` is instantiated. This ensures redirection runs first, bypassing any bundler chunk-splitting issues that would otherwise load the configuration store before the main module's inline code.
2. **Complete Isolation**:
   - Overrides all of Electron's paths (`appData`, `userData`, `sessionData`, `logs`, and `crashDumps`) to the local `user-data` directory.
3. **Safety Fallback**:
   - Resolves the portable folder with `path.resolve` to satisfy Electron's requirement of absolute paths.
   - Tests directory write access on startup (by writing/deleting a temporary `.writable-test` file). If the portable folder is write-protected (e.g., read-only USB or anti-virus lock), it catches the error, logs a warning, and gracefully falls back to default paths rather than crashing on launch.
### Verification
- **Lint & Format:** Verified via `pnpm oxfmt --check src/config/store.ts` and `pnpm oxlint --type-aware src/config/store.ts` (0 errors, 0 warnings).
- **Compilation:** Verified via `pnpm build` (compiles successfully).
- **Redirection Test:** Ran in dev mode with `PORTABLE_EXECUTABLE_DIR` set. Confirmed that `config.json`, cookies, and cache files were generated inside the portable mock folder, and that `%APPDATA%/YouTube Music/config.json` remained untouched.
- **Regression Test:** Ran dev mode normally (without the environment variable). Confirmed that the application safely continues to load and save settings to the default system-wide `%APPDATA%` paths (fully transparent for non-portable Windows, Linux, and macOS).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a portable app mode using `PORTABLE_EXECUTABLE_DIR`, routing user data, session data, logs, and crash dumps into subfolders under the selected directory.
  * Ensures the portable directory is writable before switching over, including a safe write/delete test.
  * Prevents path traversal when resolving the portable `user-data` location.
* **Bug Fixes**
  * Improves robustness: if portable setup or Electron path switching fails, the app automatically falls back to default storage locations and logs an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->