### PR TITLE
feat(plugins): Blocklist — auto-skip blocked artists

### DIFF
--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -379,7 +379,7 @@
       "description": "Block artists to automatically skip their songs",
       "name": "Blocklist",
       "templates": {
-        "button": "Block artist"
+        "button": "Block {{name}}"
       },
       "menu": {
         "add": {

--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -375,6 +375,23 @@
         }
       }
     },
+    "blocklist": {
+      "description": "Block artists to automatically skip their songs",
+      "name": "Blocklist",
+      "templates": {
+        "button": "Block artist"
+      },
+      "menu": {
+        "add": {
+          "label": "Add blocked artist…",
+          "prompt-title": "Block artist",
+          "prompt-label": "Artist name"
+        },
+        "no-artists": "No blocked artists",
+        "remove": "Remove",
+        "clear": "Clear all"
+      }
+    },
     "blur-nav-bar": {
       "description": "Makes navigation bar transparent and blurry",
       "name": "Blur Navigation Bar"

--- a/src/plugins/blocklist/index.ts
+++ b/src/plugins/blocklist/index.ts
@@ -1,0 +1,43 @@
+import { t } from '@/i18n';
+import { createPlugin } from '@/utils';
+
+import { onMenu } from './menu';
+import {
+  onConfigChange,
+  onPlayerApiReady,
+  onRendererLoad,
+  stop,
+} from './renderer';
+import style from './style.css?inline';
+
+export type BlockedArtist = {
+  /** Display name of the artist, used for matching (case-insensitive). */
+  name: string;
+  /** YouTube channel id (`UC...`) of the artist, when known. */
+  channelId?: string;
+};
+
+export type BlocklistPluginConfig = {
+  enabled: boolean;
+  blockedArtists: BlockedArtist[];
+};
+
+export const defaultConfig: BlocklistPluginConfig = {
+  enabled: false,
+  blockedArtists: [],
+};
+
+export default createPlugin({
+  name: () => t('plugins.blocklist.name'),
+  description: () => t('plugins.blocklist.description'),
+  restartNeeded: true,
+  config: defaultConfig,
+  stylesheets: [style],
+  menu: onMenu,
+  renderer: {
+    start: onRendererLoad,
+    onConfigChange,
+    onPlayerApiReady,
+    stop,
+  },
+});

--- a/src/plugins/blocklist/menu.ts
+++ b/src/plugins/blocklist/menu.ts
@@ -1,0 +1,90 @@
+import prompt from 'custom-electron-prompt';
+
+import { t } from '@/i18n';
+import promptOptions from '@/providers/prompt-options';
+
+import type { BlocklistPluginConfig } from './index';
+import type { MenuTemplate } from '@/menu';
+import type { MenuContext } from '@/types/contexts';
+
+export const onMenu = async ({
+  getConfig,
+  setConfig,
+  refresh,
+  window,
+}: MenuContext<BlocklistPluginConfig>): Promise<MenuTemplate> => {
+  const config = await getConfig();
+
+  const template: MenuTemplate = [
+    {
+      label: t('plugins.blocklist.menu.add.label'),
+      async click() {
+        const name = await prompt(
+          {
+            title: t('plugins.blocklist.menu.add.prompt-title'),
+            label: t('plugins.blocklist.menu.add.prompt-label'),
+            type: 'input',
+            value: '',
+            width: 400,
+            ...promptOptions(),
+          },
+          window,
+        );
+
+        const trimmed = typeof name === 'string' ? name.trim() : '';
+        if (!trimmed) return;
+
+        const alreadyBlocked = config.blockedArtists.some(
+          (artist) => artist.name.toLowerCase() === trimmed.toLowerCase(),
+        );
+        if (alreadyBlocked) return;
+
+        setConfig({
+          blockedArtists: [...config.blockedArtists, { name: trimmed }],
+        });
+        await refresh();
+      },
+    },
+    { type: 'separator' },
+  ];
+
+  if (config.blockedArtists.length === 0) {
+    template.push({
+      label: t('plugins.blocklist.menu.no-artists'),
+      enabled: false,
+    });
+    return template;
+  }
+
+  for (const artist of config.blockedArtists) {
+    template.push({
+      label: artist.name,
+      submenu: [
+        {
+          label: t('plugins.blocklist.menu.remove'),
+          click() {
+            setConfig({
+              blockedArtists: config.blockedArtists.filter(
+                (it) => it !== artist,
+              ),
+            });
+            refresh();
+          },
+        },
+      ],
+    });
+  }
+
+  template.push(
+    { type: 'separator' },
+    {
+      label: t('plugins.blocklist.menu.clear'),
+      click() {
+        setConfig({ blockedArtists: [] });
+        refresh();
+      },
+    },
+  );
+
+  return template;
+};

--- a/src/plugins/blocklist/renderer.tsx
+++ b/src/plugins/blocklist/renderer.tsx
@@ -121,6 +121,22 @@ const dedupeArtists = (artists: BlockedArtist[]): BlockedArtist[] => {
   return result;
 };
 
+// Resolve an artist's display name from its channel id. A menu item's own
+// text is the action label ("Go to artist"), never the artist name, so read
+// the name from a link to that same channel on the underlying page (the song
+// row or artist card that opened the menu). Links inside the popup are skipped
+// so we don't read the "Go to artist" label back as the name.
+const resolveArtistName = (channelId: string): string | undefined => {
+  for (const link of document.querySelectorAll<HTMLAnchorElement>(
+    `a[href*="${channelId}"]`,
+  )) {
+    if (link.closest('ytmusic-popup-container')) continue;
+    const name = link.textContent?.trim();
+    if (name) return name;
+  }
+  return undefined;
+};
+
 // "Go to artist" links inside the open popup menu (works for song rows).
 const getMenuLinkedArtists = (menu: HTMLElement): BlockedArtist[] => {
   const artists: BlockedArtist[] = [];
@@ -131,7 +147,7 @@ const getMenuLinkedArtists = (menu: HTMLElement): BlockedArtist[] => {
       item.querySelector('#navigation-endpoint')?.getAttribute('href'),
     );
     if (!channelId) continue;
-    const name = item.querySelector<HTMLElement>('.text')?.textContent?.trim();
+    const name = resolveArtistName(channelId);
     if (name) artists.push({ name, channelId });
   }
   return artists;

--- a/src/plugins/blocklist/renderer.tsx
+++ b/src/plugins/blocklist/renderer.tsx
@@ -1,6 +1,5 @@
 import { t } from '@/i18n';
 import {
-  isAlbumOrPlaylist,
   isMusicOrVideoTrack,
   isPlayerMenu,
 } from '@/plugins/utils/renderer/check';
@@ -130,18 +129,6 @@ const getPlayerBarArtists = (): BlockedArtist[] => {
   return artists;
 };
 
-// The artist whose page is currently open (for the artist-page header menu).
-const getPageArtist = (): BlockedArtist | null => {
-  const channelId = parseChannelId(location.pathname);
-  if (!channelId) return null;
-  const name = document
-    .querySelector<HTMLElement>(
-      'ytmusic-immersive-header-renderer .title, ytmusic-visual-header-renderer .title',
-    )
-    ?.textContent?.trim();
-  return name ? { name, channelId } : null;
-};
-
 const getMenuArtists = (menu: HTMLElement): BlockedArtist[] => {
   // The now-playing bar menu exposes the full artist list via the byline.
   if (isPlayerMenu(menu)) {
@@ -159,12 +146,6 @@ const getMenuArtists = (menu: HTMLElement): BlockedArtist[] => {
     if (info?.artist) {
       return [{ name: info.artist, channelId: parseChannelId(info.artistUrl) }];
     }
-  }
-
-  // The artist-page header menu (which otherwise only offers "Share").
-  if (location.pathname.startsWith('/channel/') && !isAlbumOrPlaylist()) {
-    const page = getPageArtist();
-    if (page) return [page];
   }
 
   return [];

--- a/src/plugins/blocklist/renderer.tsx
+++ b/src/plugins/blocklist/renderer.tsx
@@ -1,12 +1,13 @@
-import { createSignal } from 'solid-js';
-import { render } from 'solid-js/web';
-
 import { t } from '@/i18n';
-import { isMusicOrVideoTrack } from '@/plugins/utils/renderer/check';
+import {
+  isAlbumOrPlaylist,
+  isMusicOrVideoTrack,
+  isPlayerMenu,
+} from '@/plugins/utils/renderer/check';
 import { getSongMenu } from '@/providers/dom-elements';
 import { getSongInfo } from '@/providers/song-info-front';
 
-import { BlockArtistButton } from './templates/block-button';
+import { createBlockButton } from './templates/block-button';
 
 import type { BlockedArtist, BlocklistPluginConfig } from './index';
 import type { RendererContext } from '@/types/contexts';
@@ -17,10 +18,10 @@ let config: BlocklistPluginConfig = { enabled: true, blockedArtists: [] };
 let setConfig: RendererContext<BlocklistPluginConfig>['setConfig'] = () => {};
 let api: MusicPlayer | null = null;
 
-let buttonContainer: HTMLDivElement | null = null;
-let disposeButton: (() => void) | null = null;
-
-const [buttonText, setButtonText] = createSignal('');
+// Artist channel ids start with "UC" (albums/playlists use MPRE/VL/PL instead),
+// so this only matches links that point at an artist.
+const ARTIST_ID = /(?:channel|browse)\/(UC[0-9A-Za-z_-]+)/;
+const parseChannelId = (href?: string | null) => href?.match(ARTIST_ID)?.[1];
 
 /** Normalize an artist name for matching (drop the " - Topic" suffix, casefold). */
 const normalize = (name: string) =>
@@ -63,8 +64,6 @@ const shouldSkip = (author?: string | null, videoId?: string | null) => {
 
   const lastAttempt = recentSkipAttempts.get(videoId);
   if (lastAttempt !== undefined && now - lastAttempt < SKIP_COOLDOWN_MS) {
-    // We already tried to skip this exact track and it came back — something
-    // else controls playback (e.g. a Music Together session). Stop fighting it.
     return false;
   }
 
@@ -88,52 +87,99 @@ const onVideoDataChange = (
   skipIfBlocked(data?.author, data?.videoId);
 };
 
-/**
- * Resolve the artist for the song the currently-open context menu targets.
- * Prefers the menu's "Go to artist" navigation item (works for any song row),
- * and falls back to the currently-playing song (the player-bar menu).
- */
-const getMenuArtist = (): BlockedArtist | null => {
-  const menu = getSongMenu();
-  if (menu) {
-    for (const item of menu.querySelectorAll<HTMLElement>(
-      'ytmusic-menu-navigation-item-renderer',
-    )) {
-      const href = item
-        .querySelector('#navigation-endpoint')
-        ?.getAttribute('href');
-      // Artist pages look like "channel/UC..."; albums use "browse/..." instead.
-      if (href?.startsWith('channel/')) {
-        const name = item
-          .querySelector<HTMLElement>('.text')
-          ?.textContent?.trim();
-        if (name) return { name, channelId: href.slice('channel/'.length) };
-      }
+/* ---- resolving which artist(s) a menu targets ---- */
+
+const dedupeArtists = (artists: BlockedArtist[]): BlockedArtist[] => {
+  const seen = new Set<string>();
+  const result: BlockedArtist[] = [];
+  for (const artist of artists) {
+    const key = (artist.channelId ?? artist.name).toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(artist);
+  }
+  return result;
+};
+
+// "Go to artist" links inside the open popup menu (works for song rows).
+const getMenuLinkedArtists = (menu: HTMLElement): BlockedArtist[] => {
+  const artists: BlockedArtist[] = [];
+  for (const item of menu.querySelectorAll<HTMLElement>(
+    'ytmusic-menu-navigation-item-renderer',
+  )) {
+    const channelId = parseChannelId(
+      item.querySelector('#navigation-endpoint')?.getAttribute('href'),
+    );
+    if (!channelId) continue;
+    const name = item.querySelector<HTMLElement>('.text')?.textContent?.trim();
+    if (name) artists.push({ name, channelId });
+  }
+  return artists;
+};
+
+// Every artist listed in the now-playing bar byline (full multi-artist list).
+const getPlayerBarArtists = (): BlockedArtist[] => {
+  const artists: BlockedArtist[] = [];
+  for (const link of document.querySelectorAll<HTMLAnchorElement>(
+    'ytmusic-player-bar a.yt-simple-endpoint[href]',
+  )) {
+    const channelId = parseChannelId(link.getAttribute('href'));
+    const name = link.textContent?.trim();
+    if (channelId && name) artists.push({ name, channelId });
+  }
+  return artists;
+};
+
+// The artist whose page is currently open (for the artist-page header menu).
+const getPageArtist = (): BlockedArtist | null => {
+  const channelId = parseChannelId(location.pathname);
+  if (!channelId) return null;
+  const name = document
+    .querySelector<HTMLElement>(
+      'ytmusic-immersive-header-renderer .title, ytmusic-visual-header-renderer .title',
+    )
+    ?.textContent?.trim();
+  return name ? { name, channelId } : null;
+};
+
+const getMenuArtists = (menu: HTMLElement): BlockedArtist[] => {
+  // The now-playing bar menu exposes the full artist list via the byline.
+  if (isPlayerMenu(menu)) {
+    const byline = getPlayerBarArtists();
+    if (byline.length) return dedupeArtists(byline);
+  }
+
+  // Any menu with "Go to artist" links (song rows, player bar, …).
+  const linked = getMenuLinkedArtists(menu);
+  if (linked.length) return dedupeArtists(linked);
+
+  // A track menu with no artist link — fall back to the current song's artist.
+  if (isMusicOrVideoTrack() || isPlayerMenu(menu)) {
+    const info = getSongInfo();
+    if (info?.artist) {
+      return [{ name: info.artist, channelId: parseChannelId(info.artistUrl) }];
     }
   }
 
-  const info = getSongInfo();
-  if (info?.artist) {
-    return {
-      name: info.artist,
-      channelId: info.artistUrl?.split('/channel/')[1],
-    };
+  // The artist-page header menu (which otherwise only offers "Share").
+  if (location.pathname.startsWith('/channel/') && !isAlbumOrPlaylist()) {
+    const page = getPageArtist();
+    if (page) return [page];
   }
 
-  return null;
+  return [];
 };
 
-const blockFromMenu = () => {
-  const artist = getMenuArtist();
-  if (!artist) return;
+/* ---- blocking + menu injection ---- */
 
+const blockArtist = (artist: BlockedArtist) => {
   if (!isBlocked(artist.name)) {
     const blockedArtists = [...config.blockedArtists, artist];
     config = { ...config, blockedArtists };
     setConfig({ blockedArtists });
   }
 
-  // Close the popup menu, then skip the current song if it is now blocked.
+  // Close the popup, then skip the current song if it is now blocked.
   document
     .querySelector<HTMLElement & { close?: () => void }>(
       'ytmusic-popup-container tp-yt-iron-dropdown',
@@ -144,19 +190,37 @@ const blockFromMenu = () => {
   skipIfBlocked(current?.artist, current?.videoId);
 };
 
-const menuObserver = new MutationObserver(() => {
+const injectBlockButtons = () => {
   const menu = getSongMenu();
-  if (
-    !menu ||
-    !buttonContainer ||
-    menu.contains(buttonContainer) ||
-    !isMusicOrVideoTrack()
-  ) {
+  if (!menu) return;
+
+  const artists = getMenuArtists(menu);
+  const key = artists.map((artist) => artist.channelId ?? artist.name).join('|');
+  const existing = menu.querySelector<HTMLElement>('.blocklist-injected');
+
+  if (!artists.length) {
+    if (existing) {
+      menu.querySelectorAll('.blocklist-injected').forEach((el) => el.remove());
+    }
     return;
   }
 
-  menu.prepend(buttonContainer);
-});
+  if (existing?.dataset.blocklistKey === key) return;
+  menu.querySelectorAll('.blocklist-injected').forEach((el) => el.remove());
+
+  const fragment = document.createDocumentFragment();
+  for (const artist of artists) {
+    const button = createBlockButton(
+      t('plugins.blocklist.templates.button', { name: artist.name }),
+      () => blockArtist(artist),
+    );
+    button.dataset.blocklistKey = key;
+    fragment.append(button);
+  }
+  menu.prepend(fragment);
+};
+
+const menuObserver = new MutationObserver(injectBlockButtons);
 
 export const onRendererLoad = async (
   context: RendererContext<BlocklistPluginConfig>,
@@ -174,41 +238,24 @@ export const onPlayerApiReady = (
   _context: RendererContext<BlocklistPluginConfig>,
 ) => {
   api = playerApi;
-  setButtonText(t('plugins.blocklist.templates.button'));
-
-  buttonContainer = document.createElement('div');
-  buttonContainer.classList.add(
-    'blocklist-menu-item',
-    'style-scope',
-    'menu-item',
-    'ytmusic-menu-popup-renderer',
-  );
-  buttonContainer.setAttribute('role', 'option');
-  buttonContainer.setAttribute('tabindex', '-1');
-
-  disposeButton = render(
-    () => <BlockArtistButton onClick={blockFromMenu} text={buttonText()} />,
-    buttonContainer,
-  );
-
-  const popupContainer = document.querySelector('ytmusic-popup-container');
-  if (popupContainer) {
-    menuObserver.observe(popupContainer, { childList: true, subtree: true });
-  }
 
   // A blocked song might already be loaded when the plugin starts.
   const current = getSongInfo();
   skipIfBlocked(current?.artist, current?.videoId);
   playerApi.addEventListener('videodatachange', onVideoDataChange);
+
+  const popupContainer = document.querySelector('ytmusic-popup-container');
+  if (popupContainer) {
+    menuObserver.observe(popupContainer, { childList: true, subtree: true });
+  }
 };
 
 export const stop = () => {
   menuObserver.disconnect();
   recentSkipAttempts.clear();
   api?.removeEventListener('videodatachange', onVideoDataChange);
-  disposeButton?.();
-  disposeButton = null;
-  buttonContainer?.remove();
-  buttonContainer = null;
+  getSongMenu()
+    ?.querySelectorAll('.blocklist-injected')
+    .forEach((el) => el.remove());
   api = null;
 };

--- a/src/plugins/blocklist/renderer.tsx
+++ b/src/plugins/blocklist/renderer.tsx
@@ -1,0 +1,214 @@
+import { createSignal } from 'solid-js';
+import { render } from 'solid-js/web';
+
+import { t } from '@/i18n';
+import { isMusicOrVideoTrack } from '@/plugins/utils/renderer/check';
+import { getSongMenu } from '@/providers/dom-elements';
+import { getSongInfo } from '@/providers/song-info-front';
+
+import { BlockArtistButton } from './templates/block-button';
+
+import type { BlockedArtist, BlocklistPluginConfig } from './index';
+import type { RendererContext } from '@/types/contexts';
+import type { MusicPlayer } from '@/types/music-player';
+import type { VideoDataChangeValue } from '@/types/player-api-events';
+
+let config: BlocklistPluginConfig = { enabled: true, blockedArtists: [] };
+let setConfig: RendererContext<BlocklistPluginConfig>['setConfig'] = () => {};
+let api: MusicPlayer | null = null;
+
+let buttonContainer: HTMLDivElement | null = null;
+let disposeButton: (() => void) | null = null;
+
+const [buttonText, setButtonText] = createSignal('');
+
+/** Normalize an artist name for matching (drop the " - Topic" suffix, casefold). */
+const normalize = (name: string) =>
+  name
+    .normalize('NFC')
+    .replace(/\s*-\s*topic\s*$/i, '')
+    .trim()
+    .toLowerCase();
+
+/** Split a combined author string into individual artists (collaborations). */
+const splitArtists = (author: string) =>
+  author
+    .split(/,|&|、|·|\/|(?:\s(?:feat\.?|ft\.?|x|×|vs\.?)\s)/i)
+    .map((part) => part.trim())
+    .filter(Boolean);
+
+const isBlocked = (author?: string | null) => {
+  if (!author) return false;
+  const whole = normalize(author);
+  const parts = splitArtists(author).map(normalize);
+  return config.blockedArtists.some((artist) => {
+    const target = normalize(artist.name);
+    return target.length > 0 && (whole === target || parts.includes(target));
+  });
+};
+
+// If a skip does not "stick" (e.g. a Music Together host controls playback and
+// re-syncs us back to the same song), give up instead of fighting in a loop.
+const SKIP_COOLDOWN_MS = 5000;
+const recentSkipAttempts = new Map<string, number>();
+
+const shouldSkip = (author?: string | null, videoId?: string | null) => {
+  if (!isBlocked(author)) return false;
+  if (!videoId) return true;
+
+  const now = Date.now();
+  for (const [id, at] of recentSkipAttempts) {
+    if (now - at > SKIP_COOLDOWN_MS) recentSkipAttempts.delete(id);
+  }
+
+  const lastAttempt = recentSkipAttempts.get(videoId);
+  if (lastAttempt !== undefined && now - lastAttempt < SKIP_COOLDOWN_MS) {
+    // We already tried to skip this exact track and it came back — something
+    // else controls playback (e.g. a Music Together session). Stop fighting it.
+    return false;
+  }
+
+  recentSkipAttempts.set(videoId, now);
+  return true;
+};
+
+const skipIfBlocked = (author?: string | null, videoId?: string | null) => {
+  if (shouldSkip(author, videoId)) {
+    api?.nextVideo();
+    return true;
+  }
+  return false;
+};
+
+const onVideoDataChange = (
+  name: 'dataloaded' | 'dataupdated',
+  data: VideoDataChangeValue,
+) => {
+  if (name !== 'dataloaded') return;
+  skipIfBlocked(data?.author, data?.videoId);
+};
+
+/**
+ * Resolve the artist for the song the currently-open context menu targets.
+ * Prefers the menu's "Go to artist" navigation item (works for any song row),
+ * and falls back to the currently-playing song (the player-bar menu).
+ */
+const getMenuArtist = (): BlockedArtist | null => {
+  const menu = getSongMenu();
+  if (menu) {
+    for (const item of menu.querySelectorAll<HTMLElement>(
+      'ytmusic-menu-navigation-item-renderer',
+    )) {
+      const href = item
+        .querySelector('#navigation-endpoint')
+        ?.getAttribute('href');
+      // Artist pages look like "channel/UC..."; albums use "browse/..." instead.
+      if (href?.startsWith('channel/')) {
+        const name = item
+          .querySelector<HTMLElement>('.text')
+          ?.textContent?.trim();
+        if (name) return { name, channelId: href.slice('channel/'.length) };
+      }
+    }
+  }
+
+  const info = getSongInfo();
+  if (info?.artist) {
+    return {
+      name: info.artist,
+      channelId: info.artistUrl?.split('/channel/')[1],
+    };
+  }
+
+  return null;
+};
+
+const blockFromMenu = () => {
+  const artist = getMenuArtist();
+  if (!artist) return;
+
+  if (!isBlocked(artist.name)) {
+    const blockedArtists = [...config.blockedArtists, artist];
+    config = { ...config, blockedArtists };
+    setConfig({ blockedArtists });
+  }
+
+  // Close the popup menu, then skip the current song if it is now blocked.
+  document
+    .querySelector<HTMLElement & { close?: () => void }>(
+      'ytmusic-popup-container tp-yt-iron-dropdown',
+    )
+    ?.close?.();
+
+  const current = getSongInfo();
+  skipIfBlocked(current?.artist, current?.videoId);
+};
+
+const menuObserver = new MutationObserver(() => {
+  const menu = getSongMenu();
+  if (
+    !menu ||
+    !buttonContainer ||
+    menu.contains(buttonContainer) ||
+    !isMusicOrVideoTrack()
+  ) {
+    return;
+  }
+
+  menu.prepend(buttonContainer);
+});
+
+export const onRendererLoad = async (
+  context: RendererContext<BlocklistPluginConfig>,
+) => {
+  setConfig = context.setConfig;
+  config = await context.getConfig();
+};
+
+export const onConfigChange = (newConfig: BlocklistPluginConfig) => {
+  config = newConfig;
+};
+
+export const onPlayerApiReady = (
+  playerApi: MusicPlayer,
+  _context: RendererContext<BlocklistPluginConfig>,
+) => {
+  api = playerApi;
+  setButtonText(t('plugins.blocklist.templates.button'));
+
+  buttonContainer = document.createElement('div');
+  buttonContainer.classList.add(
+    'blocklist-menu-item',
+    'style-scope',
+    'menu-item',
+    'ytmusic-menu-popup-renderer',
+  );
+  buttonContainer.setAttribute('role', 'option');
+  buttonContainer.setAttribute('tabindex', '-1');
+
+  disposeButton = render(
+    () => <BlockArtistButton onClick={blockFromMenu} text={buttonText()} />,
+    buttonContainer,
+  );
+
+  const popupContainer = document.querySelector('ytmusic-popup-container');
+  if (popupContainer) {
+    menuObserver.observe(popupContainer, { childList: true, subtree: true });
+  }
+
+  // A blocked song might already be loaded when the plugin starts.
+  const current = getSongInfo();
+  skipIfBlocked(current?.artist, current?.videoId);
+  playerApi.addEventListener('videodatachange', onVideoDataChange);
+};
+
+export const stop = () => {
+  menuObserver.disconnect();
+  recentSkipAttempts.clear();
+  api?.removeEventListener('videodatachange', onVideoDataChange);
+  disposeButton?.();
+  disposeButton = null;
+  buttonContainer?.remove();
+  buttonContainer = null;
+  api = null;
+};

--- a/src/plugins/blocklist/renderer.tsx
+++ b/src/plugins/blocklist/renderer.tsx
@@ -78,11 +78,28 @@ const skipIfBlocked = (author?: string | null, videoId?: string | null) => {
   return false;
 };
 
+// Tracks queue position so forward playback can be told apart from a deliberate
+// backward navigation (e.g. the user pressing Previous).
+let lastPlaylistIndex = -1;
+
 const onVideoDataChange = (
   name: 'dataloaded' | 'dataupdated',
   data: VideoDataChangeValue,
 ) => {
   if (name !== 'dataloaded') return;
+
+  const index = api?.getPlaylistIndex();
+  const wentBackward =
+    typeof index === 'number' &&
+    lastPlaylistIndex >= 0 &&
+    index < lastPlaylistIndex;
+  if (typeof index === 'number') lastPlaylistIndex = index;
+
+  // Respect a deliberate back-navigation: if the user moved backward onto this
+  // track (e.g. pressed Previous), let it play even if the artist is blocked.
+  // One-time only — a later forward play of the same artist still gets skipped.
+  if (wentBackward) return;
+
   skipIfBlocked(data?.author, data?.videoId);
 };
 
@@ -234,6 +251,7 @@ export const onPlayerApiReady = (
 export const stop = () => {
   menuObserver.disconnect();
   recentSkipAttempts.clear();
+  lastPlaylistIndex = -1;
   api?.removeEventListener('videodatachange', onVideoDataChange);
   getSongMenu()
     ?.querySelectorAll('.blocklist-injected')

--- a/src/plugins/blocklist/renderer.tsx
+++ b/src/plugins/blocklist/renderer.tsx
@@ -54,19 +54,23 @@ const recentSkipAttempts = new Map<string, number>();
 
 const shouldSkip = (author?: string | null, videoId?: string | null) => {
   if (!isBlocked(author)) return false;
-  if (!videoId) return true;
+
+  // Fall back to the author name when a videoId is missing so the cooldown
+  // still guards against a runaway skip loop.
+  const key = videoId || author;
+  if (!key) return true;
 
   const now = Date.now();
   for (const [id, at] of recentSkipAttempts) {
     if (now - at > SKIP_COOLDOWN_MS) recentSkipAttempts.delete(id);
   }
 
-  const lastAttempt = recentSkipAttempts.get(videoId);
+  const lastAttempt = recentSkipAttempts.get(key);
   if (lastAttempt !== undefined && now - lastAttempt < SKIP_COOLDOWN_MS) {
     return false;
   }
 
-  recentSkipAttempts.set(videoId, now);
+  recentSkipAttempts.set(key, now);
   return true;
 };
 

--- a/src/plugins/blocklist/style.css
+++ b/src/plugins/blocklist/style.css
@@ -1,0 +1,21 @@
+.blocklist-menu-item .yt-simple-endpoint {
+  cursor: pointer;
+}
+
+.blocklist-menu-item .yt-simple-endpoint:hover {
+  background-color: var(--ytmusic-menu-item-hover-background-color);
+}
+
+.blocklist-menu-item .ytmd-menu-item {
+  display: var(--ytmusic-menu-item_-_display);
+  height: var(--ytmusic-menu-item_-_height);
+  align-items: var(--ytmusic-menu-item_-_align-items);
+  padding: var(--ytmusic-menu-item_-_padding);
+  cursor: pointer;
+  flex: var(--ytmusic-menu-item-icon_-_flex);
+  margin: var(--ytmusic-menu-item-icon_-_margin);
+  fill: var(--ytmusic-menu-item-icon_-_fill);
+  stroke: var(--iron-icon-stroke-color, none);
+  width: var(--iron-icon-width, 24px);
+  height: var(--iron-icon-height, 24px);
+}

--- a/src/plugins/blocklist/templates/block-button.tsx
+++ b/src/plugins/blocklist/templates/block-button.tsx
@@ -1,0 +1,33 @@
+export const BlockArtistButton = (props: {
+  onClick: () => void;
+  text: string;
+}) => (
+  <a
+    class="yt-simple-endpoint style-scope ytmusic-menu-navigation-item-renderer"
+    onClick={props.onClick}
+    tabindex={-1}
+  >
+    <div class="icon ytmd-menu-item style-scope ytmusic-menu-navigation-item-renderer">
+      <svg
+        class="style-scope yt-icon"
+        preserveAspectRatio="xMidYMid meet"
+        style={{
+          'pointer-events': 'none',
+          'display': 'block',
+          'width': '100%',
+          'height': '100%',
+        }}
+        viewBox="0 0 24 24"
+      >
+        <path
+          class="style-scope yt-icon"
+          d="M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M12,4C13.85,4 15.55,4.63 16.9,5.69L5.69,16.9C4.63,15.55 4,13.85 4,12A8,8 0 0,1 12,4M12,20C10.15,20 8.45,19.37 7.1,18.31L18.31,7.1C19.37,8.45 20,10.15 20,12A8,8 0 0,1 12,20Z"
+          fill="#aaaaaa"
+        />
+      </svg>
+    </div>
+    <div class="text style-scope ytmusic-menu-navigation-item-renderer">
+      {props.text}
+    </div>
+  </a>
+);

--- a/src/plugins/blocklist/templates/block-button.tsx
+++ b/src/plugins/blocklist/templates/block-button.tsx
@@ -1,33 +1,32 @@
-export const BlockArtistButton = (props: {
-  onClick: () => void;
-  text: string;
-}) => (
-  <a
-    class="yt-simple-endpoint style-scope ytmusic-menu-navigation-item-renderer"
-    onClick={props.onClick}
-    tabindex={-1}
-  >
-    <div class="icon ytmd-menu-item style-scope ytmusic-menu-navigation-item-renderer">
-      <svg
-        class="style-scope yt-icon"
-        preserveAspectRatio="xMidYMid meet"
-        style={{
-          'pointer-events': 'none',
-          'display': 'block',
-          'width': '100%',
-          'height': '100%',
-        }}
-        viewBox="0 0 24 24"
-      >
-        <path
-          class="style-scope yt-icon"
-          d="M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M12,4C13.85,4 15.55,4.63 16.9,5.69L5.69,16.9C4.63,15.55 4,13.85 4,12A8,8 0 0,1 12,4M12,20C10.15,20 8.45,19.37 7.1,18.31L18.31,7.1C19.37,8.45 20,10.15 20,12A8,8 0 0,1 12,20Z"
-          fill="#aaaaaa"
-        />
-      </svg>
-    </div>
-    <div class="text style-scope ytmusic-menu-navigation-item-renderer">
-      {props.text}
-    </div>
-  </a>
-);
+import { ElementFromHtml } from '@/plugins/utils/renderer';
+
+const BLOCK_ICON = `<svg class="style-scope yt-icon" preserveAspectRatio="xMidYMid meet" style="pointer-events: none; display: block; width: 100%; height: 100%;" viewBox="0 0 24 24"><path class="style-scope yt-icon" d="M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M12,4C13.85,4 15.55,4.63 16.9,5.69L5.69,16.9C4.63,15.55 4,13.85 4,12A8,8 0 0,1 12,4M12,20C10.15,20 8.45,19.37 7.1,18.31L18.31,7.1C19.37,8.45 20,10.15 20,12A8,8 0 0,1 12,20Z" fill="#aaaaaa"></path></svg>`;
+
+/**
+ * Build a single "Block <artist>" row that matches YouTube Music's native
+ * context-menu items. `label` is applied via textContent so artist names are
+ * never interpreted as HTML.
+ */
+export const createBlockButton = (
+  label: string,
+  onClick: () => void,
+): HTMLElement => {
+  const element = ElementFromHtml(
+    `<div class="blocklist-injected blocklist-menu-item style-scope menu-item ytmusic-menu-popup-renderer" role="option" tabindex="-1">` +
+      `<a class="yt-simple-endpoint style-scope ytmusic-menu-navigation-item-renderer" tabindex="-1">` +
+      `<div class="icon ytmd-menu-item style-scope ytmusic-menu-navigation-item-renderer">${BLOCK_ICON}</div>` +
+      `<div class="text style-scope ytmusic-menu-navigation-item-renderer"></div>` +
+      `</a>` +
+      `</div>`,
+  );
+
+  const text = element.querySelector<HTMLElement>('.text');
+  if (text) text.textContent = label;
+
+  element.querySelector('a')?.addEventListener('click', (event) => {
+    event.preventDefault();
+    onClick();
+  });
+
+  return element;
+};


### PR DESCRIPTION
## What

Adds a new **Blocklist** plugin: block an artist and any song by that artist is automatically skipped.

## How it works

- **Block from a song** — adds a "Block \<artist\>" item to YouTube Music's right‑click / ⋮ menu on song rows and the now‑playing bar. Multi‑artist tracks show **one row per credited artist** so you pick exactly who to block (the now‑playing bar reads the full artist list from the byline).
- **Auto‑skip** — hooks the player API `videodatachange` event and calls `nextVideo()` when a loaded track's artist matches the blocklist. Matching is case‑insensitive, strips ` - Topic`, and splits collaborations (`A & B`, `feat.`, …).
- **Respects a deliberate go‑back** — if you manually navigate *backward* onto a track that was just skipped (e.g. press **Previous**, or click an earlier song), it plays instead of being re‑skipped. Detected via queue‑position direction, so it's **one‑time**: a later forward play of the same artist still skips.
- **Manage the list** — Settings → Plugins → Blocklist: add (via prompt), remove, clear all. Add/remove apply live via `onConfigChange`.

## Music Together interaction

On a **guest** in a Music Together session the guest doesn't control the shared queue, so a naive `nextVideo()` would be re‑synced back by the host and loop. To avoid fighting external playback control, the auto‑skip backs off when a skip of the same track doesn't stick within a short cooldown. The `music-together` plugin is **not** modified. Host / solo playback is unaffected.

## Matching & known limitations

- **Name‑based.** Skip decisions compare the playing track's artist **name** (case‑insensitive, normalized) against the blocklist. Each entry also stores the artist's channel id, but the track only exposes the artist as a name at skip time, so two different artists sharing the exact same name would both be skipped (rare).
- **Featured artists credited only in the title are not caught.** If an artist appears only in the song *title* — e.g. `Song (feat. <Blocked Artist>)` — and not in YouTube Music's artist metadata (it's absent from the byline / channel links too), the track won't be auto‑skipped, because matching reads the artist field rather than the title. YTM doesn't expose title‑only features as structured data, so catching them reliably would require parsing titles (with some false‑positive risk).

## Files

- `src/plugins/blocklist/` — `index.ts`, `menu.ts`, `renderer.tsx`, `templates/block-button.tsx`, `style.css`
- `src/i18n/resources/en.json` — `plugins.blocklist.*` strings (English; other locales fall back)

## Testing

- ✅ `electron-vite build` passes (plugin bundles into main + renderer)
- ✅ `tsc --noEmit` passes with 0 errors
- ✅ Manually tested in a dev build: blocking from song rows and the now‑playing bar, multi‑artist per‑artist rows, auto‑skip, and the back‑navigation reprieve.
- ⚠️ Couldn't run `oxlint` locally (unrelated allocator crash on an ARM/Raspberry Pi host affecting all files); style/rules were matched against the existing Downloader plugin — relying on CI for lint.

Opening as a **draft** for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a blocklist plugin with an in-app menu to add, remove, and clear blocked artists.
  * Blocked artists can be managed directly from playback menus, with changes saved for future sessions.
  * Automatically localizes blocklist labels and actions.
* **Bug Fixes**
  * Improved blocked-artist matching for name variations (including common “Topic” suffixes) and multi-artist credits.
  * Reduced repeated skipping and prevented unintended skips when moving backward.
* **Style**
  * Added styling for the blocklist menu controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->