### PR TITLE
feat(api-server): added elapsedMilliseconds value for precision

### DIFF
--- a/src/plugins/api-server/backend/routes/control.ts
+++ b/src/plugins/api-server/backend/routes/control.ts
@@ -736,8 +736,23 @@ export const register = (
       return ctx.body(null);
     }
 
-    const body = { ...info };
+    const body = {
+      elapsedMilliseconds: 0,
+      ...info
+    };
     delete body.image;
+
+    // Prefer live video.currentTime for ms precision
+    const currentTime = (await window.webContents.executeJavaScript(
+      'document.querySelector("video")?.currentTime ?? null',
+    )) as number | null;
+
+    if (typeof currentTime === 'number' && Number.isFinite(currentTime)) {
+      body.elapsedMilliseconds = Math.floor(currentTime * 1000);
+      body.elapsedSeconds = Math.floor(currentTime);
+    } else if (typeof body.elapsedSeconds === 'number') {
+      body.elapsedMilliseconds = Math.floor(body.elapsedSeconds * 1000);
+    }
 
     ctx.status(200);
     return ctx.json(body satisfies ResponseSongInfo);

--- a/src/plugins/api-server/backend/scheme/song-info.ts
+++ b/src/plugins/api-server/backend/scheme/song-info.ts
@@ -12,6 +12,7 @@ export const SongInfoSchema = z.object({
   isPaused: z.boolean().optional(),
   songDuration: z.number(),
   elapsedSeconds: z.number().optional(),
+  elapsedMilliseconds: z.number().optional(),
   url: z.string().optional(),
   album: z.string().nullable().optional(),
   videoId: z.string(),

--- a/src/providers/song-info.ts
+++ b/src/providers/song-info.ts
@@ -37,6 +37,7 @@ export interface SongInfo {
   isPaused?: boolean;
   songDuration: number;
   elapsedSeconds?: number;
+  elapsedMilliseconds?: number;
   url?: string;
   album?: string | null;
   videoId: string;


### PR DESCRIPTION
Fix #4320 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Song information responses now include playback progress with millisecond precision when available.
  * Playback timing is synchronized with the current video position and remains compatible with second-based timing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->