### PR TITLE
feat(plugins): add connection diagnostics to Music Together

### DIFF
--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -628,6 +628,42 @@
         "click-to-copy-id": "Copy Host ID",
         "close": "Close Music Together",
         "connected-users": "Connected Users",
+        "diagnostics": {
+          "check": {
+            "nat": "Network type (NAT)",
+            "signaling": "Signaling server",
+            "stun": "Direct connection (STUN)",
+            "turn": "Relay fallback (TURN)"
+          },
+          "copy": "Copy summary",
+          "detail": {
+            "public-ip": "Public address: {{ip}}",
+            "public-ip-hidden": "Public address: click to reveal",
+            "reveal": "Click to reveal your public IP address",
+            "signaling-fail": "Unreachable ({{reason}})",
+            "signaling-ok": "Reachable",
+            "stun-fail": "No public address (UDP/STUN blocked)",
+            "stun-ok": "Public address found",
+            "turn-fail": "Relay unreachable",
+            "turn-ok": "Relay reachable"
+          },
+          "nat": {
+            "blocked": "UDP or STUN blocked",
+            "open": "Open / cone (direct works)",
+            "symmetric": "Symmetric (relay required)",
+            "unknown": "Undetermined"
+          },
+          "run-again": "Run again",
+          "running": "Running checks…",
+          "test": "Test connection",
+          "title": "Connection diagnostics",
+          "verdict": {
+            "blocked": "This network will likely block Music Together. Try another network or a VPN.",
+            "good": "Direct connections should work on this network.",
+            "no-signaling": "Can't reach the Music Together server. Check your firewall or internet connection.",
+            "relay": "Direct connections may fail here; a relay will be used (works, but adds latency)."
+          }
+        },
         "disconnect": "Disconnect Music Together",
         "empty-user": "No connected users",
         "host": "Music Together Host",
@@ -648,6 +684,8 @@
       "toast": {
         "add-song-failed": "Failed to add song",
         "closed": "Music Together closed",
+        "diagnostics-copied": "Diagnostics summary copied to clipboard",
+        "diagnostics-copy-failed": "Failed to copy diagnostics summary",
         "disconnected": "Music Together disconnected",
         "host-failed": "Failed to host Music Together",
         "id-copied": "Host ID copied to clipboard",

--- a/src/plugins/music-together/connection.ts
+++ b/src/plugins/music-together/connection.ts
@@ -44,6 +44,42 @@ export type ConnectionListener = (
 ) => void;
 export type ConnectionMode = 'host' | 'guest' | 'disconnected';
 
+/**
+ * ICE servers used to negotiate the WebRTC peer connection.
+ *
+ * Exported so the diagnostics run against byte-identical configuration to a
+ * real Music Together session. Keep this in sync with any change to the Peer
+ * options below.
+ *
+ * Only hosts that actually resolve belong here: the former
+ * `eu-0`/`us-0.turn.peerjs.com` relays were decommissioned (their DNS no longer
+ * resolves), so every ICE attempt spammed the console with
+ * `ERR_NAME_NOT_RESOLVED` while providing no relay at all.
+ */
+export const ICE_SERVERS: RTCIceServer[] = [
+  { urls: 'stun:stun.l.google.com:19302' },
+  {
+    urls: 'stun:freestun.net:3478',
+  },
+  {
+    urls: 'turn:freestun.net:3478',
+    username: 'free',
+    credential: 'free',
+  },
+  // Open Relay Project (Metered) — free public TURN. The `443?transport=tcp`
+  // entry tunnels the relay over TCP/443, which slips through the strict,
+  // HTTPS-only firewalls that block UDP relaying entirely.
+  {
+    urls: [
+      'turn:openrelay.metered.ca:80',
+      'turn:openrelay.metered.ca:443',
+      'turn:openrelay.metered.ca:443?transport=tcp',
+    ],
+    username: 'openrelayproject',
+    credential: 'openrelayproject',
+  },
+];
+
 const RECOVERABLE_PEER_ERRORS = new Set([
   PeerErrorType.Network,
   PeerErrorType.ServerError,
@@ -67,25 +103,7 @@ export class Connection {
     this.peer = new Peer({
       debug: 0,
       config: {
-        iceServers: [
-          { urls: 'stun:stun.l.google.com:19302' },
-          {
-            urls: [
-              'turn:eu-0.turn.peerjs.com:3478',
-              'turn:us-0.turn.peerjs.com:3478',
-            ],
-            username: 'peerjs',
-            credential: 'peerjsp',
-          },
-          {
-            urls: 'stun:freestun.net:3478',
-          },
-          {
-            urls: 'turn:freestun.net:3478',
-            username: 'free',
-            credential: 'free',
-          },
-        ],
+        iceServers: ICE_SERVERS,
         sdpSemantics: 'unified-plan',
       },
     });

--- a/src/plugins/music-together/connection.ts
+++ b/src/plugins/music-together/connection.ts
@@ -57,7 +57,16 @@ export type ConnectionMode = 'host' | 'guest' | 'disconnected';
  * `ERR_NAME_NOT_RESOLVED` while providing no relay at all.
  */
 export const ICE_SERVERS: RTCIceServer[] = [
+  // Several independent STUN servers. The diagnostics NAT check only reports an
+  // open/cone NAT once it has server-reflexive candidates from two *different*
+  // STUN servers (see `classifyNat` in diagnostics.ts). Relying on Google plus
+  // the free — and often slow or unreachable — freestun.net meant that a single
+  // freestun timeout left just one response, degrading the result to
+  // "Undetermined". Cloudflare and a second Google endpoint add reliable,
+  // independent mappings from distinct operators.
   { urls: 'stun:stun.l.google.com:19302' },
+  { urls: 'stun:stun1.l.google.com:19302' },
+  { urls: 'stun:stun.cloudflare.com:3478' },
   {
     urls: 'stun:freestun.net:3478',
   },

--- a/src/plugins/music-together/diagnostics.ts
+++ b/src/plugins/music-together/diagnostics.ts
@@ -1,0 +1,358 @@
+import { Peer } from 'peerjs';
+
+import { ICE_SERVERS } from './connection';
+
+/**
+ * Music Together connection diagnostics.
+ *
+ * Music Together relies on PeerJS (WebRTC). That does not work on every
+ * network: strict/symmetric NATs, firewalls that block UDP or the STUN/TURN
+ * ports, an unreachable signaling broker, or a downed relay all cause a
+ * host/join to fail silently. These checks run entirely in the renderer using
+ * the exact same {@link ICE_SERVERS} a real session uses, so the user can see
+ * *why* a connection would fail before they try it.
+ *
+ * Nothing here needs a second peer — a throwaway {@link Peer} tests the
+ * signaling broker, and self-contained {@link RTCPeerConnection}s gather ICE
+ * candidates to probe STUN, TURN and the NAT type.
+ */
+
+export type CheckStatus = 'pass' | 'warn' | 'fail';
+export type CheckId = 'signaling' | 'stun' | 'turn' | 'nat';
+
+export type DiagnosticCheck = {
+  id: CheckId;
+  status: CheckStatus;
+  /** Non-translatable specifics (public IP, NAT label, error code). */
+  detail?: string;
+};
+
+export type NatType = 'open' | 'symmetric' | 'blocked' | 'unknown';
+export type Verdict = 'good' | 'relay' | 'blocked' | 'no-signaling';
+
+export type DiagnosticResult = {
+  checks: DiagnosticCheck[];
+  natType: NatType;
+  verdict: Verdict;
+  publicIp?: string;
+  /** Plain-text, copyable technical summary for bug reports. */
+  summary: string;
+};
+
+const urlsOf = (server: RTCIceServer): string[] =>
+  Array.isArray(server.urls) ? server.urls : [server.urls];
+
+const STUN_SERVERS = ICE_SERVERS.filter((server) =>
+  urlsOf(server).every((url) => url.startsWith('stun:')),
+);
+const TURN_SERVERS = ICE_SERVERS.filter((server) =>
+  urlsOf(server).some(
+    (url) => url.startsWith('turn:') || url.startsWith('turns:'),
+  ),
+);
+
+const SIGNALING_TIMEOUT = 8_000;
+const STUN_TIMEOUT = 8_000;
+const TURN_TIMEOUT = 10_000;
+
+type SignalingResult = { ok: boolean; error?: string };
+
+const testSignaling = (timeout = SIGNALING_TIMEOUT): Promise<SignalingResult> =>
+  new Promise((resolve) => {
+    let settled = false;
+    let peer: Peer;
+    try {
+      peer = new Peer({
+        debug: 0,
+        config: {
+          iceServers: ICE_SERVERS,
+          sdpSemantics: 'unified-plan',
+        },
+      });
+    } catch (err) {
+      resolve({ ok: false, error: String(err) });
+      return;
+    }
+
+    const finish = (result: SignalingResult) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      try {
+        if (!peer.destroyed) peer.destroy();
+      } catch {
+        // ignore
+      }
+      resolve(result);
+    };
+
+    const timer = setTimeout(
+      () => finish({ ok: false, error: 'timeout' }),
+      timeout,
+    );
+
+    peer.on('open', () => finish({ ok: true }));
+    peer.on('error', (err) => finish({ ok: false, error: err.type }));
+  });
+
+type SrflxMapping = {
+  relatedPort: number;
+  publicPort: number;
+  publicIp: string;
+};
+type GatherResult = {
+  hasHost: boolean;
+  hasSrflx: boolean;
+  hasRelay: boolean;
+  srflx: SrflxMapping[];
+  /** Distinct STUN server URLs that produced a reflexive candidate. */
+  srflxServers: Set<string>;
+  publicIp?: string;
+  error?: string;
+};
+
+/**
+ * Fallback parser for the raw candidate string, used when the structured
+ * {@link RTCIceCandidate} fields are unavailable.
+ *
+ * `candidate:<foundation> <component> <transport> <priority> <address> <port>
+ *  typ <type> [raddr <relatedAddr> rport <relatedPort> ...]`
+ */
+const parseCandidate = (candidate: string) => {
+  const parts = candidate.split(' ');
+  const typIndex = parts.indexOf('typ');
+  const rportIndex = parts.indexOf('rport');
+  return {
+    address: parts[4],
+    port: Number(parts[5]),
+    type: typIndex >= 0 ? parts[typIndex + 1] : undefined,
+    relatedPort: rportIndex >= 0 ? Number(parts[rportIndex + 1]) : 0,
+  };
+};
+
+const gatherCandidates = (
+  iceServers: RTCIceServer[],
+  timeout: number,
+  policy: RTCIceTransportPolicy = 'all',
+): Promise<GatherResult> =>
+  new Promise((resolve) => {
+    const result: GatherResult = {
+      hasHost: false,
+      hasSrflx: false,
+      hasRelay: false,
+      srflx: [],
+      srflxServers: new Set<string>(),
+    };
+
+    let pc: RTCPeerConnection;
+    try {
+      pc = new RTCPeerConnection({ iceServers, iceTransportPolicy: policy });
+    } catch (err) {
+      resolve({ ...result, error: String(err) });
+      return;
+    }
+
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      try {
+        pc.close();
+      } catch {
+        // ignore
+      }
+      resolve(result);
+    };
+    const timer = setTimeout(finish, timeout);
+
+    pc.onicecandidate = (event) => {
+      const candidate = event.candidate;
+      if (!candidate || !candidate.candidate) {
+        finish(); // null candidate => gathering complete
+        return;
+      }
+
+      const parsed = parseCandidate(candidate.candidate);
+      const type = candidate.type ?? parsed.type;
+      const address = candidate.address ?? parsed.address;
+      const port = candidate.port ?? parsed.port;
+      const relatedPort = candidate.relatedPort ?? parsed.relatedPort ?? 0;
+
+      if (type === 'host') result.hasHost = true;
+      if (type === 'relay') result.hasRelay = true;
+      if (type === 'srflx') {
+        result.hasSrflx = true;
+        if (address) result.publicIp = address;
+        // `url` (the server that produced this candidate) is populated by
+        // Chromium but missing from the DOM typings.
+        const url = (
+          event as RTCPeerConnectionIceEvent & { url?: string | null }
+        ).url;
+        if (url) result.srflxServers.add(url);
+        result.srflx.push({
+          relatedPort,
+          publicPort: port ?? 0,
+          publicIp: address ?? '',
+        });
+      }
+    };
+
+    pc.onicegatheringstatechange = () => {
+      if (pc.iceGatheringState === 'complete') finish();
+    };
+
+    try {
+      pc.createDataChannel('music-together-diagnostics');
+      pc.createOffer()
+        .then((offer) => pc.setLocalDescription(offer))
+        .catch((err) => {
+          result.error = String(err);
+          finish();
+        });
+    } catch (err) {
+      result.error = String(err);
+      finish();
+    }
+  });
+
+/**
+ * Two-server NAT heuristic: the same local port is reflected by two different
+ * STUN servers. If the public port differs per destination the NAT is
+ * symmetric (direct P2P usually fails and a relay is required); if it stays
+ * the same it is a cone (direct works).
+ *
+ * Confirming a cone requires responses from *two* servers — a single response
+ * cannot rule out a symmetric NAT (the other server may just have timed out),
+ * so a lone reply yields 'unknown' (which the verdict treats conservatively)
+ * instead of a falsely reassuring 'open'.
+ */
+const classifyNat = (stun: GatherResult): NatType => {
+  if (!stun.hasSrflx) {
+    // No reflexive candidate at all: UDP or STUN is blocked on this network.
+    return stun.hasHost ? 'blocked' : 'unknown';
+  }
+
+  const byLocalPort = new Map<number, Set<number>>();
+  for (const mapping of stun.srflx) {
+    const ports = byLocalPort.get(mapping.relatedPort) ?? new Set<number>();
+    ports.add(mapping.publicPort);
+    byLocalPort.set(mapping.relatedPort, ports);
+  }
+
+  const isSymmetric = Array.from(byLocalPort.values()).some(
+    (ports) => ports.size > 1,
+  );
+  if (isSymmetric) return 'symmetric';
+
+  // Not symmetric, but only trust 'open' once two independent STUN servers
+  // have actually replied; otherwise we never verified the mapping.
+  return stun.srflxServers.size >= 2 ? 'open' : 'unknown';
+};
+
+const natStatus = (natType: NatType): CheckStatus => {
+  if (natType === 'open') return 'pass';
+  if (natType === 'blocked') return 'fail';
+  return 'warn';
+};
+
+const decideVerdict = (
+  signaling: SignalingResult,
+  stun: GatherResult,
+  turn: GatherResult,
+  natType: NatType,
+): Verdict => {
+  if (!signaling.ok) return 'no-signaling';
+  if (stun.hasSrflx && natType === 'open') return 'good';
+  if (turn.hasRelay) return 'relay';
+  return 'blocked';
+};
+
+const buildSummary = (
+  signaling: SignalingResult,
+  stun: GatherResult,
+  turn: GatherResult,
+  natType: NatType,
+  verdict: Verdict,
+): string => {
+  const yn = (ok: boolean) => (ok ? 'ok' : 'fail');
+  return [
+    'Music Together connection diagnostics',
+    `- signaling broker: ${yn(signaling.ok)}${signaling.error ? ` (${signaling.error})` : ''}`,
+    `- STUN (direct): ${yn(stun.hasSrflx)}${stun.publicIp ? ` (public ${stun.publicIp})` : ''}`,
+    `- TURN (relay): ${yn(turn.hasRelay)}`,
+    `- NAT type: ${natType}`,
+    `- verdict: ${verdict}`,
+  ].join('\n');
+};
+
+/**
+ * Run all connection checks. `onUpdate` fires as each individual check resolves
+ * so the UI can fill rows progressively; the returned promise resolves once
+ * every check is done with the aggregated result.
+ */
+export const runDiagnostics = async (
+  onUpdate?: (check: DiagnosticCheck) => void,
+): Promise<DiagnosticResult> => {
+  const emit = (check: DiagnosticCheck) => {
+    onUpdate?.(check);
+    return check;
+  };
+
+  const signalingP = testSignaling().then((result) => {
+    emit({
+      id: 'signaling',
+      status: result.ok ? 'pass' : 'fail',
+      detail: result.ok ? undefined : result.error,
+    });
+    return result;
+  });
+
+  const stunP = gatherCandidates(STUN_SERVERS, STUN_TIMEOUT).then((result) => {
+    emit({
+      id: 'stun',
+      status: result.hasSrflx ? 'pass' : 'warn',
+      detail: result.publicIp,
+    });
+    return result;
+  });
+
+  const turnP = gatherCandidates(TURN_SERVERS, TURN_TIMEOUT, 'relay').then(
+    (result) => {
+      emit({
+        id: 'turn',
+        status: result.hasRelay ? 'pass' : 'warn',
+      });
+      return result;
+    },
+  );
+
+  const [signaling, stun, turn] = await Promise.all([signalingP, stunP, turnP]);
+
+  const natType = classifyNat(stun);
+  emit({ id: 'nat', status: natStatus(natType), detail: natType });
+
+  const verdict = decideVerdict(signaling, stun, turn, natType);
+  const checks: DiagnosticCheck[] = [
+    {
+      id: 'signaling',
+      status: signaling.ok ? 'pass' : 'fail',
+      detail: signaling.ok ? undefined : signaling.error,
+    },
+    {
+      id: 'stun',
+      status: stun.hasSrflx ? 'pass' : 'warn',
+      detail: stun.publicIp,
+    },
+    { id: 'turn', status: turn.hasRelay ? 'pass' : 'warn' },
+    { id: 'nat', status: natStatus(natType), detail: natType },
+  ];
+
+  return {
+    checks,
+    natType,
+    verdict,
+    publicIp: stun.publicIp,
+    summary: buildSummary(signaling, stun, turn, natType, verdict),
+  };
+};

--- a/src/plugins/music-together/index.ts
+++ b/src/plugins/music-together/index.ts
@@ -6,6 +6,7 @@ import { createPlugin } from '@/utils';
 import { waitForElement } from '@/utils/wait-for-element';
 
 import { Connection, type ConnectionEventUnion } from './connection';
+import { runDiagnostics } from './diagnostics';
 import { Queue } from './queue';
 import style from './style.css?inline';
 import settingHTML from './templates/setting.html?raw';
@@ -15,6 +16,7 @@ import {
   type Profile,
   type VideoData,
 } from './types';
+import { createDiagnosticsPopup } from './ui/diagnostics';
 import { createGuestPopup } from './ui/guest';
 import { createHostPopup } from './ui/host';
 import { createSettingPopup } from './ui/setting';
@@ -54,6 +56,7 @@ export default createPlugin<
       host: ReturnType<typeof createHostPopup>;
       guest: ReturnType<typeof createGuestPopup>;
       setting: ReturnType<typeof createSettingPopup>;
+      diagnostics: ReturnType<typeof createDiagnosticsPopup>;
     };
     elements: {
       setting: HTMLElement;
@@ -63,6 +66,7 @@ export default createPlugin<
     stateInterval?: number;
     updateNext: boolean;
     ignoreChange: boolean;
+    diagnosticsRunning: boolean;
     rollbackInjector?: () => void;
     me?: Omit<Profile, 'id'>;
     profiles: Record<string, Profile>;
@@ -74,6 +78,7 @@ export default createPlugin<
     onHost: () => Promise<boolean>;
     onJoin: () => Promise<boolean>;
     onStop: () => void;
+    runDiagnosticsFlow: () => Promise<void>;
     putProfile: (id: string, profile?: Profile) => void;
     showSpinner: () => void;
     hideSpinner: () => void;
@@ -101,11 +106,13 @@ export default createPlugin<
   renderer: {
     updateNext: false,
     ignoreChange: false,
+    diagnosticsRunning: false,
     permission: 'playlist',
     popups: {} as {
       host: ReturnType<typeof createHostPopup>;
       guest: ReturnType<typeof createGuestPopup>;
       setting: ReturnType<typeof createSettingPopup>;
+      diagnostics: ReturnType<typeof createDiagnosticsPopup>;
     },
     elements: {} as {
       setting: HTMLElement;
@@ -665,6 +672,23 @@ export default createPlugin<
       this.popups.setting.dismiss();
     },
 
+    async runDiagnosticsFlow() {
+      if (this.diagnosticsRunning) return;
+      this.diagnosticsRunning = true;
+      this.popups.diagnostics.reset();
+
+      try {
+        const result = await runDiagnostics((check) => {
+          this.popups.diagnostics.setCheck(check);
+        });
+        this.popups.diagnostics.setResult(result);
+      } catch (error) {
+        console.error('Music Together: diagnostics failed', error);
+      } finally {
+        this.diagnosticsRunning = false;
+      }
+    },
+
     /* methods */
     putProfile(id: string, profile?: Profile) {
       if (profile === undefined) {
@@ -884,12 +908,44 @@ export default createPlugin<
               );
             }
           }
+
+          if (id === 'music-together-test') {
+            settingPopup.dismiss();
+            diagnosticsPopup.showAtAnchor(setting);
+            void this.runDiagnosticsFlow();
+          }
+        },
+      });
+      const diagnosticsPopup = createDiagnosticsPopup({
+        onItemClick: (id) => {
+          if (id === 'music-together-diagnostics-run') {
+            void this.runDiagnosticsFlow();
+          }
+
+          if (id === 'music-together-diagnostics-copy') {
+            const summary = diagnosticsPopup.getSummary();
+            if (!summary) return;
+
+            navigator.clipboard
+              .writeText(summary)
+              .then(() => {
+                this.api?.toastService?.show(
+                  t('plugins.music-together.toast.diagnostics-copied'),
+                );
+              })
+              .catch(() => {
+                this.api?.toastService?.show(
+                  t('plugins.music-together.toast.diagnostics-copy-failed'),
+                );
+              });
+          }
         },
       });
       this.popups = {
         host: hostPopup,
         guest: guestPopup,
         setting: settingPopup,
+        diagnostics: diagnosticsPopup,
       };
       setting.addEventListener('click', () => {
         let popup = settingPopup;

--- a/src/plugins/music-together/style.css
+++ b/src/plugins/music-together/style.css
@@ -140,6 +140,128 @@
   text-align: center;
 }
 
+.music-together-diagnostics {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 12px;
+
+  box-sizing: border-box;
+  width: 260px;
+  max-width: 100%;
+  padding: 16px;
+}
+.music-together-diagnostics-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.music-together-diagnostics-row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 12px;
+}
+.music-together-diagnostics-indicator {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+
+  border-radius: 50%;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+
+  &.is-pending {
+    border: 2px solid rgba(255, 255, 255, 0.2);
+    border-top-color: rgba(255, 255, 255, 0.8);
+    animation: music-together-spin 0.8s linear infinite;
+  }
+  &.is-pass {
+    background-color: rgba(46, 204, 113, 0.15);
+    color: #2ecc71;
+  }
+  &.is-pass::after {
+    content: '✓';
+  }
+  &.is-warn {
+    background-color: rgba(241, 196, 15, 0.15);
+    color: #f1c40f;
+  }
+  &.is-warn::after {
+    content: '!';
+  }
+  &.is-fail {
+    background-color: rgba(231, 76, 60, 0.15);
+    color: #e74c3c;
+  }
+  &.is-fail::after {
+    content: '✕';
+  }
+}
+@keyframes music-together-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+.music-together-diagnostics-text {
+  flex: 1;
+  min-width: 0;
+
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  overflow: hidden;
+}
+.music-together-diagnostics-label {
+  font-size: 14px;
+  color: #fff;
+  white-space: nowrap;
+}
+.music-together-diagnostics-detail {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.5);
+
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+
+  &.is-revealable {
+    cursor: pointer;
+    text-decoration: underline dotted;
+    text-underline-offset: 2px;
+  }
+  &.is-revealable:focus-visible {
+    outline: 1px solid rgba(255, 255, 255, 0.6);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+}
+.music-together-diagnostics-verdict {
+  font-size: 13px;
+  line-height: 1.4;
+  overflow-wrap: break-word;
+
+  &.is-running {
+    color: rgba(255, 255, 255, 0.5);
+  }
+  &.is-good {
+    color: #2ecc71;
+  }
+  &.is-relay {
+    color: #f1c40f;
+  }
+  &.is-blocked,
+  &.is-no-signaling {
+    color: #e74c3c;
+  }
+}
+
 .music-together-owner {
   width: 24px;
   height: 24px;

--- a/src/plugins/music-together/templates/diagnostics.html
+++ b/src/plugins/music-together/templates/diagnostics.html
@@ -1,0 +1,17 @@
+<div class="music-together-diagnostics">
+  <div class="music-together-status-item">
+    <pear-trans
+      key="plugins.music-together.menu.diagnostics.title"
+    ></pear-trans>
+  </div>
+  <div class="music-together-diagnostics-list"></div>
+  <div class="music-together-divider horizontal" style="margin: 4px 0"></div>
+  <div
+    class="music-together-diagnostics-verdict is-running"
+    id="music-together-diagnostics-verdict"
+  >
+    <pear-trans
+      key="plugins.music-together.menu.diagnostics.running"
+    ></pear-trans>
+  </div>
+</div>

--- a/src/plugins/music-together/ui/diagnostics.ts
+++ b/src/plugins/music-together/ui/diagnostics.ts
@@ -1,0 +1,215 @@
+import { t } from '@/i18n';
+import { ElementFromHtml } from '@/plugins/utils/renderer';
+
+import { Popup } from '../element';
+import IconKey from '../icons/key.svg?raw';
+import IconTune from '../icons/tune.svg?raw';
+
+import diagnosticsHTML from '../templates/diagnostics.html?raw';
+
+import type {
+  CheckId,
+  DiagnosticCheck,
+  DiagnosticResult,
+  NatType,
+} from '../diagnostics';
+
+const CHECK_ORDER: CheckId[] = ['signaling', 'stun', 'turn', 'nat'];
+
+const natLabel = (natType: NatType) =>
+  t(`plugins.music-together.menu.diagnostics.nat.${natType}`);
+
+const detailText = (check: DiagnosticCheck): string => {
+  switch (check.id) {
+    case 'signaling':
+      return check.status === 'pass'
+        ? t('plugins.music-together.menu.diagnostics.detail.signaling-ok')
+        : t('plugins.music-together.menu.diagnostics.detail.signaling-fail', {
+            reason: check.detail ?? 'unknown',
+          });
+    case 'stun':
+      return check.status === 'pass'
+        ? t('plugins.music-together.menu.diagnostics.detail.stun-ok')
+        : t('plugins.music-together.menu.diagnostics.detail.stun-fail');
+    case 'turn':
+      return check.status === 'pass'
+        ? t('plugins.music-together.menu.diagnostics.detail.turn-ok')
+        : t('plugins.music-together.menu.diagnostics.detail.turn-fail');
+    case 'nat':
+      return natLabel((check.detail as NatType) ?? 'unknown');
+    default:
+      return '';
+  }
+};
+
+/**
+ * Show the public IP behind a click-to-reveal, so it stays out of casual
+ * screenshots shared for support.
+ */
+const setupReveal = (detail: HTMLSpanElement, ip: string) => {
+  const hidden = t(
+    'plugins.music-together.menu.diagnostics.detail.public-ip-hidden',
+  );
+  const shown = t('plugins.music-together.menu.diagnostics.detail.public-ip', {
+    ip,
+  });
+
+  let revealed = false;
+  const toggle = () => {
+    revealed = !revealed;
+    detail.textContent = revealed ? shown : hidden;
+    detail.setAttribute('aria-pressed', String(revealed));
+  };
+
+  detail.textContent = hidden;
+  detail.classList.add('is-revealable');
+  detail.title = t('plugins.music-together.menu.diagnostics.detail.reveal');
+  // Expose as a real button so keyboard-only users can focus and toggle it.
+  detail.setAttribute('role', 'button');
+  detail.setAttribute('tabindex', '0');
+  detail.setAttribute('aria-pressed', 'false');
+  detail.onclick = toggle;
+  detail.onkeydown = (event) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      toggle();
+    }
+  };
+};
+
+const clearReveal = (detail: HTMLSpanElement) => {
+  detail.classList.remove('is-revealable');
+  detail.onclick = null;
+  detail.onkeydown = null;
+  detail.removeAttribute('title');
+  detail.removeAttribute('role');
+  detail.removeAttribute('tabindex');
+  detail.removeAttribute('aria-pressed');
+};
+
+const createDiagnostics = () => {
+  const element = ElementFromHtml(diagnosticsHTML);
+  const list = element.querySelector<HTMLDivElement>(
+    '.music-together-diagnostics-list',
+  )!;
+  const verdictLabel = element.querySelector<HTMLDivElement>(
+    '#music-together-diagnostics-verdict',
+  )!;
+
+  const rows = new Map<
+    CheckId,
+    { indicator: HTMLSpanElement; detail: HTMLSpanElement }
+  >();
+
+  for (const id of CHECK_ORDER) {
+    const row = document.createElement('div');
+    row.className = 'music-together-diagnostics-row';
+
+    const indicator = document.createElement('span');
+    indicator.className = 'music-together-diagnostics-indicator is-pending';
+
+    const text = document.createElement('div');
+    text.className = 'music-together-diagnostics-text';
+
+    const label = document.createElement('span');
+    label.className = 'music-together-diagnostics-label';
+    label.textContent = t(
+      `plugins.music-together.menu.diagnostics.check.${id}`,
+    );
+
+    const detail = document.createElement('span');
+    detail.className = 'music-together-diagnostics-detail';
+
+    text.append(label, detail);
+    row.append(indicator, text);
+    list.append(row);
+
+    rows.set(id, { indicator, detail });
+  }
+
+  let summary = '';
+
+  const reset = () => {
+    summary = '';
+    for (const { indicator, detail } of rows.values()) {
+      indicator.className = 'music-together-diagnostics-indicator is-pending';
+      clearReveal(detail);
+      detail.textContent = '';
+    }
+    verdictLabel.className = 'music-together-diagnostics-verdict is-running';
+    verdictLabel.textContent = t(
+      'plugins.music-together.menu.diagnostics.running',
+    );
+  };
+
+  const setCheck = (check: DiagnosticCheck) => {
+    const row = rows.get(check.id);
+    if (!row) return;
+    row.indicator.className = `music-together-diagnostics-indicator is-${check.status}`;
+
+    clearReveal(row.detail);
+    if (check.id === 'stun' && check.status === 'pass' && check.detail) {
+      setupReveal(row.detail, check.detail);
+    } else {
+      row.detail.textContent = detailText(check);
+    }
+  };
+
+  const setResult = (result: DiagnosticResult) => {
+    for (const check of result.checks) setCheck(check);
+    summary = result.summary;
+    verdictLabel.className = `music-together-diagnostics-verdict is-${result.verdict}`;
+    verdictLabel.textContent = t(
+      `plugins.music-together.menu.diagnostics.verdict.${result.verdict}`,
+    );
+  };
+
+  return {
+    element,
+    reset,
+    setCheck,
+    setResult,
+    getSummary: () => summary,
+  };
+};
+
+export type DiagnosticsPopupProps = {
+  onItemClick: (id: string) => void;
+};
+
+export const createDiagnosticsPopup = (props: DiagnosticsPopupProps) => {
+  const diagnostics = createDiagnostics();
+
+  const result = Popup({
+    data: [
+      {
+        type: 'custom',
+        element: diagnostics.element,
+      },
+      {
+        type: 'divider',
+      },
+      {
+        id: 'music-together-diagnostics-run',
+        type: 'item',
+        icon: ElementFromHtml(IconTune),
+        text: t('plugins.music-together.menu.diagnostics.run-again'),
+        onClick: () => props.onItemClick('music-together-diagnostics-run'),
+      },
+      {
+        id: 'music-together-diagnostics-copy',
+        type: 'item',
+        icon: ElementFromHtml(IconKey),
+        text: t('plugins.music-together.menu.diagnostics.copy'),
+        onClick: () => props.onItemClick('music-together-diagnostics-copy'),
+      },
+    ],
+    anchorAt: 'bottom-right',
+    popupAt: 'top-right',
+  });
+
+  return {
+    ...diagnostics,
+    ...result,
+  };
+};

--- a/src/plugins/music-together/ui/setting.ts
+++ b/src/plugins/music-together/ui/setting.ts
@@ -6,6 +6,7 @@ import { createStatus } from './status';
 
 import IconConnect from '../icons/connect.svg?raw';
 import IconMusicCast from '../icons/music-cast.svg?raw';
+import IconTune from '../icons/tune.svg?raw';
 
 export type SettingPopupProps = {
   onItemClick: (id: string) => void;
@@ -35,6 +36,16 @@ export const createSettingPopup = (props: SettingPopupProps) => {
         icon: ElementFromHtml(IconConnect),
         text: t('plugins.music-together.menu.join'),
         onClick: () => props.onItemClick('music-together-join'),
+      },
+      {
+        type: 'divider',
+      },
+      {
+        id: 'music-together-test',
+        type: 'item',
+        icon: ElementFromHtml(IconTune),
+        text: t('plugins.music-together.menu.diagnostics.test'),
+        onClick: () => props.onItemClick('music-together-test'),
       },
     ],
     anchorAt: 'bottom-right',


### PR DESCRIPTION
## Summary

Music Together is peer-to-peer over **PeerJS/WebRTC**, which fails on many networks — symmetric NAT/CGNAT, UDP-blocking firewalls, an unreachable signaling broker, or a dead relay. Today those failures are **silent**, surfacing only as a generic *"Failed to host/join"* toast.

This PR adds a **"Test connection"** pre-flight diagnostic so users can see whether — and *why* — Music Together will work on their network, and fixes a couple of real connectivity bugs found along the way.

## What it adds

A new **Test connection** item in the Music Together popup runs four checks against the *same* ICE servers a real session uses (no second peer required):

- **Signaling broker** — throwaway `Peer`; confirms the PeerJS cloud is reachable.
- **Direct (STUN)** — gathers `srflx` candidates; confirms UDP + STUN and the public address.
- **Relay (TURN)** — relay-only `RTCPeerConnection`; confirms the fallback path.
- **NAT type** — two-STUN-server mapped-port heuristic (open/cone vs symmetric vs blocked).

Results fill in progressively (spinner → ✓ / ! / ✕) and end with a plain-language **verdict** ("Direct connections should work" / "…will use a relay" / "This network will likely block Music Together" / "Can't reach the server"), plus **Run again** and a **copyable summary** for bug reports. The discovered public IP sits behind a **click-to-reveal** so it stays out of casual screenshots.

## Connectivity fixes

- **Removed dead TURN servers.** `eu-0`/`us-0.turn.peerjs.com` are decommissioned — their DNS no longer resolves, so every ICE attempt spammed the console with `ERR_NAME_NOT_RESOLVED` while relaying nothing.
- **Added the Open Relay Project TURN servers** (incl. `443?transport=tcp`, which tunnels the relay over TCP/443 to pass HTTPS-only firewalls) so relay fallback actually works on strict networks.
- Extracted the ICE server list into an exported `ICE_SERVERS` constant so the live connection and the diagnostics stay byte-identical.

## Implementation notes

- Renderer-only; **no new dependencies** (reuses the existing `peerjs`).
- All throwaway `Peer` / `RTCPeerConnection` instances are torn down with timeouts — nothing leaks or disturbs an active session.
- No changes to the Music Together sync protocol.
- New i18n strings are English-only under `plugins.music-together.menu.diagnostics.*`; other locales fall back to English (consistent with the repo).

## Testing

- `pnpm tsc --noEmit` — passes (0 errors).
- `pnpm oxfmt --check` — clean.
- Manually verified in-app: checks run and render, the verdict is accurate, the previous console flood is gone, the IP reveal toggles, and the panel lays out correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Music Together “connection diagnostics” panel to check signaling reachability, STUN/TURN connectivity, NAT type, and an overall verdict (good/relay/blocked/no-signaling).
  * Added “Run again” and “Copy diagnostics” actions with localized success/failure toasts.
  * Enabled click-to-reveal for the discovered public IP in the STUN result.
* **Bug Fixes**
  * Improved connectivity checking by using an expanded STUN/TURN set for diagnostics (aligning behavior more closely with real sessions).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->