### PR TITLE
album-color-theme: fix Home page ignoring the theme

### DIFF
--- a/src/plugins/album-color-theme/style.css
+++ b/src/plugins/album-color-theme/style.css
@@ -84,6 +84,10 @@ ytmusic-app-layout[is-bauhaus-sidenav-enabled]
   background: var(--ytmusic-background) !important;
 }
 
+body {
+  background-color: var(--ytmusic-background) !important;
+}
+
 ytmusic-browse-response[has-background]:not([disable-gradient])
   .background-gradient.ytmusic-browse-response {
   background: unset !important;


### PR DESCRIPTION
YTM hardcodes body's background to a flat #030303 instead of a themeable variable, which was hiding the album color tint on Home since that page doesn't have its own opaque cover image over body like artist/playlist pages do. Added one rule to make body use the same --ytmusic-background variable the plugin already computes. Closes #4536

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the app background to consistently match the active theme, improving visual consistency on the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->