### PR TITLE
shortcuts: add seek, speed step, and focus-on-double-press keybinds; notify on like/dislike

### DIFF
--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -688,6 +688,7 @@
             "tray-controls": "Open/Close on tray click"
           }
         },
+        "notify-on-like-change": "Show notification on like/dislike",
         "priority": "Notification Priority",
         "toast-style": "Toast style",
         "unpause-notification": "Show notification on unpause"
@@ -723,7 +724,20 @@
     },
     "playback-speed": {
       "description": "Listen fast, listen slow! Adds a slider that controls song speed",
+      "menu": {
+        "global-shortcuts": "Global Hotkeys"
+      },
       "name": "Playback Speed",
+      "prompt": {
+        "global-shortcuts": {
+          "keybind-options": {
+            "decrease": "Decrease Speed",
+            "increase": "Increase Speed"
+          },
+          "label": "Choose Global Speed Keybinds:",
+          "title": "Global Speed Keybinds"
+        }
+      },
       "templates": {
         "button": "Speed"
       }
@@ -807,8 +821,11 @@
     "shortcuts": {
       "description": "Allows setting global hotkeys for playback (play/pause/next/previous) and turning off media OSD by overriding media keys, turning on Ctrl/CMD + F to search, turning on Linux MPRIS support for media keys, and custom hotkeys for advanced users",
       "menu": {
+        "focus-window-on-double-play-pause": "Focus Window on Double Play/Pause Press",
         "override-media-keys": "Override Media Keys",
-        "set-keybinds": "Set Global Song Controls"
+        "set-keybinds": "Set Global Song Controls",
+        "set-seek-keybinds": "Set Seek Keybinds",
+        "set-seek-seconds": "Set Seek Duration"
       },
       "name": "Shortcuts (& MPRIS)",
       "prompt": {
@@ -820,6 +837,18 @@
           },
           "label": "Choose Global Keybinds for Songs Control:",
           "title": "Global Keybinds"
+        },
+        "seek-keybind": {
+          "keybind-options": {
+            "backward": "Seek Backward",
+            "forward": "Seek Forward"
+          },
+          "label": "Choose Global Keybinds for Seeking:",
+          "title": "Seek Keybinds"
+        },
+        "seek-seconds": {
+          "label": "Choose Seek Duration (seconds)",
+          "title": "Seek Duration"
         }
       }
     },

--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -678,6 +678,11 @@
     },
     "notifications": {
       "description": "Display a notification when a song starts playing (interactive notifications are available on Windows)",
+      "like-status": {
+        "disliked": "Disliked",
+        "indifferent": "Removed rating",
+        "liked": "Liked"
+      },
       "menu": {
         "interactive": "Interactive Notifications",
         "interactive-settings": {

--- a/src/plugins/notifications/index.ts
+++ b/src/plugins/notifications/index.ts
@@ -22,6 +22,7 @@ export interface NotificationsPluginConfig {
   refreshOnPlayPause: boolean;
   trayControls: boolean;
   hideButtonText: boolean;
+  notifyOnLikeChange: boolean;
 }
 
 export const defaultConfig: NotificationsPluginConfig = {
@@ -33,6 +34,7 @@ export const defaultConfig: NotificationsPluginConfig = {
   refreshOnPlayPause: false,
   trayControls: true,
   hideButtonText: false,
+  notifyOnLikeChange: false,
 };
 
 export default createPlugin({

--- a/src/plugins/notifications/main.ts
+++ b/src/plugins/notifications/main.ts
@@ -1,6 +1,7 @@
 import { Notification } from 'electron';
 import is from 'electron-is';
 
+import { t } from '@/i18n';
 import {
   registerCallback,
   type SongInfo,
@@ -32,9 +33,9 @@ const notify = (info: SongInfo) => {
 };
 
 const likeStatusLabel: Record<LikeType, string> = {
-  [LikeType.Like]: 'Liked',
-  [LikeType.Dislike]: 'Disliked',
-  [LikeType.Indifferent]: 'Removed rating',
+  [LikeType.Like]: t('plugins.notifications.like-status.liked'),
+  [LikeType.Dislike]: t('plugins.notifications.like-status.disliked'),
+  [LikeType.Indifferent]: t('plugins.notifications.like-status.indifferent'),
 };
 
 const setupLikeChangeNotification = (

--- a/src/plugins/notifications/main.ts
+++ b/src/plugins/notifications/main.ts
@@ -6,6 +6,7 @@ import {
   type SongInfo,
   SongInfoEvent,
 } from '@/providers/song-info';
+import { LikeType } from '@/types/datahost-get-state';
 
 import interactive from './interactive';
 import { notificationImage } from './utils';
@@ -14,6 +15,7 @@ import type { NotificationsPluginConfig } from './index';
 import type { BackendContext } from '@/types/contexts';
 
 let config: NotificationsPluginConfig;
+let latestSongInfo: SongInfo | undefined;
 
 const notify = (info: SongInfo) => {
   // Send the notification
@@ -27,6 +29,41 @@ const notify = (info: SongInfo) => {
   currentNotification.show();
 
   return currentNotification;
+};
+
+const likeStatusLabel: Record<LikeType, string> = {
+  [LikeType.Like]: 'Liked',
+  [LikeType.Dislike]: 'Disliked',
+  [LikeType.Indifferent]: 'Removed rating',
+};
+
+const setupLikeChangeNotification = (
+  context: BackendContext<NotificationsPluginConfig>,
+) => {
+  let isInitialEvent = true;
+
+  context.ipc.on('peard:player-api-loaded', () => {
+    context.ipc.send('peard:setup-like-changed-listener');
+  });
+  context.ipc.on('peard:like-changed', (likeType: LikeType) => {
+    if (isInitialEvent) {
+      isInitialEvent = false;
+      return;
+    }
+
+    if (!latestSongInfo) {
+      return;
+    }
+
+    const notification = new Notification({
+      title: likeStatusLabel[likeType],
+      body: latestSongInfo.title || 'Playing',
+      icon: notificationImage(latestSongInfo, config),
+      silent: true,
+      urgency: config.urgency,
+    });
+    notification.show();
+  });
 };
 
 const setup = () => {
@@ -54,6 +91,14 @@ export const onMainLoad = async (
   context: BackendContext<NotificationsPluginConfig>,
 ) => {
   config = await context.getConfig();
+
+  registerCallback((songInfo: SongInfo) => {
+    latestSongInfo = songInfo;
+  });
+
+  if (config.notifyOnLikeChange) {
+    setupLikeChangeNotification(context);
+  }
 
   // Register the callback for new song information
   if (is.windows() && config.interactive)

--- a/src/plugins/notifications/menu.ts
+++ b/src/plugins/notifications/menu.ts
@@ -104,5 +104,11 @@ export const onMenu = async ({
       checked: config.unpauseNotification,
       click: (item) => setConfig({ unpauseNotification: item.checked }),
     },
+    {
+      label: t('plugins.notifications.menu.notify-on-like-change'),
+      type: 'checkbox',
+      checked: config.notifyOnLikeChange,
+      click: (item) => setConfig({ notifyOnLikeChange: item.checked }),
+    },
   ];
 };

--- a/src/plugins/playback-speed/index.ts
+++ b/src/plugins/playback-speed/index.ts
@@ -97,9 +97,14 @@ export default createPlugin({
 
     const register = (shortcut: string, delta: number) => {
       try {
-        globalShortcut.register(shortcut, () =>
+        const registered = globalShortcut.register(shortcut, () =>
           ipc.send('changePlaybackSpeed', delta),
         );
+        if (!registered) {
+          console.warn(
+            `Global shortcut "${shortcut}" is already in use by another app or the system, could not register it`,
+          );
+        }
       } catch (error) {
         console.warn(`Failed to register global shortcut "${shortcut}"`, error);
       }

--- a/src/plugins/playback-speed/index.ts
+++ b/src/plugins/playback-speed/index.ts
@@ -1,7 +1,20 @@
+import prompt, { type KeybindOptions } from 'custom-electron-prompt';
+import { globalShortcut } from 'electron';
+
 import { t } from '@/i18n';
+import promptOptions from '@/providers/prompt-options';
 import { createPlugin } from '@/utils';
 
 import { onPlayerApiReady, onUnload } from './renderer';
+
+export type PlaybackSpeedPluginConfig = {
+  enabled: boolean;
+  step: number;
+  globalShortcuts: {
+    speedUp: string;
+    speedDown: string;
+  };
+};
 
 export default createPlugin({
   name: () => t('plugins.playback-speed.name'),
@@ -9,9 +22,95 @@ export default createPlugin({
   restartNeeded: false,
   config: {
     enabled: false,
-  },
+    step: 0.1,
+    globalShortcuts: {
+      speedUp: '',
+      speedDown: '',
+    },
+  } as PlaybackSpeedPluginConfig,
   renderer: {
     stop: onUnload,
     onPlayerApiReady,
+  },
+
+  menu: async ({ getConfig, setConfig, window }) => {
+    const config = await getConfig();
+
+    const kb = (
+      label_: string,
+      value_: string,
+      default_: string,
+    ): KeybindOptions => ({
+      value: value_,
+      label: label_,
+      default: default_ || undefined,
+    });
+
+    async function promptGlobalShortcuts() {
+      const output = await prompt(
+        {
+          title: t('plugins.playback-speed.prompt.global-shortcuts.title'),
+          label: t('plugins.playback-speed.prompt.global-shortcuts.label'),
+          type: 'keybind',
+          keybindOptions: [
+            kb(
+              t(
+                'plugins.playback-speed.prompt.global-shortcuts.keybind-options.increase',
+              ),
+              'speedUp',
+              config.globalShortcuts?.speedUp,
+            ),
+            kb(
+              t(
+                'plugins.playback-speed.prompt.global-shortcuts.keybind-options.decrease',
+              ),
+              'speedDown',
+              config.globalShortcuts?.speedDown,
+            ),
+          ],
+          ...promptOptions(),
+        },
+        window,
+      );
+
+      if (output) {
+        const newGlobalShortcuts = { speedUp: '', speedDown: '' };
+        for (const { value, accelerator } of output) {
+          newGlobalShortcuts[value as keyof typeof newGlobalShortcuts] =
+            accelerator;
+        }
+
+        setConfig({ globalShortcuts: newGlobalShortcuts });
+      }
+    }
+
+    return [
+      {
+        label: t('plugins.playback-speed.menu.global-shortcuts'),
+        click: () => promptGlobalShortcuts(),
+      },
+    ];
+  },
+
+  async backend({ getConfig, ipc }) {
+    const config = await getConfig();
+
+    const register = (shortcut: string, delta: number) => {
+      try {
+        globalShortcut.register(shortcut, () =>
+          ipc.send('changePlaybackSpeed', delta),
+        );
+      } catch (error) {
+        console.warn(`Failed to register global shortcut "${shortcut}"`, error);
+      }
+    };
+
+    if (config.globalShortcuts?.speedUp) {
+      register(config.globalShortcuts.speedUp, config.step);
+    }
+
+    if (config.globalShortcuts?.speedDown) {
+      register(config.globalShortcuts.speedDown, -config.step);
+    }
   },
 });

--- a/src/plugins/playback-speed/renderer.tsx
+++ b/src/plugins/playback-speed/renderer.tsx
@@ -10,6 +10,10 @@ import { getSongMenu } from '@/providers/dom-elements';
 
 import { PlaybackSpeedSlider } from './components/slider';
 
+import type { PlaybackSpeedPluginConfig } from './index';
+import type { RendererContext } from '@/types/contexts';
+import type { MusicPlayer } from '@/types/music-player';
+
 const MIN_PLAYBACK_SPEED = 0.07;
 const MAX_PLAYBACK_SPEED = 16;
 
@@ -27,17 +31,29 @@ const roundToTwo = (n: number) => Math.round(n * 1e2) / 1e2;
 const [speed, setSpeed] = createSignal(1);
 const sliderContainer = document.createElement('div');
 
-export const onPlayerApiReady = () => {
+const updatePlayBackSpeed = () => {
+  const videoElement = document.querySelector<HTMLVideoElement>('video');
+  if (videoElement) {
+    videoElement.playbackRate = speed();
+  }
+
+  setSpeed(speed());
+};
+
+export const onPlayerApiReady = (
+  _playerApi: MusicPlayer,
+  context: RendererContext<PlaybackSpeedPluginConfig>,
+) => {
+  context.ipc.on('changePlaybackSpeed', (delta: number) => {
+    const targetSpeed = Math.min(
+      Math.max(MIN_PLAYBACK_SPEED, roundToTwo(speed() + delta)),
+      MAX_PLAYBACK_SPEED,
+    );
+    setSpeed(targetSpeed);
+    updatePlayBackSpeed();
+  });
+
   const observePopupContainer = () => {
-    const updatePlayBackSpeed = () => {
-      const videoElement = document.querySelector<HTMLVideoElement>('video');
-      if (videoElement) {
-        videoElement.playbackRate = speed();
-      }
-
-      setSpeed(speed());
-    };
-
     render(
       () => (
         <PlaybackSpeedSlider

--- a/src/plugins/playback-speed/renderer.tsx
+++ b/src/plugins/playback-speed/renderer.tsx
@@ -131,11 +131,14 @@ export const onPlayerApiReady = (
   observeVideo();
 };
 
-export const onUnload = () => {
+export const onUnload = (
+  context: RendererContext<PlaybackSpeedPluginConfig>,
+) => {
   const video = document.querySelector<HTMLVideoElement>('video');
   if (video) {
     video.removeEventListener('ratechange', forcePlaybackRate);
     video.removeEventListener('peard:src-changed', forcePlaybackRate);
   }
+  context.ipc.removeAllListeners('changePlaybackSpeed');
   getSongMenu()?.removeChild(sliderContainer);
 };

--- a/src/plugins/precise-volume/index.ts
+++ b/src/plugins/precise-volume/index.ts
@@ -173,9 +173,14 @@ export default createPlugin({
 
     const register = (shortcut: string, toIncrease: boolean) => {
       try {
-        globalShortcut.register(shortcut, () =>
+        const registered = globalShortcut.register(shortcut, () =>
           ipc.send('changeVolume', toIncrease),
         );
+        if (!registered) {
+          console.warn(
+            `Global shortcut "${shortcut}" is already in use by another app or the system, could not register it`,
+          );
+        }
       } catch (error) {
         console.warn(`Failed to register global shortcut "${shortcut}"`, error);
       }

--- a/src/plugins/precise-volume/index.ts
+++ b/src/plugins/precise-volume/index.ts
@@ -171,16 +171,22 @@ export default createPlugin({
   async backend({ getConfig, ipc }) {
     const config = await getConfig();
 
+    const register = (shortcut: string, toIncrease: boolean) => {
+      try {
+        globalShortcut.register(shortcut, () =>
+          ipc.send('changeVolume', toIncrease),
+        );
+      } catch (error) {
+        console.warn(`Failed to register global shortcut "${shortcut}"`, error);
+      }
+    };
+
     if (config.globalShortcuts?.volumeUp) {
-      globalShortcut.register(config.globalShortcuts.volumeUp, () =>
-        ipc.send('changeVolume', true),
-      );
+      register(config.globalShortcuts.volumeUp, true);
     }
 
     if (config.globalShortcuts?.volumeDown) {
-      globalShortcut.register(config.globalShortcuts.volumeDown, () =>
-        ipc.send('changeVolume', false),
-      );
+      register(config.globalShortcuts.volumeDown, false);
     }
   },
 

--- a/src/plugins/shortcuts/index.ts
+++ b/src/plugins/shortcuts/index.ts
@@ -9,11 +9,18 @@ export type ShortcutMappingType = {
   playPause: string;
   next: string;
 };
+export type SeekMappingType = {
+  forward: string;
+  backward: string;
+};
 export type ShortcutsPluginConfig = {
   enabled: boolean;
   overrideMediaKeys: boolean;
   global: ShortcutMappingType;
   local: ShortcutMappingType;
+  seekSeconds: number;
+  seekGlobalShortcuts: SeekMappingType;
+  focusWindowOnDoublePlayPause: boolean;
 };
 
 export default createPlugin({
@@ -33,6 +40,12 @@ export default createPlugin({
       playPause: '',
       next: '',
     },
+    seekSeconds: 10,
+    seekGlobalShortcuts: {
+      forward: '',
+      backward: '',
+    },
+    focusWindowOnDoublePlayPause: false,
   } as ShortcutsPluginConfig,
   menu: onMenu,
 

--- a/src/plugins/shortcuts/main.ts
+++ b/src/plugins/shortcuts/main.ts
@@ -9,14 +9,25 @@ import { registerMPRIS } from './mpris';
 import type { ShortcutMappingType, ShortcutsPluginConfig } from './index';
 import type { BackendContext } from '@/types/contexts';
 
+const DOUBLE_PRESS_THRESHOLD_MS = 400;
+
 function _registerGlobalShortcut(
   webContents: Electron.WebContents,
   shortcut: string,
   action: (webContents: Electron.WebContents) => void,
 ) {
-  globalShortcut.register(shortcut, () => {
-    action(webContents);
-  });
+  try {
+    const registered = globalShortcut.register(shortcut, () => {
+      action(webContents);
+    });
+    if (!registered) {
+      console.warn(
+        `Global shortcut "${shortcut}" is already in use by another app or the system, could not register it`,
+      );
+    }
+  } catch (error) {
+    console.warn(`Failed to register global shortcut "${shortcut}"`, error);
+  }
 }
 
 function _registerLocalShortcut(
@@ -24,9 +35,36 @@ function _registerLocalShortcut(
   shortcut: string,
   action: (webContents: Electron.WebContents) => void,
 ) {
-  registerElectronLocalShortcut(win, shortcut, () => {
-    action(win.webContents);
-  });
+  try {
+    registerElectronLocalShortcut(win, shortcut, () => {
+      action(win.webContents);
+    });
+  } catch (error) {
+    console.warn(`Failed to register local shortcut "${shortcut}"`, error);
+  }
+}
+
+function _createPlayPauseHandler(win: BrowserWindow, playPause: () => void) {
+  let lastPressTime = 0;
+
+  return () => {
+    const now = Date.now();
+    if (now - lastPressTime < DOUBLE_PRESS_THRESHOLD_MS) {
+      lastPressTime = 0;
+
+      if (win.isMinimized()) {
+        win.restore();
+      }
+      if (!win.isVisible()) {
+        win.show();
+      }
+      win.focus();
+      return;
+    }
+
+    lastPressTime = now;
+    playPause();
+  };
 }
 
 export const onMainLoad = async ({
@@ -36,10 +74,18 @@ export const onMainLoad = async ({
   const config = await getConfig();
 
   const songControls = getSongControls(window);
-  const { playPause, next, previous } = songControls;
+  const { playPause, next, previous, goForward, goBack } = songControls;
+
+  const playPauseAction = config.focusWindowOnDoublePlayPause
+    ? _createPlayPauseHandler(window, playPause)
+    : playPause;
 
   if (config.overrideMediaKeys) {
-    _registerGlobalShortcut(window.webContents, 'MediaPlayPause', playPause);
+    _registerGlobalShortcut(
+      window.webContents,
+      'MediaPlayPause',
+      playPauseAction,
+    );
     _registerGlobalShortcut(window.webContents, 'MediaNextTrack', next);
     _registerGlobalShortcut(window.webContents, 'MediaPreviousTrack', previous);
   }
@@ -73,7 +119,8 @@ export const onMainLoad = async ({
         ':',
         action,
       );
-      const actionCallback: () => void = songControls[action];
+      const actionCallback: () => void =
+        action === 'playPause' ? playPauseAction : songControls[action];
       if (typeof actionCallback !== 'function') {
         console.warn('Invalid action', action);
         continue;
@@ -90,5 +137,22 @@ export const onMainLoad = async ({
         _registerLocalShortcut(window, local[action], actionCallback);
       }
     }
+  }
+
+  const { seekSeconds, seekGlobalShortcuts } = config;
+
+  if (seekGlobalShortcuts.forward) {
+    _registerGlobalShortcut(
+      window.webContents,
+      seekGlobalShortcuts.forward,
+      () => goForward(seekSeconds),
+    );
+  }
+  if (seekGlobalShortcuts.backward) {
+    _registerGlobalShortcut(
+      window.webContents,
+      seekGlobalShortcuts.backward,
+      () => goBack(seekSeconds),
+    );
   }
 };

--- a/src/plugins/shortcuts/menu.ts
+++ b/src/plugins/shortcuts/menu.ts
@@ -70,6 +70,62 @@ export const onMenu = async ({
     // Else -> pressed cancel
   }
 
+  async function promptSeekKeybind(
+    config: ShortcutsPluginConfig,
+    win: BrowserWindow,
+  ) {
+    const output = await prompt(
+      {
+        title: t('plugins.shortcuts.prompt.seek-keybind.title'),
+        label: t('plugins.shortcuts.prompt.seek-keybind.label'),
+        type: 'keybind',
+        keybindOptions: [
+          kb(
+            t('plugins.shortcuts.prompt.seek-keybind.keybind-options.forward'),
+            'forward',
+            config.seekGlobalShortcuts?.forward,
+          ),
+          kb(
+            t('plugins.shortcuts.prompt.seek-keybind.keybind-options.backward'),
+            'backward',
+            config.seekGlobalShortcuts?.backward,
+          ),
+        ],
+        ...promptOptions(),
+      },
+      win,
+    );
+
+    if (output) {
+      const newSeekGlobalShortcuts = { forward: '', backward: '' };
+      for (const { value, accelerator } of output) {
+        newSeekGlobalShortcuts[value as keyof typeof newSeekGlobalShortcuts] =
+          accelerator;
+      }
+
+      setConfig({ seekGlobalShortcuts: newSeekGlobalShortcuts });
+    }
+  }
+
+  async function promptSeekSeconds(config: ShortcutsPluginConfig) {
+    const output = await prompt(
+      {
+        title: t('plugins.shortcuts.prompt.seek-seconds.title'),
+        label: t('plugins.shortcuts.prompt.seek-seconds.label'),
+        value: config.seekSeconds || 10,
+        type: 'counter',
+        counterOptions: { minimum: 1, maximum: 120, multiFire: true },
+        width: 380,
+        ...promptOptions(),
+      },
+      window,
+    );
+
+    if (output || output === 0) {
+      setConfig({ seekSeconds: Number(output) });
+    }
+  }
+
   return [
     {
       label: t('plugins.shortcuts.menu.set-keybinds'),
@@ -80,6 +136,21 @@ export const onMenu = async ({
       type: 'checkbox',
       checked: config.overrideMediaKeys,
       click: (item) => setConfig({ overrideMediaKeys: item.checked }),
+    },
+    {
+      label: t('plugins.shortcuts.menu.focus-window-on-double-play-pause'),
+      type: 'checkbox',
+      checked: config.focusWindowOnDoublePlayPause,
+      click: (item) =>
+        setConfig({ focusWindowOnDoublePlayPause: item.checked }),
+    },
+    {
+      label: t('plugins.shortcuts.menu.set-seek-keybinds'),
+      click: () => promptSeekKeybind(config, window),
+    },
+    {
+      label: t('plugins.shortcuts.menu.set-seek-seconds'),
+      click: () => promptSeekSeconds(config),
     },
   ];
 };


### PR DESCRIPTION
Picks up most of the keybind megathread (#4561):

- **playback-speed**: global shortcuts to step speed up/down by a configurable amount - Resolves #148.
- **shortcuts**: global shortcuts to seek forward/backward by a configurable duration - resolves #1453.
- **shortcuts**: pressing play/pause twice quickly brings the window to front instead of toggling playback again, since there was no way to get back to the window via keyboard before - resolves #1219.
- **notifications**: fires a native OS notification when you like/dislike a song, since there was previously zero feedback for that action - resolves the feedback half of #783 — that issue also asked for pressing like a second time to not silently un-like the song, which this PR doesn't change.
- also fixed a real bug found along the way: precise-volume, playback-speed, and shortcuts would all silently crash their entire plugin on startup if a saved keybind accelerator was malformed (no catch around globalShortcut.register) — precise-volume's volume-up/down shortcuts themselves are pre-existing, unrelated to this PR, we just hardened the registration call.

Two other items from the megathread are already covered, not touched here:
- #922 (like/dislike keybinds) — added in #4578, which wires up like/dislike in the shortcuts plugin's keybind config, reusing the same functions MPRIS and the API server already call.
- #1455 (volume up/down shortcuts) — already existed via the precise-volume plugin's own global shortcuts, no code needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an option to show notifications when like/dislike changes.
  * Added configurable global shortcuts to increase/decrease playback speed.
  * Added seek shortcuts (forward/backward) plus configurable seek duration.
  * Added an option to focus/show the app window after double-pressing play/pause.

* **Bug Fixes**
  * Improved handling and reporting when global shortcuts are unavailable, already in use, or fail to register.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->