### PR TITLE
feat(shortcuts): enable MPRIS by default on Linux

### DIFF
--- a/src/plugins/shortcuts/index.ts
+++ b/src/plugins/shortcuts/index.ts
@@ -21,7 +21,7 @@ export default createPlugin({
   description: () => t('plugins.shortcuts.description'),
   restartNeeded: true,
   config: {
-    enabled: false,
+    enabled: true,
     overrideMediaKeys: false,
     global: {
       previous: '',


### PR DESCRIPTION
MPRIS support in the shortcuts plugin already works, it's just been disabled by default so people don't find it unless someone tells them where to look (see the thread in #3872).

Just flips enabled to true, nothing else changes. `overrideMediaKeys` and the `keybinds` stay off/empty by default so this has no effect on Windows/Mac. Tested with a fresh config,  `org.mpris.MediaPlayer2.YoutubeMusic` shows up on dbus right away and Identity/PlaybackStatus respond fine through busctl.

Also closes #4219 — with shortcuts disabled (the old default), `src/index.ts` only disables chromium's own `MediaSessionService/MPRIS` when shortcuts is enabled, so chromium's MPRIS was running under an unlisted dbus name that flatpak's sandbox blocks. Enabling it by default means that never happens on a fresh install.

Closes #3872
Closes #4219

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shortcuts are now enabled by default when the plugin is added, so keyboard shortcuts work immediately without extra setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->