### PR TITLE
feat(big_romanization): config option to make romaji bigger

### DIFF
--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -884,6 +884,10 @@
           "label": "Romanize lyrics",
           "tooltip": "If the lyrics are in a different language, try to display a latin version."
         },
+        "big_romanization": {
+          "label": "Big romanized lyrics",
+          "tooltip": "Make romanized lyrics bigger, and kanji, hangul, etc. smaller"
+        },
         "show-lyrics-even-if-inexact": {
           "label": "Show lyrics even if inexact",
           "tooltip": "If the song is not found, the plugin tries again with a different search query.\nThe result from the second attempt may not be exact."

--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -884,7 +884,7 @@
           "label": "Romanize lyrics",
           "tooltip": "If the lyrics are in a different language, try to display a latin version."
         },
-        "big_romanization": {
+        "big-romanization": {
           "label": "Big romanized lyrics",
           "tooltip": "Make romanized lyrics bigger, and kanji, hangul, etc. smaller"
         },

--- a/src/i18n/resources/es.json
+++ b/src/i18n/resources/es.json
@@ -902,7 +902,7 @@
           "label": "Romanizar letras",
           "tooltip": "Si la letra está en un idioma diferente, intenta mostrar una versión en latín."
         },
-        "big_romanization": {
+        "big-romanization": {
           "label": "Letras romanizadas grandes",
           "tooltip": "Las letras romanizadas se ven en grande y los kanjis, hangul, etc. en pequeño."
         },

--- a/src/i18n/resources/es.json
+++ b/src/i18n/resources/es.json
@@ -902,6 +902,10 @@
           "label": "Romanizar letras",
           "tooltip": "Si la letra está en un idioma diferente, intenta mostrar una versión en latín."
         },
+        "big_romanization": {
+          "label": "Letras romanizadas grandes",
+          "tooltip": "Las letras romanizadas se ven en grande y los kanjis, hangul, etc. en pequeño."
+        },
         "show-lyrics-even-if-inexact": {
           "label": "Mostrar la letra aunque sea inexacta",
           "tooltip": "Si no se encuentra la canción, el plugin vuelve a intentarlo con una búsqueda diferente.\nEl resultado del segundo intento puede no ser exacto."

--- a/src/plugins/synced-lyrics/index.ts
+++ b/src/plugins/synced-lyrics/index.ts
@@ -27,7 +27,7 @@ export default createPlugin<
     defaultTextString: '♪',
     lineEffect: 'fancy',
     romanization: true,
-    big_romanization: true,
+    bigRomanization: true,
   },
 
   menu,

--- a/src/plugins/synced-lyrics/index.ts
+++ b/src/plugins/synced-lyrics/index.ts
@@ -27,6 +27,7 @@ export default createPlugin<
     defaultTextString: '♪',
     lineEffect: 'fancy',
     romanization: true,
+    big_romanization: true,
   },
 
   menu,

--- a/src/plugins/synced-lyrics/menu.ts
+++ b/src/plugins/synced-lyrics/menu.ts
@@ -154,13 +154,13 @@ export const menu = async (
       },
     },
     {
-      label: t('plugins.synced-lyrics.menu.big_romanization.label'),
-      toolTip: t('plugins.synced-lyrics.menu.big_romanization.tooltip'),
+      label: t('plugins.synced-lyrics.menu.big-romanization.label'),
+      toolTip: t('plugins.synced-lyrics.menu.big-romanization.tooltip'),
       type: 'checkbox',
-      checked: config.big_romanization,
+      checked: config.bigRomanization,
       click(item) {
         ctx.setConfig({
-          big_romanization: item.checked,
+          bigRomanization: item.checked,
         });
       },
     },

--- a/src/plugins/synced-lyrics/menu.ts
+++ b/src/plugins/synced-lyrics/menu.ts
@@ -154,6 +154,18 @@ export const menu = async (
       },
     },
     {
+      label: t('plugins.synced-lyrics.menu.big_romanization.label'),
+      toolTip: t('plugins.synced-lyrics.menu.big_romanization.tooltip'),
+      type: 'checkbox',
+      checked: config.big_romanization,
+      click(item) {
+        ctx.setConfig({
+          big_romanization: item.checked,
+        });
+      },
+    },
+
+    {
       label: t('plugins.synced-lyrics.menu.convert-chinese-character.label'),
       toolTip: t(
         'plugins.synced-lyrics.menu.convert-chinese-character.tooltip',

--- a/src/plugins/synced-lyrics/renderer/components/PlainLyrics.tsx
+++ b/src/plugins/synced-lyrics/renderer/components/PlainLyrics.tsx
@@ -32,6 +32,12 @@ export const PlainLyrics = (props: PlainLyricsProps) => {
     });
   });
 
+  const showRomanization = createMemo(
+    () =>
+      !!config()?.romanization &&
+      simplifyUnicode(text()) !== simplifyUnicode(romanization()),
+  );
+
   return (
     <div
       class={`${
@@ -40,19 +46,17 @@ export const PlainLyrics = (props: PlainLyricsProps) => {
       style={{
         'display': 'flex',
         'flex-direction': 'column',
+        '--lyrics-original-scale':
+          showRomanization() && config()?.big_romanization ? '0.7' : '1',
       }}
     >
       <yt-formatted-string
+        class="original"
         text={{
           runs: [{ text: text() }],
         }}
       />
-      <Show
-        when={
-          config()?.romanization &&
-          simplifyUnicode(text()) !== simplifyUnicode(romanization())
-        }
-      >
+      <Show when={showRomanization()}>
         <yt-formatted-string
           class="romaji"
           text={{

--- a/src/plugins/synced-lyrics/renderer/components/PlainLyrics.tsx
+++ b/src/plugins/synced-lyrics/renderer/components/PlainLyrics.tsx
@@ -5,7 +5,7 @@ import {
   canonicalize,
   convertChineseCharacter,
   romanize,
-  simplifyUnicode,
+  createShowRomanization,
 } from '../utils';
 
 interface PlainLyricsProps {
@@ -32,11 +32,7 @@ export const PlainLyrics = (props: PlainLyricsProps) => {
     });
   });
 
-  const showRomanization = createMemo(
-    () =>
-      !!config()?.romanization &&
-      simplifyUnicode(text()) !== simplifyUnicode(romanization()),
-  );
+  const showRomanization = createShowRomanization(text, romanization);
 
   return (
     <div
@@ -47,7 +43,7 @@ export const PlainLyrics = (props: PlainLyricsProps) => {
         'display': 'flex',
         'flex-direction': 'column',
         '--lyrics-original-scale':
-          showRomanization() && config()?.big_romanization ? '0.7' : '1',
+          showRomanization() && config()?.bigRomanization ? '0.7' : '1',
       }}
     >
       <yt-formatted-string

--- a/src/plugins/synced-lyrics/renderer/components/SyncedLine.tsx
+++ b/src/plugins/synced-lyrics/renderer/components/SyncedLine.tsx
@@ -103,6 +103,12 @@ export const SyncedLine = (props: SyncedLineProps) => {
     });
   });
 
+  const showRomanization = createMemo(
+    () =>
+      !!config()?.romanization &&
+      simplifyUnicode(text()) !== simplifyUnicode(romanization()),
+  );
+
   return (
     <Show fallback={<EmptyLine {...props} />} when={text()}>
       <div
@@ -132,9 +138,14 @@ export const SyncedLine = (props: SyncedLineProps) => {
                 'important',
               );
             }}
-            style={{ 'display': 'flex', 'flex-direction': 'column' }}
+            style={{
+              'display': 'flex',
+              'flex-direction': 'column',
+              '--lyrics-original-scale':
+                showRomanization() && config()?.big_romanization ? '0.7' : '1',
+            }}
           >
-            <span>
+            <span class="original">
               <For each={text().split(' ')}>
                 {(word, index) => {
                   return (
@@ -155,12 +166,7 @@ export const SyncedLine = (props: SyncedLineProps) => {
               </For>
             </span>
 
-            <Show
-              when={
-                config()?.romanization &&
-                simplifyUnicode(text()) !== simplifyUnicode(romanization())
-              }
-            >
+            <Show when={showRomanization()}>
               <span class="romaji">
                 <For each={romanization().split(' ')}>
                   {(word, index) => {

--- a/src/plugins/synced-lyrics/renderer/components/SyncedLine.tsx
+++ b/src/plugins/synced-lyrics/renderer/components/SyncedLine.tsx
@@ -9,7 +9,7 @@ import {
   canonicalize,
   convertChineseCharacter,
   romanize,
-  simplifyUnicode,
+  createShowRomanization,
 } from '../utils';
 
 interface SyncedLineProps {
@@ -103,11 +103,7 @@ export const SyncedLine = (props: SyncedLineProps) => {
     });
   });
 
-  const showRomanization = createMemo(
-    () =>
-      !!config()?.romanization &&
-      simplifyUnicode(text()) !== simplifyUnicode(romanization()),
-  );
+  const showRomanization = createShowRomanization(text, romanization);
 
   return (
     <Show fallback={<EmptyLine {...props} />} when={text()}>
@@ -142,7 +138,7 @@ export const SyncedLine = (props: SyncedLineProps) => {
               'display': 'flex',
               'flex-direction': 'column',
               '--lyrics-original-scale':
-                showRomanization() && config()?.big_romanization ? '0.7' : '1',
+                showRomanization() && config()?.bigRomanization ? '0.7' : '1',
             }}
           >
             <span class="original">

--- a/src/plugins/synced-lyrics/renderer/renderer.tsx
+++ b/src/plugins/synced-lyrics/renderer/renderer.tsx
@@ -124,6 +124,10 @@ runWithOwner(reactiveOwner, () => {
         root.style.setProperty('--lyrics-active-offset', '0');
         break;
     }
+    root.style.setProperty(
+      '--lyrics-romaji-scale',
+      config()?.big_romanization ? '1' : '0.7',
+    );
   });
 });
 

--- a/src/plugins/synced-lyrics/renderer/renderer.tsx
+++ b/src/plugins/synced-lyrics/renderer/renderer.tsx
@@ -126,7 +126,7 @@ runWithOwner(reactiveOwner, () => {
     }
     root.style.setProperty(
       '--lyrics-romaji-scale',
-      config()?.big_romanization ? '1' : '0.7',
+      config()?.bigRomanization ? '1' : '0.7',
     );
   });
 });

--- a/src/plugins/synced-lyrics/renderer/utils.tsx
+++ b/src/plugins/synced-lyrics/renderer/utils.tsx
@@ -12,7 +12,8 @@ import { detect } from 'tinyld';
 
 import { waitForElement } from '@/utils/wait-for-element';
 
-import { LyricsRenderer, setIsVisible } from './renderer';
+import { config, LyricsRenderer, setIsVisible } from './renderer';
+import { createMemo } from 'solid-js';
 
 export const selectors = {
   head: '#tabsContent > .tab-header:nth-of-type(2)',
@@ -262,3 +263,13 @@ export const romanize = async (line: string) => {
 
   return line;
 };
+
+export const createShowRomanization = (
+  text: () => string,
+  romanization: () => string
+) =>
+  createMemo(
+    () =>
+      !!config()?.romanization &&
+      simplifyUnicode(text()) !== simplifyUnicode(romanization())
+  );

--- a/src/plugins/synced-lyrics/style.css
+++ b/src/plugins/synced-lyrics/style.css
@@ -31,6 +31,8 @@
     Satoshi, Avenir, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,
     Oxygen, Ubuntu, Cantarell, Open Sans, Helvetica Neue, sans-serif;
   --lyrics-font-size: clamp(1.4rem, 1.1vmax, 3rem);
+  --lyrics-original-scale: 1;
+  --lyrics-romaji-scale: 0.7;
   --lyrics-line-height: var(--ytmusic-body-line-height);
   --lyrics-width: 100%;
 
@@ -82,7 +84,9 @@
 
   & .text-lyrics > .romaji {
     color: var(--ytmusic-text-secondary) !important;
-    font-size: calc(var(--lyrics-font-size) * 0.7) !important;
+    font-size: calc(
+      var(--lyrics-font-size) * var(--lyrics-romaji-scale)
+    ) !important;
     font-style: italic !important;
   }
 }
@@ -126,9 +130,17 @@
     padding-block: 0.2em;
   }
 
+  & > .original {
+    font-size: calc(
+      var(--lyrics-font-size) * var(--lyrics-original-scale)
+    ) !important;
+  }
+
   & > .romaji {
     color: var(--ytmusic-text-secondary) !important;
-    font-size: calc(var(--lyrics-font-size) * 0.7) !important;
+    font-size: calc(
+      var(--lyrics-font-size) * var(--lyrics-romaji-scale)
+    ) !important;
     font-style: italic !important;
   }
 }

--- a/src/plugins/synced-lyrics/types.ts
+++ b/src/plugins/synced-lyrics/types.ts
@@ -10,7 +10,7 @@ export type SyncedLyricsPluginConfig = {
   showLyricsEvenIfInexact: boolean;
   lineEffect: LineEffect;
   romanization: boolean;
-  big_romanization: boolean;
+  bigRomanization: boolean;
   convertChineseCharacter?:
     | 'simplifiedToTraditional'
     | 'traditionalToSimplified'

--- a/src/plugins/synced-lyrics/types.ts
+++ b/src/plugins/synced-lyrics/types.ts
@@ -10,6 +10,7 @@ export type SyncedLyricsPluginConfig = {
   showLyricsEvenIfInexact: boolean;
   lineEffect: LineEffect;
   romanization: boolean;
+  big_romanization: boolean;
   convertChineseCharacter?:
     | 'simplifiedToTraditional'
     | 'traditionalToSimplified'


### PR DESCRIPTION
<img width="1216" height="708" alt="image" src="https://github.com/user-attachments/assets/7e25622e-161d-4d28-9147-f970ba2f4a73" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Big romanization” option for synced lyrics to increase the size of romanized text while keeping non-latin scripts smaller.
  * Included localized label and tooltip text for the new option (English and Spanish).
  * Updated romanization scaling to apply consistently across synced and plain lyrics using configurable font scale adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->