### PR TITLE
nix: Add home manager module

### DIFF
--- a/.github/workflows/nix-check.yml
+++ b/.github/workflows/nix-check.yml
@@ -1,0 +1,42 @@
+name: Nix Check
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - 'nix/**'
+      - 'flake.nix'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      actions: write # needed for purging the cache
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: Nix install
+        uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c
+
+      - name: Nix store cache
+        uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 1G
+          purge: true
+          purge-prefixes: nix-${{ runner.os }}-
+          purge-created: 0
+          purge-last-accessed: 0
+          purge-primary-key: never
+
+      - name: Nix check
+        run: nix flake check --print-build-logs

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ node_modules
 .vite-inspect
 
 .DS_Store
+
+# Nix
+result

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@
 - [Translation](#translation)
 - [Download](#download)
   - [Arch Linux](#arch-linux)
+  - [NixOS](#nixos)
   - [Solus](#solus)
   - [MacOS](#macos)
   - [Windows](#windows)
@@ -84,6 +85,23 @@ latest version.
 
 Install the [`pear-desktop`](https://aur.archlinux.org/packages/pear-desktop) package from the AUR. For AUR installation instructions, take a look at
 this [wiki page](https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_packages).
+
+### NixOS
+
+You can add
+[`pear-desktop`](https://search.nixos.org/packages?channel=unstable&type=packages&query=pear-desktop)
+from nixpkgs to your `environment.systemPackages` for a system-wide
+installation:
+
+```nix
+{ pkgs, ...} :
+{
+  environment.systemPackages = [ pkgs.pear-desktop ];
+}
+```
+
+Or use our [`Home Manager Module`](./nix/README.md) to install and configure it
+declaratively per user.
 
 ### [Solus](https://getsol.us/)
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1783522502,
+        "narHash": "sha256-iffAls3iaNTyJC2faYcUXSI+Gp02cDjYl+MygxKl2GI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0bb7ec54c8483066ec9d7720e780a5caa71f8612",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,56 @@
+{
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      ...
+    }:
+    let
+      inherit (nixpkgs) lib;
+      forAllSystems = lib.genAttrs [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      pkgsFor = forAllSystems (system: nixpkgs.legacyPackages.${system});
+    in
+    {
+      homeManagerModules.default = import ./nix/homeManagerModule { pearLib = self.lib; };
+
+      lib = import ./nix/lib { inherit lib; };
+
+      legacyPackages = forAllSystems (
+        system:
+        let
+          pkgs = pkgsFor.${system};
+        in
+        rec {
+          eval = pkgs.callPackage ./nix/legacyPackages/eval.nix { module = self.homeManagerModules.default; };
+          nixosOptionsDoc = pkgs.callPackage ./nix/legacyPackages/nixosOptionsDoc.nix { inherit eval; };
+        }
+      );
+
+      checks = forAllSystems (
+        system:
+        let
+          pkgs = pkgsFor.${system};
+          inherit (self.legacyPackages.${system}) nixosOptionsDoc eval;
+          config = self.lib.mkPearDesktopConfig {
+            inherit (eval) options config;
+          };
+        in
+        {
+          nixosOptionsDocJSON = nixosOptionsDoc.optionsJSON.overrideAttrs {
+            allowSubstitutes = false;
+            preferLocalBuild = true;
+          };
+          configJSON = pkgs.writeText "config.json" config;
+        }
+      );
+
+      formatter = forAllSystems (system: pkgsFor.${system}.nixfmt-tree);
+    };
+}

--- a/nix/README.md
+++ b/nix/README.md
@@ -1,0 +1,51 @@
+# Nix
+
+## Home Manager
+
+Add this repository as a flake input.
+
+```nix
+{
+  inputs = {
+    pear-desktop = {
+      url = "github:pear-devs/pear-desktop";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+}
+```
+
+Then import `homeManagerModules.default` and configure it in your home module:
+
+```nix
+{ inputs, ... }:
+{
+  imports = [
+    inputs.pear-desktop.homeManagerModules.default
+  ];
+
+  programs.pear-desktop = {
+    # This adds the package to your PATH
+    enable = true;
+
+    options = {
+      themes = [
+        # Custom CSS style stored in the nix store
+        ./style.css
+      ];
+      tray = true;
+      trayClickPlayPause = false;
+    };
+
+    plugins = {
+      do-not-track.enable = true;
+      exponential-volume.enable = true;
+    };
+  };
+}
+```
+
+> [!NOTE]
+> You need to use
+> [`extraSpecialArgs`](https://nix-community.github.io/home-manager/nix-flakes/standalone.html?highlight=extraspecialargs#standalone-setup)
+> to access your flake inputs inside the home module.

--- a/nix/homeManagerModule/default.nix
+++ b/nix/homeManagerModule/default.nix
@@ -1,0 +1,86 @@
+{
+  pearLib,
+}:
+{
+  options,
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mkIf
+    mkOption
+    mkEnableOption
+    mkPackageOption
+    mkRenamedOptionModule
+    ;
+  cfg = config.programs.pear-desktop;
+in
+{
+  options.programs.pear-desktop = {
+    enable = mkEnableOption "Pear Desktop";
+
+    package = mkPackageOption pkgs "pear-desktop" { };
+
+    url = mkOption {
+      default = "https://music.youtube.com";
+      description = ''
+        Starting page url.
+
+        This is only used if `options.resumeOnStart` is enabled.
+
+        This is set internally by the application.
+      '';
+      type = lib.types.str;
+      internal = true;
+    };
+
+    version = mkOption {
+      description = "Version used in migrations";
+      default = "3.12.0";
+      type = lib.types.str;
+      internal = true;
+    };
+  };
+
+  imports = [
+    ./options.nix
+    ./plugins
+    (mkRenamedOptionModule
+      [
+        "programs"
+        "youtube-music"
+      ]
+      [
+        "programs"
+        "pear-desktop"
+      ]
+    )
+  ];
+
+  config =
+    let
+      configPath = "YouTube Music/config.json";
+      hmConfigPath = "YouTube Music/hm_config.json";
+    in
+    mkIf cfg.enable {
+      home.packages = [ cfg.package ];
+
+      xdg.configFile.${hmConfigPath} = {
+        source = pkgs.writeText "pear-desktop-config.json" (
+          pearLib.mkPearDesktopConfig { inherit options config; }
+        );
+
+        onChange =
+          let
+            hmConfigFile = "${config.xdg.configHome}/${hmConfigPath}";
+            configFile = "${config.xdg.configHome}/${configPath}";
+          in
+          ''
+            run install -Dm664 $VERBOSE_ARG '${hmConfigFile}' '${configFile}'
+          '';
+      };
+    };
+}

--- a/nix/homeManagerModule/options.nix
+++ b/nix/homeManagerModule/options.nix
@@ -1,0 +1,175 @@
+{ lib, pkgs, ... }:
+let
+  inherit (pkgs.stdenv.hostPlatform) isDarwin isLinux;
+  inherit (lib) mkOption mkEnableOption types;
+in
+{
+  options.programs.pear-desktop.options = {
+    language = mkOption {
+      default = null;
+      description = "Language used by the application";
+      type = types.enum [
+        null
+        "ar"
+        "bg"
+        "ca"
+        "cs"
+        "de"
+        "el"
+        "en"
+        "es"
+        "et"
+        "fa"
+        "fi"
+        "fil"
+        "fr"
+        "he"
+        "hi"
+        "hr"
+        "hu"
+        "id"
+        "is"
+        "it"
+        "ja"
+        "ka"
+        "ko"
+        "lt"
+        "ms"
+        "nb"
+        "ne"
+        "nl"
+        "pl"
+        "pt-BR"
+        "pt"
+        "ro"
+        "ru"
+        "si"
+        "sl"
+        "sv"
+        "th"
+        "tr"
+        "uk"
+        "ur"
+        "vi"
+        "zh-CN"
+        "zh-TW"
+      ];
+    };
+    tray = mkEnableOption "tray support";
+    appVisible = mkEnableOption "" // {
+      default = true;
+      description = "";
+    };
+    autoUpdates = mkEnableOption "auto updates" // {
+      description = "This is not used on nix, set `programs.pear-desktop.package` instead";
+      internal = true;
+    };
+    alwaysOnTop = mkEnableOption "always on top";
+    hideMenu = mkEnableOption "" // {
+      description = "Whether to hide the menu on Windows/Linux (use Alt to toggle it)";
+      internal = isDarwin;
+    };
+    hideMenuWarned = mkOption {
+      description = "Used internally to determine if hide menu warning should be displayed";
+      default = true;
+      internal = true;
+    };
+    startAtLogin = mkOption {
+      description = ''
+        Whether to start the app at login on Windows/Mac
+
+        https://www.electronjs.org/docs/api/app#appsetloginitemsettingssettings-macos-windows
+      '';
+      internal = isLinux;
+      default = false;
+    };
+    disableHardwareAcceleration = mkEnableOption "" // {
+      description = "Whether to disable hardware acceleration";
+    };
+    removeUpgradeButton = mkEnableOption "" // {
+      description = "Whether to remove the upgrade button";
+    };
+    restartOnConfigChanges = mkEnableOption "" // {
+      description = "Whether to restart on config changes";
+    };
+    trayClickPlayPause = mkEnableOption "" // {
+      description = "Whether to play/pause when clicking the tray icon";
+    };
+    autoResetAppCache = mkEnableOption "" // {
+      description = "Whether to reset the cache when the app starts";
+    };
+    resumeOnStart = mkEnableOption "" // {
+      description = "Whether to resume the last song when the app starts";
+      default = true;
+    };
+    likeButtons = mkOption {
+      description = "Whether to show or hide the like buttons";
+      default = "";
+      type = types.enum [
+        ""
+        "force"
+        "hide"
+      ];
+    };
+    swapLikeButtonsOrder = mkEnableOption "" // {
+      description = "Whether to swap the like buttons order";
+    };
+    proxy = mkOption {
+      default = "";
+      description = "Proxy uri";
+      example = "SOCKS5://127.0.0.1:9999";
+      type = types.str;
+    };
+    startingPage = mkOption {
+      description = "Starting page";
+      default = "";
+      type = types.enum [
+        ""
+        "Default"
+        "Home"
+        "Explore"
+        "New Releases"
+        "Charts"
+        "Moods & Genres"
+        "Library"
+        "Playlists"
+        "Songs"
+        "Albums"
+        "Artists"
+        "Subscribed Artists"
+        "Uploads"
+        "Uploaded Playlists"
+        "Uploaded Songs"
+        "Uploaded Albums"
+        "Uploaded Artists"
+      ];
+    };
+    overrideUserAgent = mkEnableOption "" // {
+      default = true;
+      description = "Whether to override User-Agent";
+    };
+    usePodcastParticipantAsArtist = mkEnableOption "" // {
+      default = true;
+      description = ''
+        Whether to use the podcast participant as artist.
+
+        Workaround used when listening to a podcast.
+      '';
+    };
+    themes = mkOption {
+      default = [ ];
+      description = "Custom CSS themes";
+      type = types.listOf types.path;
+    };
+    customWindowTitle = mkOption {
+      description = ''
+        Set window title to this value instead of dynamically changing it to
+        the current song's name.
+
+        See https://github.com/pear-devs/pear-desktop/pull/3656
+      '';
+      default = null;
+      type = types.nullOr types.str;
+    };
+  };
+}

--- a/nix/homeManagerModule/plugins/album-color-theme.nix
+++ b/nix/homeManagerModule/plugins/album-color-theme.nix
@@ -1,0 +1,13 @@
+{ lib, ... }:
+let
+  inherit (lib) mkEnableOption mkOption types;
+in
+{
+  enable = mkEnableOption "Album Color Theme plugin";
+  ratio = mkOption {
+    default = 0.5;
+    description = "Color mix ratio";
+    type = types.number;
+  };
+  enableSeekbar = mkEnableOption "seek bar";
+}

--- a/nix/homeManagerModule/plugins/ambient-mode.nix
+++ b/nix/homeManagerModule/plugins/ambient-mode.nix
@@ -1,0 +1,79 @@
+{ lib, ... }:
+let
+  inherit (lib) mkOption types mkEnableOption;
+in
+{
+  enable = mkEnableOption "Ambient Mode plugin";
+  quality = mkOption {
+    default = 50;
+    description = "ambient mode quality (pixels)";
+    type = types.enum [
+      10
+      25
+      50
+      100
+      200
+      500
+      1000
+    ];
+  };
+  buffer = mkOption {
+    default = 30;
+    description = "ambient mode buffer";
+    type = types.enum [
+      1
+      5
+      10
+      20
+      30
+    ];
+  };
+  interpolationTime = mkOption {
+    default = 1500;
+    description = "ambient mode interpolation time (ms)";
+    type = types.enum [
+      0
+      500
+      1000
+      1500
+      2000
+      3000
+      4000
+      5000
+    ];
+  };
+  blur = mkOption {
+    default = 100;
+    description = "ambient mode blur (%)";
+    type = types.enum [
+      0
+      5
+      10
+      25
+      50
+      100
+      150
+      200
+      500
+    ];
+  };
+  size = mkOption {
+    default = 100;
+    description = "ambient mode size (%)";
+    type = types.enum [
+      100
+      110
+      125
+      150
+      175
+      200
+      300
+    ];
+  };
+  opacity = mkOption {
+    description = "Value between 0.0 and 1.0";
+    default = 1.0;
+    type = types.numbers.between 0 1;
+  };
+  fullscreen = mkEnableOption "ambient mode fullscreen";
+}

--- a/nix/homeManagerModule/plugins/api-server.nix
+++ b/nix/homeManagerModule/plugins/api-server.nix
@@ -1,0 +1,48 @@
+{ lib, ... }:
+let
+  inherit (lib) mkOption mkEnableOption types;
+in
+{
+  enable = mkEnableOption "API Server plugin";
+  hostname = mkOption {
+    default = null;
+    type = with types; nullOr str;
+    example = "0.0.0.0";
+    description = "API server host";
+  };
+  port = mkOption {
+    default = null;
+    type = with types; nullOr port;
+    example = 26538;
+    description = "API server port";
+  };
+  authStrategy = mkOption {
+    type = types.enum [
+      "AUTH_AT_FIRST"
+      "NONE"
+    ];
+    default = "AUTH_AT_FIRST";
+    description = "API server authentication";
+  };
+  secret = mkOption {
+    default = null;
+    type = with types; nullOr str;
+    internal = true;
+  };
+  authorizedClients = mkOption {
+    default = [ ];
+    type = types.listOf types.str;
+    internal = true;
+  };
+  useHttps = mkEnableOption "HTTPS support";
+  certPath = mkOption {
+    description = "string path to HTTPS certificate";
+    type = with types; nullOr str;
+    default = null;
+  };
+  keyPath = mkOption {
+    description = "path to HTTPS key";
+    type = with types; nullOr str;
+    default = null;
+  };
+}

--- a/nix/homeManagerModule/plugins/auth-proxy-adapter.nix
+++ b/nix/homeManagerModule/plugins/auth-proxy-adapter.nix
@@ -1,0 +1,17 @@
+{ lib, ... }:
+let
+  inherit (lib) mkOption mkEnableOption types;
+in
+{
+  enable = mkEnableOption "Auth Proxy Adapter plugin";
+  hostname = mkOption {
+    default = "127.0.0.1";
+    type = types.str;
+    description = "auth proxy host";
+  };
+  port = mkOption {
+    default = 4545;
+    type = types.port;
+    description = "auth proxy port";
+  };
+}

--- a/nix/homeManagerModule/plugins/captions-selector.nix
+++ b/nix/homeManagerModule/plugins/captions-selector.nix
@@ -1,0 +1,16 @@
+{ lib, ... }:
+let
+  inherit (lib) mkEnableOption mkOption;
+in
+{
+  enable = mkEnableOption "Captions Selector plugin";
+  disableCaptions = mkEnableOption "" // {
+    description = "Whether to disable captions";
+  };
+  autoload = mkEnableOption "autoload last used caption";
+  lastCaptionsCode = mkOption {
+    default = "";
+    type = lib.types.str;
+    internal = true;
+  };
+}

--- a/nix/homeManagerModule/plugins/clock.nix
+++ b/nix/homeManagerModule/plugins/clock.nix
@@ -1,0 +1,11 @@
+{ lib, ... }:
+let
+  inherit (lib) mkEnableOption;
+in
+{
+  enable = mkEnableOption "Clock plugin";
+  displaySeconds = mkEnableOption "" // {
+    description = "Whether to display seconds";
+  };
+  hour12 = mkEnableOption "12-hour clock";
+}

--- a/nix/homeManagerModule/plugins/crossfade.nix
+++ b/nix/homeManagerModule/plugins/crossfade.nix
@@ -1,0 +1,33 @@
+{ lib, ... }:
+let
+  inherit (lib) mkEnableOption mkOption types;
+in
+{
+  enable = mkEnableOption "Crossfade plugin";
+  fadeInDuration = mkOption {
+    description = "fade in duration (ms)";
+    default = 1500;
+    type = types.number;
+  };
+  fadeOutDuration = mkOption {
+    description = "fade out duration (ms)";
+    default = 5000;
+    type = types.number;
+  };
+  secondsBeforeEnd = mkOption {
+    description = "crossfade n seconds before end";
+    default = 10;
+    type = types.number;
+  };
+  fadeScaling = mkOption {
+    description = "fade scaling";
+    default = "linear";
+    type = types.oneOf [
+      (types.enum [
+        "linear"
+        "logarithmic"
+      ])
+      types.number
+    ];
+  };
+}

--- a/nix/homeManagerModule/plugins/custom-output-device.nix
+++ b/nix/homeManagerModule/plugins/custom-output-device.nix
@@ -1,0 +1,30 @@
+{ lib, ... }:
+let
+  inherit (lib) mkEnableOption mkOption types;
+in
+{
+  enable = mkEnableOption "Custom output device plugin";
+  output = mkOption {
+    type = types.str;
+    default = "output";
+    description = ''
+      AudioContext.sinkId
+
+      [Link]: https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/sinkId
+    '';
+  };
+  devices = mkOption {
+    type = with types; attrsOf str;
+    default = { };
+    description = ''
+      Map of audio devices
+
+      key: MediaDeviceInfo.deviceId
+      value: MediaDeviceInfo.label
+
+      P.S.: This is set by the application, you shouldn't *need* to change this.
+
+      [Link]: https://developer.mozilla.org/en-US/docs/Web/API/MediaDeviceInfo
+    '';
+  };
+}

--- a/nix/homeManagerModule/plugins/default.nix
+++ b/nix/homeManagerModule/plugins/default.nix
@@ -1,0 +1,118 @@
+{ lib, pkgs, ... }:
+let
+  inherit (lib)
+    mkEnableOption
+    mkRenamedOptionModule
+    mergeAttrs
+    ;
+  inherit (builtins) listToAttrs map;
+
+  complexPlugins = [
+    "album-color-theme"
+    "ambient-mode"
+    "api-server"
+    "auth-proxy-adapter"
+    "captions-selector"
+    "clock"
+    "crossfade"
+    "custom-output-device"
+    "disable-autoplay"
+    "discord"
+    "do-not-track"
+    "downloader"
+    "equalizer"
+    "in-app-menu"
+    "lyrics-genius"
+    "notifications"
+    "picture-in-picture"
+    "precise-volume"
+    "scrobbler"
+    "shortcuts"
+    "skip-silences"
+    "sponsorblock"
+    "synced-lyrics"
+    "transparent-player"
+    "video-toggle"
+    "visualizer"
+  ];
+
+  simplePlugins = {
+    audio-compressor = "Audio Compressor plugin";
+    album-actions = "Album Actions plugin";
+    amuse = "Amuse plugin";
+    blur-nav-bar = "Blur Navigation Bar plugin";
+    bypass-age-restrictions = "Bypass Age Restrictions plugin";
+    compact-sidebar = "Compact Sidebar plugin";
+    exponential-volume = "Exponential Volume plugin";
+    lumiastream = "Lumia Stream plugin";
+    music-together = "Music Together plugin";
+    navigation = "Navigation plugin";
+    no-google-login = "No Google Login plugin";
+    playback-speed = "Playback Speed plugin";
+    quality-changer = "Quality Changer plugin";
+    skip-disliked-songs = "Skip Disliked Songs plugin";
+    taskbar-mediacontrol = "Taskbar Media Control plugin (Windows)";
+    touchbar = "TouchBar plugin";
+    tuna-obs = "Tuna OBS plugin";
+    unobtrusive-player = "Unobtrusive Player plugin";
+    performance-improvement = "Performance Improvement plugin";
+  };
+
+  baseOptionName = [
+    "programs"
+    "pear-desktop"
+    "plugins"
+  ];
+
+  renamedEnableOptions =
+    builtins.map
+      (
+        pluginName:
+        let
+          optionName = baseOptionName ++ (lib.lists.flatten [ pluginName ]);
+        in
+        mkRenamedOptionModule (optionName ++ [ "enabled" ]) (optionName ++ [ "enable" ])
+      )
+      (
+        (builtins.attrNames simplePlugins)
+        ++ complexPlugins
+        ++ [
+          [
+
+            "scrobbler"
+            "scrobblers"
+            "lastfm"
+          ]
+          [
+
+            "scrobbler"
+            "scrobblers"
+            "listenbrainz"
+          ]
+          [
+
+            "downloader"
+            "downloadOnFinish"
+          ]
+        ]
+      );
+in
+{
+  imports = renamedEnableOptions ++ [
+    (mkRenamedOptionModule (baseOptionName ++ [ "adblocker" ]) (baseOptionName ++ [ "do-not-track" ]))
+  ];
+
+  options.programs.pear-desktop.plugins =
+    mergeAttrs
+      (listToAttrs (
+        map (plugin: {
+          name = plugin;
+          value = import ./${plugin}.nix { inherit lib pkgs; };
+        }) complexPlugins
+      ))
+      (
+        lib.attrsets.mapAttrs (pluginName: pluginDescription: {
+          enable = mkEnableOption pluginDescription;
+        }) simplePlugins
+      );
+}

--- a/nix/homeManagerModule/plugins/disable-autoplay.nix
+++ b/nix/homeManagerModule/plugins/disable-autoplay.nix
@@ -1,0 +1,10 @@
+{ lib, ... }:
+let
+  inherit (lib) mkEnableOption;
+in
+{
+  enable = mkEnableOption "'Disable Autoplay' plugin";
+  applyOnce = mkEnableOption "" // {
+    description = "Whether to apply only on startup";
+  };
+}

--- a/nix/homeManagerModule/plugins/discord.nix
+++ b/nix/homeManagerModule/plugins/discord.nix
@@ -1,0 +1,48 @@
+{ lib, ... }:
+let
+  inherit (lib) types mkOption mkEnableOption;
+in
+{
+  enable = mkEnableOption "Discord Rich Presence plugin";
+  autoReconnect = mkEnableOption "" // {
+    description = "If enabled, will try to reconnect to discord every 5 seconds after disconnecting or failing to connect";
+    default = true;
+  };
+  activityTimeoutEnabled = mkEnableOption "" // {
+    description = "If enabled, the discord rich presence gets cleared when music paused after the time specified below";
+    default = true;
+  };
+  activityTimeoutTime = mkOption {
+    description = "The time in milliseconds after which the discord rich presence gets cleared when music paused";
+    default = 10 * 60 * 1000;
+    type = types.number;
+  };
+  playOnYouTubeMusic = mkEnableOption "" // {
+    description = ''Add a "Play on Pear Desktop" button to rich presence'';
+    default = true;
+  };
+  hideGitHubButton = mkEnableOption "" // {
+    description = ''Hide the "View App On GitHub" button in the rich presence'';
+  };
+  hideDurationLeft = mkEnableOption "" // {
+    description = ''Hide the "duration left" in the rich presence'';
+  };
+  statusDisplayType = mkOption {
+    description = ''
+      Controls which field is displayed in the Discord status text
+
+      0: Name
+      1: State
+      2: Details
+
+      https://discord-api-types.dev/api/discord-api-types-v10/enum/StatusDisplayType
+    '';
+    default = 2;
+    example = 1;
+    type = types.enum [
+      0
+      1
+      2
+    ];
+  };
+}

--- a/nix/homeManagerModule/plugins/do-not-track.nix
+++ b/nix/homeManagerModule/plugins/do-not-track.nix
@@ -1,0 +1,27 @@
+{ lib, ... }:
+let
+  inherit (lib) mkOption types mkEnableOption;
+in
+{
+  enable = mkEnableOption "AdBlocker plugin";
+  cache = mkEnableOption "" // {
+    description = "When enabled, the adblocker will cache the blocklists";
+    default = true;
+  };
+  blocker = mkOption {
+    description = "Which adblocker to use";
+    type = types.enum [
+      "With blocklists"
+      "In player"
+    ];
+    default = "In player";
+  };
+  additionalBlockLists = mkOption {
+    description = "Additional list of filters to use";
+    type = types.listOf types.str;
+    default = [ ];
+  };
+  disableDefaultLists = mkEnableOption "" // {
+    description = "Whether to disable the default blocklists";
+  };
+}

--- a/nix/homeManagerModule/plugins/downloader.nix
+++ b/nix/homeManagerModule/plugins/downloader.nix
@@ -1,0 +1,68 @@
+{ lib, ... }:
+let
+  inherit (lib) mkOption mkEnableOption types;
+in
+{
+  enable = mkEnableOption "Downloader plugin";
+  downloadFolder = mkOption {
+    description = "download folder";
+    default = null;
+    type = types.nullOr types.str;
+  };
+  downloadOnFinish = {
+    enable = mkEnableOption "download on finish";
+    seconds = mkOption {
+      description = "last x seconds";
+      default = 20;
+      type = types.number;
+    };
+    percent = mkOption {
+      description = "last x percent";
+      default = 10;
+      type = types.number;
+    };
+    mode = mkOption {
+      description = "time mode";
+      type = types.enum [
+        "percent"
+        "seconds"
+      ];
+      default = "seconds";
+    };
+    folder = mkOption {
+      description = "download on finish folder";
+      default = null;
+      type = types.nullOr types.str;
+    };
+  };
+  selectedPreset = mkOption {
+    default = "mp3 (256kbps)";
+    description = "downloader preset";
+    type = types.enum [
+      "mp3 (256kbps)"
+      "Custom"
+      "Source"
+    ];
+  };
+  customPresetSetting = {
+    extension = mkOption {
+      description = "custom preset setting extension";
+      default = "mp3";
+      type = types.nullOr types.str;
+    };
+    ffmpegArgs = mkOption {
+      description = "custom preset setting ffmpeg args";
+      default = [
+        "-b:a"
+        "256k"
+      ];
+      type = types.listOf types.str;
+    };
+  };
+  skipExisting = mkEnableOption "skip existing";
+  playlistMaxItems = mkOption {
+    description = "playlist max items";
+    default = null;
+    type = with types; nullOr number;
+  };
+}

--- a/nix/homeManagerModule/plugins/equalizer.nix
+++ b/nix/homeManagerModule/plugins/equalizer.nix
@@ -1,0 +1,44 @@
+{ lib, ... }:
+let
+  inherit (lib) mkOption mkEnableOption types;
+in
+{
+  enable = mkEnableOption "Equalizer plugin";
+  filters = mkOption {
+    internal = true;
+    default = [ ];
+    type =
+      with types;
+      listOf (submodule {
+        options = {
+          type = mkOption {
+            description = "BiquadFilterType";
+            default = "lowshelf";
+            type = str;
+            internal = true;
+          };
+          frequency = mkOption {
+            default = 80;
+            type = number;
+            description = "frequency";
+            internal = true;
+          };
+          Q = mkOption {
+            type = number;
+            description = "Q";
+            default = 100;
+            internal = true;
+          };
+          gain = mkOption {
+            type = number;
+            description = "gain";
+            default = 12.0;
+            internal = true;
+          };
+        };
+      });
+  };
+  presets = {
+    bass-booster = mkEnableOption "Equalizer's bass-booster preset";
+  };
+}

--- a/nix/homeManagerModule/plugins/in-app-menu.nix
+++ b/nix/homeManagerModule/plugins/in-app-menu.nix
@@ -1,0 +1,12 @@
+{ lib, pkgs, ... }:
+let
+  inherit (lib) mkEnableOption;
+  inherit (pkgs.stdenv.hostPlatform) isLinux;
+in
+{
+  enable = mkEnableOption "In-App Menu plugin";
+  hideDOMWindowControls = mkEnableOption "" // {
+    description = "Whether to hide DOM window controls";
+    internal = !isLinux;
+  };
+}

--- a/nix/homeManagerModule/plugins/lyrics-genius.nix
+++ b/nix/homeManagerModule/plugins/lyrics-genius.nix
@@ -1,0 +1,8 @@
+{ lib, ... }:
+let
+  inherit (lib) mkEnableOption;
+in
+{
+  enable = mkEnableOption "Lyrics Genius plugin";
+  romanizedLyrics = mkEnableOption "romanized lyrics";
+}

--- a/nix/homeManagerModule/plugins/notifications.nix
+++ b/nix/homeManagerModule/plugins/notifications.nix
@@ -1,0 +1,58 @@
+{ lib, pkgs }:
+let
+  inherit (lib) mkEnableOption mkOption types;
+  inherit (pkgs.stdenv.hostPlatform) isLinux;
+in
+{
+  enable = mkEnableOption "Notifications plugin";
+  unpauseNotification = mkEnableOption "" // {
+    description = "Whether to show notification on unpause";
+  };
+  urgency = mkOption {
+    default = "normal";
+    description = "Only has effect on Linux";
+    type = types.enum [
+      "low"
+      "normal"
+      "critical"
+    ];
+    internal = !isLinux;
+  };
+  interactive = mkOption {
+    default = true;
+    type = types.bool;
+    description = "Only has effect on Windows";
+    internal = true;
+  };
+  toastStyle = mkOption {
+    default = 1;
+    type = types.enum [
+      1
+      2
+      3
+      4
+      5
+      6
+      7
+    ];
+    description = ''
+      1: logo
+      2: banner_centered_top
+      3: hero
+      4: banner_top_custom
+      5: banner_centered_bottom
+      6: banner_bottom
+      7: legacy
+    '';
+    internal = true;
+  };
+  refreshOnPlayPause = mkEnableOption "refresh on play/pause" // {
+    internal = true;
+  };
+  trayControls = mkEnableOption "tray controls" // {
+    internal = true;
+  };
+  hideButtonText = mkEnableOption "hide button text" // {
+    internal = true;
+  };
+}

--- a/nix/homeManagerModule/plugins/picture-in-picture.nix
+++ b/nix/homeManagerModule/plugins/picture-in-picture.nix
@@ -1,0 +1,46 @@
+{ lib, ... }:
+let
+  inherit (lib) mkEnableOption mkOption types;
+in
+{
+  enable = mkEnableOption "Picture-in-picture plugin";
+  alwaysOnTop = mkEnableOption "always on top" // {
+    default = true;
+  };
+  savePosition = mkEnableOption "save window position" // {
+    default = true;
+  };
+  saveSize = mkEnableOption "save window size";
+  hotkey = mkOption {
+    default = "P";
+    type = types.str;
+    description = "hotkey to open the PiP";
+  };
+  pip-position = mkOption {
+    default = [
+      10
+      10
+    ];
+    description = "[x y]";
+    type = with types; listOf int;
+    internal = true;
+  };
+  pip-size = mkOption {
+    default = [
+      450
+      275
+    ];
+    description = "[width height]";
+    type = with types; listOf int;
+    internal = true;
+  };
+  isInPiP = mkOption {
+    default = false;
+    type = types.bool;
+    internal = true;
+  };
+  useNativePiP = mkEnableOption "" // {
+    default = true;
+    description = "Use the browser's native PiP";
+  };
+}

--- a/nix/homeManagerModule/plugins/precise-volume.nix
+++ b/nix/homeManagerModule/plugins/precise-volume.nix
@@ -1,0 +1,34 @@
+{ lib, ... }:
+let
+  inherit (lib) mkEnableOption mkOption types;
+in
+{
+  enable = mkEnableOption "Precise Volume plugin";
+  steps = mkOption {
+    default = 1;
+    description = "Percentage of volume to change";
+    type = types.number;
+  };
+  arrowsShortcut = mkEnableOption "" // {
+    default = true;
+    description = "ArrowUp + ArrowDown local shortcuts";
+  };
+  globalShortcuts = {
+    volumeUp = mkOption {
+      description = "Global shortcut for volume up";
+      default = "";
+      type = types.str;
+    };
+    volumeDown = mkOption {
+      description = "Global shortcut for volume down";
+      default = "";
+      type = types.str;
+    };
+  };
+  savedVolume = mkOption {
+    default = null;
+    description = "Default volume";
+    type = types.nullOr types.number;
+    internal = true;
+  };
+}

--- a/nix/homeManagerModule/plugins/scrobbler.nix
+++ b/nix/homeManagerModule/plugins/scrobbler.nix
@@ -1,0 +1,68 @@
+{ lib, ... }:
+let
+  inherit (lib) mkEnableOption mkOption types;
+in
+{
+  enable = mkEnableOption "Scrobbler plugin";
+  scrobbleOtherMedia = mkEnableOption "" // {
+    description = "Attempt to scrobble other video types (e.g. Podcasts, normal videos)";
+    default = true;
+  };
+  alternativeTitles = mkEnableOption "" // {
+    description = ''
+      Use alternative titles for scrobbling (Useful for non-roman song titles, e.g. (Not) A Devil -> デビルじゃないもん)
+    '';
+    default = true;
+  };
+  alternativeArtist = mkEnableOption "" // {
+    description = ''
+      Use alternative artist for scrobbling (e.g., DECO27 & (or) PinocchioP -> DECO27 / marasy -> まらしぃ)
+    '';
+    default = true;
+  };
+  scrobblers = {
+    lastfm = {
+      enable = mkEnableOption "Last.fm scrobbling";
+      token = mkOption {
+        description = "Token used for authentication";
+        default = null;
+        type = with types; nullOr str;
+      };
+      sessionKey = mkOption {
+        description = "Session key used for scrobbling";
+        default = null;
+        type = with types; nullOr str;
+      };
+      apiRoot = mkOption {
+        description = "Root of the Last.fm API";
+        default = null;
+        example = "https://ws.audioscrobbler.com/2.0/";
+        type = with types; nullOr str;
+      };
+      apiKey = mkOption {
+        description = "Last.fm api key";
+        default = null;
+        type = with types; nullOr str;
+      };
+      secret = mkOption {
+        description = "Last.fm api secret";
+        default = null;
+        type = with types; nullOr str;
+      };
+    };
+    listenbrainz = {
+      enable = mkEnableOption "ListenBrainz scrobbling";
+      token = mkOption {
+        description = "ListenBrainz API key";
+        default = null;
+        type = types.nullOr types.str;
+      };
+      apiRoot = mkOption {
+        description = "Root of the ListenBrainz API";
+        default = null;
+        example = "https://api.listenbrainz.org/1/";
+        type = with types; nullOr str;
+      };
+    };
+  };
+}

--- a/nix/homeManagerModule/plugins/shortcuts.nix
+++ b/nix/homeManagerModule/plugins/shortcuts.nix
@@ -1,0 +1,39 @@
+{ lib, ... }:
+let
+  inherit (lib) mkEnableOption mkOption types;
+  shortcutMappingType = types.submodule {
+    options = {
+      previous = mkOption {
+        default = "";
+        type = types.str;
+        description = "previous shortcut";
+      };
+      playPause = mkOption {
+        default = "";
+        type = types.str;
+        description = "play/pause shortcut";
+      };
+      next = mkOption {
+        default = "";
+        type = types.str;
+        description = "next shortcut";
+      };
+    };
+  };
+in
+{
+  enable = mkEnableOption "Shortcuts plugin";
+  overrideMediaKeys = mkEnableOption "" // {
+    description = "Whether to override media keys";
+  };
+  global = mkOption {
+    default = { };
+    type = shortcutMappingType;
+    description = "global shortcuts";
+  };
+  local = mkOption {
+    default = { };
+    type = shortcutMappingType;
+    internal = true;
+  };
+}

--- a/nix/homeManagerModule/plugins/skip-silences.nix
+++ b/nix/homeManagerModule/plugins/skip-silences.nix
@@ -1,0 +1,10 @@
+{ lib, ... }:
+let
+  inherit (lib) mkEnableOption;
+in
+{
+  enable = mkEnableOption "Skip Silences plugin";
+  onlySkipBeginning = mkEnableOption "" // {
+    description = "Whether to only skip beginning";
+  };
+}

--- a/nix/homeManagerModule/plugins/sponsorblock.nix
+++ b/nix/homeManagerModule/plugins/sponsorblock.nix
@@ -1,0 +1,30 @@
+{ lib, ... }:
+let
+  inherit (lib) mkEnableOption mkOption types;
+in
+{
+  enable = mkEnableOption "SponsorBlock plugin";
+  apiURL = mkOption {
+    default = "https://sponsor.ajay.app";
+    type = types.str;
+    description = "API url";
+    internal = true;
+  };
+  categories =
+    let
+      categoryList = [
+        "sponsor"
+        "intro"
+        "outro"
+        "interaction"
+        "selfpromo"
+        "music_offtopic"
+      ];
+    in
+    mkOption {
+      default = categoryList;
+      description = "SponsorBlock categories";
+      type = types.listOf (types.enum categoryList);
+      internal = true;
+    };
+}

--- a/nix/homeManagerModule/plugins/synced-lyrics.nix
+++ b/nix/homeManagerModule/plugins/synced-lyrics.nix
@@ -1,0 +1,32 @@
+{ lib, ... }:
+let
+  inherit (lib) mkEnableOption mkOption types;
+in
+{
+  enable = mkEnableOption "Synced Lyrics plugin";
+  preciseTiming = mkEnableOption "precise timing" // {
+    default = true;
+  };
+  showLyricsEvenIfInexact = mkEnableOption "lyrics even if inexact" // {
+    default = true;
+  };
+  showTimeCodes = mkEnableOption "time codes";
+  defaultTextString = mkOption {
+    default = "♪";
+    type = types.str;
+    description = "character between lyrics";
+  };
+  lineEffect = mkOption {
+    default = "fancy";
+    type = types.enum [
+      "fancy"
+      "scale"
+      "offset"
+      "focus"
+    ];
+    description = "line effect";
+  };
+  romanization = mkEnableOption "romanized lyrics" // {
+    default = true;
+  };
+}

--- a/nix/homeManagerModule/plugins/transparent-player.nix
+++ b/nix/homeManagerModule/plugins/transparent-player.nix
@@ -1,0 +1,22 @@
+{ lib, ... }:
+let
+  inherit (lib) mkEnableOption mkOption types;
+in
+{
+  enable = mkEnableOption "Transparent player plugin";
+  opacity = mkOption {
+    type = types.number;
+    default = 0.5;
+    description = "Transparent player's opacity";
+  };
+  type = mkOption {
+    type = types.enum [
+      "mica"
+      "acrylic"
+      "tabbed"
+      "none"
+    ];
+    default = "none";
+    description = "Transparent player's material type";
+  };
+}

--- a/nix/homeManagerModule/plugins/video-toggle.nix
+++ b/nix/homeManagerModule/plugins/video-toggle.nix
@@ -1,0 +1,32 @@
+{ lib, ... }:
+let
+  inherit (lib) mkEnableOption mkOption types;
+in
+{
+  enable = mkEnableOption "Video Toggle plugin";
+  hideVideo = mkEnableOption "" // {
+    description = "Whether to hide the video";
+    internal = true;
+  };
+  mode = mkOption {
+    default = "custom";
+    type = types.enum [
+      "custom"
+      "native"
+      "disabled"
+    ];
+    description = "video toggle mode";
+  };
+  forceHide = mkEnableOption "" // {
+    description = "Whether to forcefully hide the video toggle";
+  };
+  align = mkOption {
+    default = "left";
+    type = types.enum [
+      "left"
+      "middle"
+      "right"
+    ];
+    description = "video toggle alignment";
+  };
+}

--- a/nix/homeManagerModule/plugins/visualizer.nix
+++ b/nix/homeManagerModule/plugins/visualizer.nix
@@ -1,0 +1,245 @@
+{ lib, ... }:
+let
+  inherit (lib) mkEnableOption mkOption types;
+  mkOptionalOption =
+    { type, ... }@args:
+    mkOption {
+      default = null;
+      type = types.nullOr type;
+    }
+    // (builtins.removeAttrs args [ "type" ]);
+in
+{
+  enable = mkEnableOption "Visualizer plugin";
+  type = mkOption {
+    default = "butterchurn";
+    description = "Visualizer type";
+    type = types.enum [
+      "butterchurn"
+      "vudio"
+      "wave"
+    ];
+  };
+  butterchurn = {
+    preset = mkOption {
+      default = "martin [shadow harlequins shape code] - fata morgana";
+      type = types.str;
+      internal = true;
+    };
+    blendTimeInSeconds = mkOption {
+      default = 2.7;
+      type = types.number;
+      internal = true;
+    };
+  };
+  vudio = {
+    effect = mkOption {
+      default = "lighting";
+      type = types.enum [
+        "waveform"
+        "circlewave"
+        "circlebar"
+        "lighting"
+      ];
+      internal = true;
+    };
+    accuracy = mkOption {
+      default = 128;
+      type = types.number;
+      internal = true;
+    };
+    lighting = {
+      maxHeight = mkOption {
+        default = 160;
+        type = types.number;
+        internal = true;
+      };
+      maxSize = mkOption {
+        default = 12;
+        type = types.number;
+        internal = true;
+      };
+      lineWidth = mkOption {
+        default = 1;
+        type = types.number;
+        internal = true;
+      };
+      color = mkOption {
+        default = "#49f3f7";
+        type = types.str;
+        internal = true;
+      };
+      shadowBlur = mkOption {
+        default = 2;
+        type = types.number;
+        internal = true;
+      };
+      shadowColor = mkOption {
+        default = "rgba(244,244,244,.5)";
+        type = types.str;
+        internal = true;
+      };
+      fadeSide = mkEnableOption "fade side" // {
+        default = true;
+        internal = true;
+      };
+      prettify = mkEnableOption "prettify" // {
+        internal = true;
+      };
+      horizontalAlign = mkOption {
+        default = "center";
+        type = types.enum [
+          "left"
+          "center"
+          "right"
+        ];
+        internal = true;
+      };
+      verticalAlign = mkOption {
+        default = "middle";
+        type = types.enum [
+          "top"
+          "middle"
+          "bottom"
+        ];
+        internal = true;
+      };
+      dottify = mkEnableOption "dottify" // {
+        default = true;
+        internal = true;
+      };
+    };
+  };
+  wave =
+    let
+      waveColor =
+        with types;
+        submodule {
+          options = {
+            gradient = mkOption {
+              default = null;
+              type = nullOr (listOf str);
+            };
+            rotate = mkOption {
+              default = null;
+              type = nullOr number;
+            };
+          };
+        };
+      animation =
+        with types;
+        submodule {
+          options = {
+            type = mkOption {
+              type = str;
+              internal = true;
+            };
+            config = {
+              bottom = mkOptionalOption {
+                type = bool;
+                internal = true;
+              };
+              top = mkOptionalOption {
+                type = bool;
+                internal = true;
+              };
+              count = mkOptionalOption {
+                type = number;
+                internal = true;
+              };
+              cubeHeight = mkOptionalOption {
+                type = number;
+                internal = true;
+              };
+              lineWidth = mkOptionalOption {
+                type = number;
+                internal = true;
+              };
+              diameter = mkOptionalOption {
+                type = number;
+                internal = true;
+              };
+              fillColor = mkOptionalOption {
+                type = oneOf [
+                  str
+                  waveColor
+                ];
+                internal = true;
+              };
+              lineColor = mkOptionalOption {
+                type = oneOf [
+                  str
+                  waveColor
+                ];
+                internal = true;
+              };
+              radius = mkOptionalOption {
+                type = number;
+                internal = true;
+              };
+              frequencyBand = mkOptionalOption {
+                type = str;
+                internal = true;
+              };
+            };
+          };
+        };
+    in
+    {
+      animations = mkOption {
+        type = with types; listOf animation;
+        internal = true;
+        default = [
+          {
+            type = "Cubes";
+            config = {
+              bottom = true;
+              count = 30;
+              cubeHeight = 5;
+              fillColor = {
+                gradient = [
+                  "#FAD961"
+                  "#F76B1C"
+                ];
+              };
+              lineColor = "rgba(0,0,0,0)";
+              radius = 20;
+            };
+          }
+          {
+            type = "Cubes";
+            config = {
+              top = true;
+              count = 12;
+              cubeHeight = 5;
+              fillColor = {
+                gradient = [
+                  "#FAD961"
+                  "#F76B1C"
+                ];
+              };
+              lineColor = "rgba(0,0,0,0)";
+              radius = 10;
+            };
+          }
+          {
+            type = "Circles";
+            config = {
+              lineColor = {
+                gradient = [
+                  "#FAD961"
+                  "#FAD961"
+                  "#F76B1C"
+                ];
+                rotate = 90;
+              };
+              lineWidth = 4;
+              diameter = 20;
+              count = 10;
+              frequencyBand = "base";
+            };
+          }
+        ];
+      };
+    };
+}

--- a/nix/legacyPackages/eval.nix
+++ b/nix/legacyPackages/eval.nix
@@ -1,0 +1,19 @@
+{
+  lib,
+  pkgs,
+  module,
+}:
+lib.evalModules {
+  modules = [
+    {
+      config = {
+        _module.check = false;
+      };
+    }
+    module
+  ];
+
+  specialArgs = {
+    inherit pkgs;
+  };
+}

--- a/nix/legacyPackages/nixosOptionsDoc.nix
+++ b/nix/legacyPackages/nixosOptionsDoc.nix
@@ -1,0 +1,7 @@
+{
+  eval,
+  nixosOptionsDoc,
+}:
+nixosOptionsDoc {
+  inherit (eval) options;
+}

--- a/nix/lib/default.nix
+++ b/nix/lib/default.nix
@@ -1,0 +1,78 @@
+{ lib }:
+let
+  inherit (lib.attrsets)
+    mapAttrs'
+    mapAttrsRecursiveCond
+    nameValuePair
+    filterAttrsRecursive
+    ;
+in
+rec {
+  mapAttrsRecursive' =
+    f: set:
+    let
+      recurse =
+        path:
+        mapAttrs' (
+          name: value:
+          if builtins.isAttrs value then
+            nameValuePair name (recurse (path ++ [ name ]) value)
+          else
+            f (path ++ [ name ]) value
+        );
+    in
+    recurse [ ] set;
+
+  toPearDesktopJSON =
+    opts: cfg:
+    let
+      # This is done to avoid "obsolete option" warnings:
+      # - 1) check if it's not an option (directory), or if it's a defined option
+      # - 2) get the corresponding configuration value
+      definedOptions = filterAttrsRecursive (
+        n: v: (!lib.isOption v) && n != "_module" || (v.isDefined or false)
+      ) opts;
+      definedConfig = mapAttrsRecursiveCond (as: !(lib.isOption as)) (
+        path: value: lib.getAttrFromPath path cfg
+      ) definedOptions;
+    in
+    builtins.toJSON (
+      mapAttrsRecursive' (
+        path: value:
+        let
+          name = lib.lists.last path;
+          renamedKeys = {
+            enable = "enabled";
+          };
+        in
+        nameValuePair (renamedKeys.${name} or name) value
+      ) (filterAttrsRecursive (n: v: v != null) definedConfig)
+    );
+
+  mkPearDesktopConfig =
+    {
+      options,
+      config,
+    }:
+    let
+      opts = options.programs.pear-desktop;
+      cfg = config.programs.pear-desktop;
+
+      urlJSON = builtins.toJSON cfg.url;
+      versionJSON = builtins.toJSON cfg.version;
+      optionsJSON = toPearDesktopJSON opts.options cfg.options;
+      pluginsJSON = toPearDesktopJSON opts.plugins cfg.plugins;
+    in
+    ''
+      {
+        "url": ${urlJSON},
+        "options": ${optionsJSON},
+        "plugins": ${pluginsJSON},
+        "__internal__": {
+          "migrations": {
+            "version": ${versionJSON}
+          }
+        }
+      }
+    '';
+}


### PR DESCRIPTION
Closes #2879 

This adds the home manager module from https://github.com/h-banii/pear-desktop-nix

as well as:
- README entry on how to use it
- the github action to run `nix flake check` (to avoid those grammar mistakes LOL)

<hr>

This can be tested using this input url:

```nix
inputs.pear-desktop.url = "github:pear-devs/pear-desktop/pull/4585/head";
```

<hr>

About joining the dev team, I only have time to help with the nix stuff, if that's okay

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Nix flake with multi-platform support, including a Nix formatter and automated flake checks.
  * Added NixOS installation guidance and a Home Manager module that generates and keeps Pear Desktop configuration in sync.
  * Expanded Home Manager configuration with new plugin option modules (e.g., API server, ambient mode, visualizer, crossfade, equalizer, and more).
* **Documentation**
  * Updated README with a NixOS section and added `nix/README` with flake input and Home Manager configuration examples.
* **Chores**
  * Added a “Nix Check” workflow to run flake checks on relevant changes and via manual trigger.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->