### PR TITLE
fix(custom-output-device): fix outdated devices and initialization

### DIFF
--- a/src/plugins/custom-output-device/renderer.ts
+++ b/src/plugins/custom-output-device/renderer.ts
@@ -1,22 +1,32 @@
+import { Mutex } from 'async-mutex';
+
 import { createRenderer } from '@/utils';
 
 import type { CustomOutputPluginConfig } from './index';
 import type { RendererContext } from '@/types/contexts';
 
+const DEVICES_MUTEX = new Mutex();
+
 const updateDeviceList = async (
   context: RendererContext<CustomOutputPluginConfig>,
 ) => {
-  const newDevices: Record<string, string> = {};
-  const devices = await navigator.mediaDevices.enumerateDevices();
-  for (const device of devices) {
-    if (device.kind !== 'audiooutput') continue;
+  const release = await DEVICES_MUTEX.acquire();
 
-    newDevices[device.deviceId] = device.label;
+  try {
+    const newDevices: Record<string, string> = {};
+    const devices = await navigator.mediaDevices.enumerateDevices();
+    for (const device of devices) {
+      if (device.kind !== 'audiooutput') continue;
+
+      newDevices[device.deviceId] = device.label;
+    }
+
+    // clear because setConfig now does a merge
+    context.setConfig({ devices: undefined });
+    context.setConfig({ devices: newDevices });
+  } finally {
+    release();
   }
-
-  // clear cause setConfig now does a merge
-  context.setConfig({ devices: undefined });
-  context.setConfig({ devices: newDevices });
 };
 
 const updateSinkId = async (

--- a/src/plugins/custom-output-device/renderer.ts
+++ b/src/plugins/custom-output-device/renderer.ts
@@ -2,23 +2,21 @@ import { createRenderer } from '@/utils';
 
 import type { CustomOutputPluginConfig } from './index';
 import type { RendererContext } from '@/types/contexts';
-import type { MusicPlayer } from '@/types/music-player';
 
 const updateDeviceList = async (
   context: RendererContext<CustomOutputPluginConfig>,
 ) => {
   const newDevices: Record<string, string> = {};
-  const devices = await navigator.mediaDevices
-    .enumerateDevices()
-    .then((devices) =>
-      devices.filter((device) => device.kind === 'audiooutput'),
-    );
+  const devices = await navigator.mediaDevices.enumerateDevices();
   for (const device of devices) {
+    if (device.kind !== 'audiooutput') continue;
+
     newDevices[device.deviceId] = device.label;
   }
-  const options = await context.getConfig();
-  options.devices = newDevices;
-  context.setConfig(options);
+
+  // clear cause setConfig now does a merge
+  context.setConfig({ devices: undefined });
+  context.setConfig({ devices: newDevices });
 };
 
 const updateSinkId = async (
@@ -29,10 +27,9 @@ const updateSinkId = async (
 ) => {
   if (!audioContext || !sinkId) return;
   if (!('setSinkId' in audioContext)) return;
+  if (typeof audioContext.setSinkId !== 'function') return;
 
-  if (typeof audioContext.setSinkId === 'function') {
-    await audioContext.setSinkId(sinkId);
-  }
+  await audioContext.setSinkId(sinkId);
 };
 
 export const renderer = createRenderer<
@@ -48,7 +45,7 @@ export const renderer = createRenderer<
     await updateSinkId(audioContext, this.options!.output);
   },
 
-  async onPlayerApiReady(_: MusicPlayer, context) {
+  async start(context) {
     this.options = await context.getConfig();
     await navigator.mediaDevices.getUserMedia({ audio: true, video: false });
     navigator.mediaDevices.ondevicechange = async () =>


### PR DESCRIPTION
The behaviour of `context.setConfig` and `render.onPlayerApiReady` has changed from the last time I contributed (the project was called something different back then).

# Changes

## Late initialization

### Bug Explanation
Now `render.onPlayerApiReady` waits until a media starts playing.

### Fix
I changed the initialization back to `render.start`. Originally, using `render.start` for this plugin caused a bug that interrupted the initialization of all plugins. Now that doesn't happen anymore, so using `render.start` looks like the perfect fix.

## Duplicated and outdated devices

### Bug Explanation
Now `contest.setConfig` does a merge instead of an override. So old output devices were not removed from the config object, but instead merged with the new ones.

### Fix
Now the `config.devices` object is cleared before inserting the new devices.

## Additional Notes

Some minor changes. Mostly logical refactors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio output device detection and refresh behavior to keep the available speaker list up to date more reliably.
  * Made switching to a selected output more resilient by safely handling unsupported sink changes.
  * Improved stability during rapid device add/remove events so the output device list stays consistent and synchronized.
  * Reduced the chance of outdated or duplicate devices appearing while audio settings are being refreshed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->