### PR TITLE
fix(shortcuts): make "Override media keys" work on Windows and macOS

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -145,10 +145,15 @@ if (is.linux()) {
 // media keys before Electron's globalShortcut can receive them, so the shortcuts
 // plugin's "Override media keys" option has no effect. Release the keys to
 // globalShortcut when that option is enabled (Linux uses MPRIS instead).
-if (!is.linux() && (await config.plugins.isEnabled('shortcuts'))) {
+//
+// This must stay synchronous: the ESM entry point is loaded asynchronously, so
+// a top-level `await` here would let the `ready` event fire before the
+// `disable-features` switch below is applied, and Chromium would silently
+// ignore it. Read the stored config directly instead of `await isEnabled(...)`.
+if (!is.linux()) {
   const shortcutsConfig =
     config.plugins.getOptions<ShortcutsPluginConfig>('shortcuts');
-  if (shortcutsConfig?.overrideMediaKeys) {
+  if (shortcutsConfig?.enabled && shortcutsConfig?.overrideMediaKeys) {
     disabledFeatures.push('HardwareMediaKeyHandling');
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ import { setUpTray } from '@/tray';
 import { LoggerPrefix } from '@/utils';
 import { isTesting } from '@/utils/testing';
 
+import type { ShortcutsPluginConfig } from '@/plugins/shortcuts';
 import type { PluginConfig } from '@/types/plugins';
 
 // Catch errors and log them
@@ -138,6 +139,18 @@ if (is.linux()) {
     'class',
     'com.github.th-ch.\u0079\u006f\u0075\u0074\u0075\u0062\u0065\u002d\u006d\u0075\u0073\u0069\u0063',
   );
+}
+
+// Windows/macOS: Chromium's HardwareMediaKeyHandling intercepts the hardware
+// media keys before Electron's globalShortcut can receive them, so the shortcuts
+// plugin's "Override media keys" option has no effect. Release the keys to
+// globalShortcut when that option is enabled (Linux uses MPRIS instead).
+if (!is.linux() && (await config.plugins.isEnabled('shortcuts'))) {
+  const shortcutsConfig =
+    config.plugins.getOptions<ShortcutsPluginConfig>('shortcuts');
+  if (shortcutsConfig?.overrideMediaKeys) {
+    disabledFeatures.push('HardwareMediaKeyHandling');
+  }
 }
 
 if (disableHardwareAcceleration) {


### PR DESCRIPTION
## Problem

On **Windows and macOS**, the Shortcuts plugin's **Override media keys** option does nothing — hardware media keys (play/pause, next, previous, from the keyboard or headphones) don't control playback.

The option registers `MediaPlayPause` / `MediaNextTrack` / `MediaPreviousTrack` via Electron's `globalShortcut`, but Chromium's `HardwareMediaKeyHandling` feature intercepts those keys before `globalShortcut` can receive them, so the bindings never fire. This is a known Electron limitation (electron/electron#24052, electron/electron#5268). The Linux path already sidesteps it by disabling `MediaSessionService` and using the app's own MPRIS service — there was no equivalent for Windows/macOS.

## Fix

When the shortcuts plugin is enabled and `overrideMediaKeys` is on, add `HardwareMediaKeyHandling` to the disabled Chromium features on non-Linux platforms. This releases the hardware keys so the `globalShortcut` bindings actually receive them.

```ts
if (!is.linux() && (await config.plugins.isEnabled('shortcuts'))) {
  const shortcutsConfig =
    config.plugins.getOptions<ShortcutsPluginConfig>('shortcuts');
  if (shortcutsConfig?.overrideMediaKeys) {
    disabledFeatures.push('HardwareMediaKeyHandling');
  }
}
```

**Default behaviour is unchanged** — the keys are only released when the user explicitly enables *Override media keys*. The SMTC media flyout keeps working because `MediaSessionService` stays enabled.

## Scope / notes

- Covers **play/pause / next / previous** only. Volume keys are intentionally out of scope: Windows routes hardware volume keys to the OS mixer and never delivers them to the app.
- The Shortcuts plugin is already `restartNeeded`, which is required here since Chromium feature flags are applied at startup.

## Testing

- `pnpm typecheck` passes.
- ⚠️ Not yet verified on real Windows/macOS hardware. To validate: enable **Settings → Plugins → Shortcuts → Override media keys**, restart, then confirm keyboard/headphone play-pause/next/previous control playback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media key handling on Windows and macOS when shortcut overrides are enabled.
  * When hardware media key handling would conflict, the app now disables Chromium’s hardware media key behavior early and restores the expected handling through the app’s shortcut logic for smoother playback control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->