### PR TITLE
fix: volume api set and get now use the same scale

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -131,10 +131,11 @@ async function onApiLoaded() {
     }
   });
   window.ipcRenderer.on('peard:update-volume', (_, volume: number) => {
-    api?.setVolume(volume);
+    const clampedVolume = Math.max(0, Math.min(100, volume));
+    api?.setVolume(clampedVolume);
     for (const selector of ['#volume-slider', '#expand-volume-slider']) {
       const slider = document.querySelector<HTMLInputElement>(selector);
-      if (slider) slider.value = String(volume);
+      if (slider) slider.value = String(clampedVolume);
     }
   });
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -131,11 +131,11 @@ async function onApiLoaded() {
     }
   });
   window.ipcRenderer.on('peard:update-volume', (_, volume: number) => {
-    document
-      .querySelector<HTMLElement & { updateVolume: (volume: number) => void }>(
-        'ytmusic-player-bar',
-      )
-      ?.updateVolume(volume);
+    api?.setVolume(volume);
+    for (const selector of ['#volume-slider', '#expand-volume-slider']) {
+      const slider = document.querySelector<HTMLInputElement>(selector);
+      if (slider) slider.value = String(volume);
+    }
   });
 
   const isFullscreen = () => {


### PR DESCRIPTION
POST /volume went through `ytmusic-player-bar.updateVolume` which transforms the value, GET reads `api.getVolume()` directly on a different scale, so read-modify-write was broken. now both use the same api call, same thing `precise-volume` already does.

closes #4458
closes #4431

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Volume updates are now clamped to a valid 0–100 range before applying, preventing out-of-bounds values.
  * Volume changes stay synchronized between both volume sliders in the player UI.
  * Playback volume is applied more consistently when adjusting the volume control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->