### PR TITLE
Fix silent podcast/RSS playback (CORS-tainted Web Audio graph)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -961,6 +961,15 @@ function removeContentSecurityPolicy(
       }
     }
 
+    // Podcast/RSS audio streams from third-party hosts that omit CORS headers,
+    // so the renderer's Web Audio graph silences it. Media is fetched in anonymous
+    // (credential-less) CORS mode, so "*" is valid here, and it covers the whole
+    // redirect chain since every hop passes through this listener.
+    if (details.resourceType === 'media') {
+      delete details.responseHeaders['Access-Control-Allow-Origin'];
+      details.responseHeaders['access-control-allow-origin'] = ['*'];
+    }
+
     callback({ cancel: false, responseHeaders: details.responseHeaders });
   });
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -310,6 +310,12 @@ async function onApiLoaded() {
   );
 
   const video = document.querySelector('video')!;
+  // Podcast audio loads as a cross-origin <video> src; without CORS mode the
+  // MediaElementAudioSourceNode below outputs zeroes ("CORS access restrictions").
+  // Paired with the Access-Control-Allow-Origin header added for media responses
+  // in the main process, this lets that audio through. Songs stream via MSE from a
+  // same-origin blob URL, so crossOrigin has no effect on them.
+  video.crossOrigin = 'anonymous';
   const audioContext = new AudioContext();
   const audioSource = audioContext.createMediaElementSource(video);
   audioSource.connect(audioContext.destination);

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -316,6 +316,10 @@ async function onApiLoaded() {
   // in the main process, this lets that audio through. Songs stream via MSE from a
   // same-origin blob URL, so crossOrigin has no effect on them.
   video.crossOrigin = 'anonymous';
+  // A track already loading when this runs (e.g. session restore) started in
+  // no-CORS mode; re-fetch direct-URL media so its audio isn't left silenced.
+  // Songs use an MSE blob src and are skipped.
+  if (video.src && !video.src.startsWith('blob:')) video.load();
   const audioContext = new AudioContext();
   const audioSource = audioContext.createMediaElementSource(video);
   audioSource.connect(audioContext.destination);


### PR DESCRIPTION
## Problem

Podcasts and RSS episodes look like they are playing. The timeline advances and the play button flips to pause, but no audio comes out. The console shows:

```
MediaElementAudioSource outputs zeroes due to CORS access restrictions for https://…
```

This was reported in #1620 and is still present in 3.12.0. It reproduces with any third-party-hosted feed, including the soundcloud, megaphone, iono, and podigee URLs named in that thread.

## Root cause

On player-api-ready the renderer wires the shared `<video>` element through a Web Audio graph:

```ts
const audioSource = audioContext.createMediaElementSource(video);
audioSource.connect(audioContext.destination);
```

By spec, a `MediaElementAudioSourceNode` fed by cross-origin media that was not fetched in CORS mode outputs digital silence. Songs stream via MSE from a same-origin `blob:` URL, so they are not affected. Podcasts set the `<video>` src directly to a third-party host that sends no `Access-Control-Allow-Origin`, so the graph silences them.

The app already registers http/https as privileged with `corsEnabled` and `bypassCSP`, but that alone cannot fix it. A media element only fetches in CORS mode when it has a `crossorigin` attribute, and it had none. The third-party responses also carried no ACAO header. Both gaps have to be closed together, which is why the header-only attempts earlier in the thread did not work.

## Fix

- `renderer.ts`: set `video.crossOrigin = 'anonymous'` so podcast media is fetched in CORS mode.
- `index.ts`: add `Access-Control-Allow-Origin: *` to responses whose `resourceType` is `'media'`. This is scoped to media so it does not interfere with the app's credentialed API requests. Anonymous media carries no credentials, so `*` is valid, and it covers the whole redirect chain because every hop passes through the listener.

## Testing

- A real RSS podcast that produced the exact CORS-zeroes error now plays with audio, and that console error is gone. This is the same failure the issue documents across soundcloud, megaphone, iono, and podigee.
- Normal songs still play. Their Web Audio output measures non-zero, and they use MSE (`blob:`), so `crossOrigin` does not apply to them.
- Lint (`oxlint --type-aware`) and type-check (`tsc --noEmit`) pass, and the added lines are oxfmt-clean.
- Tested on macOS (Apple Silicon).

Closes #1620.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playback reliability for cross-origin media streams by adjusting CORS behavior to allow credential-less access for media.
  * Updated video/audio pipeline handling to prevent silent audio when a previously loaded non-blob source was processed in no-CORS mode.
  * Ensured existing same-origin and queued playback continues to work as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->