### PR TITLE
fix: show real app info in the about panel

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import url from 'node:url';
 
 import ErrorHtmlAsset from '@assets/error.html?asset';
+import musicPlayerIcon from '@assets/icon.png?asset&asarUnpack';
 import {
   enhanceWebRequest,
   type BetterSession,
@@ -51,6 +52,8 @@ import { setupSongInfo } from '@/providers/song-info';
 import { setUpTray } from '@/tray';
 import { LoggerPrefix } from '@/utils';
 import { isTesting } from '@/utils/testing';
+
+import packageJson from '../package.json';
 
 import type { PluginConfig } from '@/types/plugins';
 
@@ -180,6 +183,16 @@ if (process.platform === 'win32') {
 } else if (process.platform === 'darwin') {
   icon = 'assets/generated/icons/mac/icon.icns';
 }
+
+// Without this, Electron's default About panel shows the raw app id instead of a proper name, and no icon.
+app.setAboutPanelOptions({
+  applicationName: APPLICATION_NAME,
+  applicationVersion: app.getVersion(),
+  version: app.getVersion(),
+  iconPath: musicPlayerIcon,
+  copyright: `Copyright (c) ${packageJson.author.name} <${packageJson.author.email}> (${packageJson.author.url})`,
+  website: packageJson.author.url,
+});
 
 function onClosed() {
   // Dereference the window


### PR DESCRIPTION
the about panel was just showing the raw app id and a broken icon since `setAboutPanelOptions` was never called anywhere. wired up the real name, version and icon, and pulled copyright/website from `package.json` instead of hardcoding them.

closes #4547

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a richer About panel in the desktop app, including the app name, version, icon, copyright, and website.
  * The About dialog now automatically reflects the app’s published author details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->