### PR TITLE
reliable scrobbler implementation with morphe parity

### DIFF
--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -784,6 +784,7 @@
           "api-settings": "Last.fm API Settings",
           "now-playing": "Send now playing",
           "love-on-like": "Love on like",
+          "force-scrobble-on-like": "Force scrobble on like",
           "timing": "Scrobble timing"
         },
         "listenbrainz": {

--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -784,7 +784,6 @@
           "api-settings": "Last.fm API Settings",
           "now-playing": "Send now playing",
           "love-on-like": "Love on like",
-          "force-scrobble-on-like": "Force scrobble on like",
           "timing": "Scrobble timing"
         },
         "listenbrainz": {

--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -781,14 +781,23 @@
       },
       "menu": {
         "lastfm": {
-          "api-settings": "Last.fm API Settings"
+          "api-settings": "Last.fm API Settings",
+          "now-playing": "Send now playing",
+          "love-on-like": "Love on like",
+          "timing": "Scrobble timing"
         },
         "listenbrainz": {
-          "token": "Enter ListenBrainz user token"
+          "token": "Enter ListenBrainz user token",
+          "now-playing": "Send now playing",
+          "love-on-like": "Love on like",
+          "timing": "Scrobble timing"
         },
         "scrobble-alternative-title": "Use alternative titles",
         "scrobble-alternative-artist": "Use alternative artists",
-        "scrobble-other-media": "Scrobble other media"
+        "scrobble-other-media": "Scrobble other media",
+        "metadata-cleanup": "Clean up metadata",
+        "parse-title": "Parse artist from title",
+        "custom-regex": "Custom cleanup regex"
       },
       "name": "Scrobbler",
       "prompt": {
@@ -801,6 +810,16 @@
             "label": "Enter your ListenBrainz user token:",
             "title": "ListenBrainz token"
           }
+        },
+        "custom-regex": {
+          "label": "Regex removed from title/artist/album:",
+          "title": "Custom cleanup regex"
+        },
+        "timing": {
+          "title": "Scrobble timing",
+          "min-duration": "Minimum song duration (seconds)",
+          "delay-percent": "Scrobble at (% of track)",
+          "delay-seconds": "Scrobble after at most (seconds)"
         }
       }
     },

--- a/src/plugins/downloader/main/index.ts
+++ b/src/plugins/downloader/main/index.ts
@@ -24,7 +24,8 @@ import { t } from '@/i18n';
 import { getNetFetchAsFetch } from '@/plugins/utils/main';
 import {
   registerCallback,
-  cleanupName,
+  cleanupTitle,
+  cleanupArtist,
   getImage,
   MediaType,
   type SongInfo,
@@ -857,8 +858,8 @@ const getVideoId = (url: URL | string): string | null => {
 
 const getMetadata = (info: YTMusic.TrackInfo): CustomSongInfo => ({
   videoId: info.basic_info.id!,
-  title: cleanupName(info.basic_info.title!),
-  artist: cleanupName(info.basic_info.author!),
+  title: cleanupTitle(info.basic_info.title!),
+  artist: cleanupArtist(info.basic_info.author!),
   album: info.player_overlays?.browser_media_session?.as(
     YTNodes.BrowserMediaSession,
   ).album?.text,

--- a/src/plugins/scrobbler/index.ts
+++ b/src/plugins/scrobbler/index.ts
@@ -107,14 +107,6 @@ export interface ScrobblerPluginConfig {
        * @default false
        */
       loveOnLike: boolean;
-      /**
-       * Immediately scrobble a track (bypassing the delay) when it is liked,
-       * instead of waiting for the usual threshold. Only applies if
-       * loveOnLike is enabled.
-       *
-       * @default false
-       */
-      forceScrobbleOnLike: boolean;
     };
     listenbrainz: {
       /**
@@ -159,8 +151,7 @@ export interface ScrobblerPluginConfig {
       delaySeconds: number;
       /**
        * Submit positive feedback to ListenBrainz when a track is liked in the
-       * player. Liking a track this way always forces an immediate scrobble,
-       * since feedback requires the track to have already been scrobbled.
+       * player.
        *
        * @default false
        */
@@ -190,7 +181,6 @@ export const defaultConfig: ScrobblerPluginConfig = {
       delayPercent: 50,
       delaySeconds: 240,
       loveOnLike: false,
-      forceScrobbleOnLike: false,
     },
     listenbrainz: {
       enabled: false,

--- a/src/plugins/scrobbler/index.ts
+++ b/src/plugins/scrobbler/index.ts
@@ -24,6 +24,25 @@ export interface ScrobblerPluginConfig {
    * @default true
    */
   alternativeArtist: boolean;
+  /**
+   * Apply metadata cleanup (strip suffixes, custom regex) before scrobbling
+   *
+   * @default true
+   */
+  metadataCleanup: boolean;
+  /**
+   * Parse "Artist - Title" out of the title field when the artist is unreliable.
+   * Off by default: it rewrites the artist for any title containing " - ".
+   *
+   * @default false
+   */
+  parseTitle: boolean;
+  /**
+   * Extra user-defined regex removed from title/artist/album (empty = disabled)
+   *
+   * @default ''
+   */
+  customRegex: string;
   scrobblers: {
     lastfm: {
       /**
@@ -58,6 +77,36 @@ export interface ScrobblerPluginConfig {
        * @default 'a5d2a36fdf64819290f6982481eaffa2'
        */
       secret: string;
+      /**
+       * Send "now playing" updates to Last.fm
+       *
+       * @default true
+       */
+      nowPlaying: boolean;
+      /**
+       * Skip scrobbling tracks shorter than this many seconds
+       *
+       * @default 30
+       */
+      minSongDuration: number;
+      /**
+       * Scrobble once this percentage of the track has played
+       *
+       * @default 50
+       */
+      delayPercent: number;
+      /**
+       * Scrobble at the latest after this many seconds
+       *
+       * @default 240
+       */
+      delaySeconds: number;
+      /**
+       * Love a track on Last.fm when it is liked in the player
+       *
+       * @default false
+       */
+      loveOnLike: boolean;
     };
     listenbrainz: {
       /**
@@ -76,6 +125,36 @@ export interface ScrobblerPluginConfig {
        * @default 'https://api.listenbrainz.org/1/'
        */
       apiRoot: string;
+      /**
+       * Send "playing now" updates to ListenBrainz
+       *
+       * @default true
+       */
+      nowPlaying: boolean;
+      /**
+       * Skip scrobbling tracks shorter than this many seconds
+       *
+       * @default 30
+       */
+      minSongDuration: number;
+      /**
+       * Scrobble once this percentage of the track has played
+       *
+       * @default 50
+       */
+      delayPercent: number;
+      /**
+       * Scrobble at the latest after this many seconds
+       *
+       * @default 240
+       */
+      delaySeconds: number;
+      /**
+       * Submit positive feedback to ListenBrainz when a track is liked in the player
+       *
+       * @default false
+       */
+      loveOnLike: boolean;
     };
   };
 }
@@ -85,6 +164,9 @@ export const defaultConfig: ScrobblerPluginConfig = {
   scrobbleOtherMedia: true,
   alternativeTitles: true,
   alternativeArtist: true,
+  metadataCleanup: true,
+  parseTitle: false,
+  customRegex: '',
   scrobblers: {
     lastfm: {
       enabled: false,
@@ -93,11 +175,21 @@ export const defaultConfig: ScrobblerPluginConfig = {
       apiRoot: 'https://ws.audioscrobbler.com/2.0/',
       apiKey: '04d76faaac8726e60988e14c105d421a',
       secret: 'a5d2a36fdf64819290f6982481eaffa2',
+      nowPlaying: true,
+      minSongDuration: 30,
+      delayPercent: 50,
+      delaySeconds: 240,
+      loveOnLike: false,
     },
     listenbrainz: {
       enabled: false,
       token: undefined,
       apiRoot: 'https://api.listenbrainz.org/1/',
+      nowPlaying: true,
+      minSongDuration: 30,
+      delayPercent: 50,
+      delaySeconds: 240,
+      loveOnLike: false,
     },
   },
 };

--- a/src/plugins/scrobbler/index.ts
+++ b/src/plugins/scrobbler/index.ts
@@ -107,6 +107,14 @@ export interface ScrobblerPluginConfig {
        * @default false
        */
       loveOnLike: boolean;
+      /**
+       * Immediately scrobble a track (bypassing the delay) when it is liked,
+       * instead of waiting for the usual threshold. Only applies if
+       * loveOnLike is enabled.
+       *
+       * @default false
+       */
+      forceScrobbleOnLike: boolean;
     };
     listenbrainz: {
       /**
@@ -150,7 +158,9 @@ export interface ScrobblerPluginConfig {
        */
       delaySeconds: number;
       /**
-       * Submit positive feedback to ListenBrainz when a track is liked in the player
+       * Submit positive feedback to ListenBrainz when a track is liked in the
+       * player. Liking a track this way always forces an immediate scrobble,
+       * since feedback requires the track to have already been scrobbled.
        *
        * @default false
        */
@@ -180,6 +190,7 @@ export const defaultConfig: ScrobblerPluginConfig = {
       delayPercent: 50,
       delaySeconds: 240,
       loveOnLike: false,
+      forceScrobbleOnLike: false,
     },
     listenbrainz: {
       enabled: false,

--- a/src/plugins/scrobbler/main.ts
+++ b/src/plugins/scrobbler/main.ts
@@ -1,13 +1,10 @@
 import { type BrowserWindow } from 'electron';
 
-import {
-  registerCallback,
-  MediaType,
-  type SongInfo,
-  SongInfoEvent,
-} from '@/providers/song-info';
+import { registerCallback, type SongInfo } from '@/providers/song-info';
+import { LikeType } from '@/types/datahost-get-state';
 import { createBackend } from '@/utils';
 
+import { ScrobbleManager } from './scrobble-manager';
 import { LastFmScrobbler } from './services/lastfm';
 import { ListenbrainzScrobbler } from './services/listenbrainz';
 
@@ -32,6 +29,7 @@ export const backend = createBackend<
       setConfig: SetConfType,
     ): Promise<void>;
     setConfig?: SetConfType;
+    manager?: ScrobbleManager;
   },
   ScrobblerPluginConfig
 >({
@@ -62,56 +60,38 @@ export const backend = createBackend<
     }
   },
 
-  async start({ getConfig, setConfig, window }) {
+  async start({ getConfig, setConfig, window, ipc }) {
     const config = (this.config = await getConfig());
-    // This will store the timeout that will trigger addScrobble
-    let scrobbleTimer: NodeJS.Timeout | undefined;
 
     this.window = window;
     this.toggleScrobblers(config, window);
     await this.createSessions(config, setConfig);
     this.setConfig = setConfig;
 
+    const manager = (this.manager = new ScrobbleManager(
+      this.enabledScrobblers,
+      config,
+      setConfig,
+    ));
+
     registerCallback((songInfo: SongInfo, event) => {
-      if (event === SongInfoEvent.TimeChanged) return;
-      // Set remove the old scrobble timer
-      clearTimeout(scrobbleTimer);
-      if (!songInfo.isPaused) {
-        const configNonnull = this.config!;
-        // Scrobblers normally have no trouble working with official music videos
-        if (
-          !configNonnull.scrobbleOtherMedia &&
-          songInfo.mediaType !== MediaType.Audio &&
-          songInfo.mediaType !== MediaType.OriginalMusicVideo
-        ) {
-          return;
-        }
+      manager.onSongInfo(songInfo, event);
+    });
 
-        // Scrobble when the song is halfway through, or has passed the 4-minute mark
-        const scrobbleTime = Math.min(
-          Math.ceil(songInfo.songDuration / 2),
-          4 * 60,
-        );
-        if (scrobbleTime > (songInfo.elapsedSeconds ?? 0)) {
-          // Scrobble still needs to happen
-          const timeToWait =
-            (scrobbleTime - (songInfo.elapsedSeconds ?? 0)) * 1000;
-          scrobbleTimer = setTimeout(
-            (info, config) => {
-              this.enabledScrobblers.forEach((scrobbler) =>
-                scrobbler.addScrobble(info, config, setConfig),
-              );
-            },
-            timeToWait,
-            songInfo,
-            configNonnull,
-          );
-        }
+    // The renderer emits an initial like-status per song plus one on every
+    // toggle. Dedupe by video + status and skip the spurious unlove on first
+    // load, so only genuine like/unlike actions reach the scrobblers.
+    let lastLikeVideoId: string | undefined;
+    let lastLikeStatus: LikeType | undefined;
+    ipc.on('peard:like-changed', (status: LikeType) => {
+      const videoId = manager.currentVideoId;
+      if (videoId === lastLikeVideoId && status === lastLikeStatus) return;
+      const firstForSong = videoId !== lastLikeVideoId;
+      lastLikeVideoId = videoId;
+      lastLikeStatus = status;
 
-        this.enabledScrobblers.forEach((scrobbler) =>
-          scrobbler.setNowPlaying(songInfo, configNonnull, setConfig),
-        );
-      }
+      if (status === LikeType.Like) manager.love();
+      else if (!firstForSong) manager.unlove();
     });
   },
 
@@ -138,5 +118,6 @@ export const backend = createBackend<
     }
 
     this.config = newConfig;
+    this.manager?.updateConfig(newConfig);
   },
 });

--- a/src/plugins/scrobbler/main.ts
+++ b/src/plugins/scrobbler/main.ts
@@ -78,6 +78,8 @@ export const backend = createBackend<
       manager.onSongInfo(songInfo, event);
     });
 
+    ipc.on('peard:video-ended', () => manager.onEnded());
+
     // The renderer emits an initial like-status per song plus one on every
     // toggle. Dedupe by video + status and skip the spurious unlove on first
     // load, so only genuine like/unlike actions reach the scrobblers.

--- a/src/plugins/scrobbler/main.ts
+++ b/src/plugins/scrobbler/main.ts
@@ -92,8 +92,9 @@ export const backend = createBackend<
       lastLikeVideoId = videoId;
       lastLikeStatus = status;
 
+      if (firstForSong) return;
       if (status === LikeType.Like) manager.love();
-      else if (!firstForSong) manager.unlove();
+      else manager.unlove();
     });
   },
 

--- a/src/plugins/scrobbler/menu.ts
+++ b/src/plugins/scrobbler/menu.ts
@@ -235,6 +235,15 @@ export const onMenu = async ({
           },
         },
         {
+          label: t('plugins.scrobbler.menu.lastfm.force-scrobble-on-like'),
+          type: 'checkbox',
+          checked: Boolean(config.scrobblers.lastfm?.forceScrobbleOnLike),
+          click(item) {
+            config.scrobblers.lastfm.forceScrobbleOnLike = item.checked;
+            setConfig(config);
+          },
+        },
+        {
           label: t('plugins.scrobbler.menu.lastfm.timing'),
           click() {
             promptTimingOptions('lastfm', config, setConfig, window);

--- a/src/plugins/scrobbler/menu.ts
+++ b/src/plugins/scrobbler/menu.ts
@@ -235,15 +235,6 @@ export const onMenu = async ({
           },
         },
         {
-          label: t('plugins.scrobbler.menu.lastfm.force-scrobble-on-like'),
-          type: 'checkbox',
-          checked: Boolean(config.scrobblers.lastfm?.forceScrobbleOnLike),
-          click(item) {
-            config.scrobblers.lastfm.forceScrobbleOnLike = item.checked;
-            setConfig(config);
-          },
-        },
-        {
           label: t('plugins.scrobbler.menu.lastfm.timing'),
           click() {
             promptTimingOptions('lastfm', config, setConfig, window);

--- a/src/plugins/scrobbler/menu.ts
+++ b/src/plugins/scrobbler/menu.ts
@@ -78,6 +78,72 @@ async function promptListenbrainzOptions(
   }
 }
 
+async function promptCustomRegex(
+  options: ScrobblerPluginConfig,
+  setConfig: SetConfType,
+  window: BrowserWindow,
+) {
+  const output = await prompt(
+    {
+      title: t('plugins.scrobbler.prompt.custom-regex.title'),
+      label: t('plugins.scrobbler.prompt.custom-regex.label'),
+      type: 'input',
+      value: options.customRegex,
+      ...promptOptions(),
+    },
+    window,
+  );
+
+  if (output !== null) {
+    options.customRegex = output;
+    setConfig(options);
+  }
+}
+
+async function promptTimingOptions(
+  scrobbler: 'lastfm' | 'listenbrainz',
+  options: ScrobblerPluginConfig,
+  setConfig: SetConfType,
+  window: BrowserWindow,
+) {
+  const target = options.scrobblers[scrobbler];
+  const output = await prompt(
+    {
+      title: t('plugins.scrobbler.prompt.timing.title'),
+      label: t('plugins.scrobbler.prompt.timing.title'),
+      type: 'multiInput',
+      multiInputOptions: [
+        {
+          label: t('plugins.scrobbler.prompt.timing.min-duration'),
+          value: String(target.minSongDuration),
+          inputAttrs: { type: 'number', min: '0' },
+        },
+        {
+          label: t('plugins.scrobbler.prompt.timing.delay-percent'),
+          value: String(target.delayPercent),
+          inputAttrs: { type: 'number', min: '0', max: '100' },
+        },
+        {
+          label: t('plugins.scrobbler.prompt.timing.delay-seconds'),
+          value: String(target.delaySeconds),
+          inputAttrs: { type: 'number', min: '0' },
+        },
+      ],
+      resizable: true,
+      height: 360,
+      ...promptOptions(),
+    },
+    window,
+  );
+
+  if (output) {
+    if (output[0]) target.minSongDuration = Number(output[0]);
+    if (output[1]) target.delayPercent = Number(output[1]);
+    if (output[2]) target.delaySeconds = Number(output[2]);
+    setConfig(options);
+  }
+}
+
 export const onMenu = async ({
   window,
   getConfig,
@@ -114,6 +180,30 @@ export const onMenu = async ({
       },
     },
     {
+      label: t('plugins.scrobbler.menu.metadata-cleanup'),
+      type: 'checkbox',
+      checked: Boolean(config.metadataCleanup),
+      click(item) {
+        config.metadataCleanup = item.checked;
+        setConfig(config);
+      },
+    },
+    {
+      label: t('plugins.scrobbler.menu.parse-title'),
+      type: 'checkbox',
+      checked: Boolean(config.parseTitle),
+      click(item) {
+        config.parseTitle = item.checked;
+        setConfig(config);
+      },
+    },
+    {
+      label: t('plugins.scrobbler.menu.custom-regex'),
+      click() {
+        promptCustomRegex(config, setConfig, window);
+      },
+    },
+    {
       label: 'Last.fm',
       submenu: [
         {
@@ -124,6 +214,30 @@ export const onMenu = async ({
             backend.toggleScrobblers(config, window);
             config.scrobblers.lastfm.enabled = item.checked;
             setConfig(config);
+          },
+        },
+        {
+          label: t('plugins.scrobbler.menu.lastfm.now-playing'),
+          type: 'checkbox',
+          checked: Boolean(config.scrobblers.lastfm?.nowPlaying),
+          click(item) {
+            config.scrobblers.lastfm.nowPlaying = item.checked;
+            setConfig(config);
+          },
+        },
+        {
+          label: t('plugins.scrobbler.menu.lastfm.love-on-like'),
+          type: 'checkbox',
+          checked: Boolean(config.scrobblers.lastfm?.loveOnLike),
+          click(item) {
+            config.scrobblers.lastfm.loveOnLike = item.checked;
+            setConfig(config);
+          },
+        },
+        {
+          label: t('plugins.scrobbler.menu.lastfm.timing'),
+          click() {
+            promptTimingOptions('lastfm', config, setConfig, window);
           },
         },
         {
@@ -145,6 +259,30 @@ export const onMenu = async ({
             backend.toggleScrobblers(config, window);
             config.scrobblers.listenbrainz.enabled = item.checked;
             setConfig(config);
+          },
+        },
+        {
+          label: t('plugins.scrobbler.menu.listenbrainz.now-playing'),
+          type: 'checkbox',
+          checked: Boolean(config.scrobblers.listenbrainz?.nowPlaying),
+          click(item) {
+            config.scrobblers.listenbrainz.nowPlaying = item.checked;
+            setConfig(config);
+          },
+        },
+        {
+          label: t('plugins.scrobbler.menu.listenbrainz.love-on-like'),
+          type: 'checkbox',
+          checked: Boolean(config.scrobblers.listenbrainz?.loveOnLike),
+          click(item) {
+            config.scrobblers.listenbrainz.loveOnLike = item.checked;
+            setConfig(config);
+          },
+        },
+        {
+          label: t('plugins.scrobbler.menu.listenbrainz.timing'),
+          click() {
+            promptTimingOptions('listenbrainz', config, setConfig, window);
           },
         },
         {

--- a/src/plugins/scrobbler/scrobble-manager.ts
+++ b/src/plugins/scrobbler/scrobble-manager.ts
@@ -259,11 +259,17 @@ export class ScrobbleManager {
       this.cancelTimer(name);
       if (state.timerStartedAt !== 0) {
         state.remainingMs -= Date.now() - state.timerStartedAt;
-        if (state.remainingMs < 0) state.remainingMs = 0;
         state.timerStartedAt = 0;
-        scrobblerDebug(
-          `[${name}] paused, ${secs(state.remainingMs)} remaining`,
-        );
+        if (state.remainingMs <= 0) {
+          scrobblerDebug(
+            `[${name}] threshold reached at pause, scrobbling now`,
+          );
+          this.scrobble(name);
+        } else {
+          scrobblerDebug(
+            `[${name}] paused, ${secs(state.remainingMs)} remaining`,
+          );
+        }
       }
     });
   }

--- a/src/plugins/scrobbler/scrobble-manager.ts
+++ b/src/plugins/scrobbler/scrobble-manager.ts
@@ -311,23 +311,7 @@ export class ScrobbleManager {
   love(): void {
     if (!this.currentSongInfo) return;
     this.eachService((name, scrobbler) => {
-      const cfg = this.config.scrobblers[name];
-      if (!cfg.loveOnLike) return;
-
-      const forceScrobble =
-        name === 'listenbrainz' ||
-        this.config.scrobblers.lastfm.forceScrobbleOnLike;
-      const state = this.timerFor(name);
-      if (
-        forceScrobble &&
-        this.songStarted &&
-        !state.scrobbled &&
-        this.currentSongInfo!.songDuration > cfg.minSongDuration
-      ) {
-        scrobblerDebug(`[${name}] forcing scrobble on like`);
-        this.scrobble(name);
-      }
-
+      if (!this.config.scrobblers[name].loveOnLike) return;
       scrobblerDebug(`[${name}] love "${this.currentSongInfo!.title}"`);
       scrobbler.love(this.currentSongInfo!, this.config, this.setConfig);
     });
@@ -348,8 +332,15 @@ export class ScrobbleManager {
   }
 
   private resolveSongInfo(songInfo: SongInfo): SongInfo {
-    let title = songInfo.title;
-    let artist = songInfo.artist;
+    let title =
+      this.config.alternativeTitles && songInfo.alternativeTitle !== undefined
+        ? songInfo.alternativeTitle
+        : songInfo.title;
+    const firstTag = songInfo.tags?.at(0);
+    let artist =
+      this.config.alternativeArtist && firstTag !== undefined
+        ? firstTag
+        : songInfo.artist;
     let album = songInfo.album ?? undefined;
 
     if (this.config.parseTitle) {
@@ -375,6 +366,13 @@ export class ScrobbleManager {
       }
     }
 
-    return { ...songInfo, title, artist, album };
+    return {
+      ...songInfo,
+      title,
+      artist,
+      album,
+      alternativeTitle: undefined,
+      tags: undefined,
+    };
   }
 }

--- a/src/plugins/scrobbler/scrobble-manager.ts
+++ b/src/plugins/scrobbler/scrobble-manager.ts
@@ -1,3 +1,5 @@
+import is from 'electron-is';
+
 import { MediaType, SongInfoEvent, type SongInfo } from '@/providers/song-info';
 
 import type { ScrobblerPluginConfig } from './index';
@@ -5,6 +7,11 @@ import type { SetConfType } from './main';
 import type { ScrobblerBase } from './services/base';
 
 type ScrobblerName = keyof ScrobblerPluginConfig['scrobblers'];
+
+// Debug logging is only emitted in development (`pnpm dev`).
+export const scrobblerDebug = (...args: unknown[]): void => {
+  if (is.dev()) console.log('[YTMusic] [Scrobbler]', ...args);
+};
 
 interface ServiceTimer {
   scrobbled: boolean;
@@ -82,9 +89,19 @@ export class ScrobbleManager {
       // Skipped media clears the current song so later play/pause events
       // never act on the previously playing track.
       this.currentSongInfo = skip ? undefined : resolved;
-      if (!skip && this.isPlaying) {
-        this.onSongStart(songInfo.elapsedSeconds ?? 0);
+
+      if (skip) {
+        scrobblerDebug(
+          `skipped media (mediaType=${songInfo.mediaType}), not scrobbling`,
+        );
+        return;
       }
+
+      scrobblerDebug(
+        `new song: "${resolved.title}" - "${resolved.artist}" ` +
+          `(duration=${resolved.songDuration}s, playing=${this.isPlaying})`,
+      );
+      if (this.isPlaying) this.onSongStart(songInfo.elapsedSeconds ?? 0);
       return;
     }
 
@@ -95,6 +112,10 @@ export class ScrobbleManager {
     this.currentSongInfo = resolved;
 
     if (improved && this.songStarted && this.isPlaying) {
+      scrobblerDebug(
+        `metadata improved for "${resolved.title}": ` +
+          `duration now ${resolved.songDuration}s, (re)starting timers`,
+      );
       this.eachService((name, scrobbler) => {
         const state = this.timerFor(name);
         if (!state.scrobbled && !state.timer && state.timerStartedAt === 0) {
@@ -134,9 +155,14 @@ export class ScrobbleManager {
     this.songStarted = true;
     const nowSeconds = Date.now() / 1000;
     this.songStartedAtSeconds = nowSeconds - elapsedSeconds;
+    scrobblerDebug(
+      `song started (elapsed=${elapsedSeconds}s, ` +
+        `startedAt=${Math.trunc(this.songStartedAtSeconds)})`,
+    );
     this.eachService((name, scrobbler) => {
       this.startTimer(name);
       if (this.config.scrobblers[name].nowPlaying) {
+        scrobblerDebug(`[${name}] sending now playing`);
         scrobbler.setNowPlaying(
           this.currentSongInfo!,
           this.config,
@@ -152,6 +178,9 @@ export class ScrobbleManager {
       if (!state.scrobbled && state.remainingMs > 0) {
         this.cancelTimer(name);
         state.timerStartedAt = Date.now();
+        scrobblerDebug(
+          `[${name}] resumed, ${Math.trunc(state.remainingMs)}ms remaining`,
+        );
         this.schedule(name, state.remainingMs);
       }
     });
@@ -159,6 +188,7 @@ export class ScrobbleManager {
 
   private onSongPause(): void {
     if (!this.songStarted) return;
+    scrobblerDebug('paused');
     this.pauseTimers();
   }
 
@@ -168,7 +198,13 @@ export class ScrobbleManager {
     const cfg = this.config.scrobblers[name];
     const duration = this.currentSongInfo?.songDuration ?? 0;
 
-    if (duration <= cfg.minSongDuration) return;
+    if (duration <= cfg.minSongDuration) {
+      scrobblerDebug(
+        `[${name}] duration ${duration}s <= min ${cfg.minSongDuration}s, ` +
+          'skipping scrobble',
+      );
+      return;
+    }
 
     const thresholdMs = Math.min(
       duration * 1000 * (cfg.delayPercent / 100),
@@ -179,12 +215,17 @@ export class ScrobbleManager {
     state.remainingMs = thresholdMs - elapsedMs;
 
     if (state.remainingMs <= 0) {
+      scrobblerDebug(`[${name}] threshold already passed, scrobbling now`);
       this.scrobble(name);
       return;
     }
 
     if (this.isPlaying) {
       state.timerStartedAt = Date.now();
+      scrobblerDebug(
+        `[${name}] scrobble in ${Math.trunc(state.remainingMs)}ms ` +
+          `(threshold=${Math.trunc(thresholdMs)}ms, elapsed=${Math.trunc(elapsedMs)}ms)`,
+      );
       this.schedule(name, state.remainingMs);
     } else {
       state.timerStartedAt = 0;
@@ -199,6 +240,9 @@ export class ScrobbleManager {
         state.remainingMs -= Date.now() - state.timerStartedAt;
         if (state.remainingMs < 0) state.remainingMs = 0;
         state.timerStartedAt = 0;
+        scrobblerDebug(
+          `[${name}] timer paused, ${Math.trunc(state.remainingMs)}ms remaining`,
+        );
       }
     });
   }
@@ -230,9 +274,13 @@ export class ScrobbleManager {
 
   private scrobble(name: ScrobblerName): void {
     const state = this.timerFor(name);
-    if (state.scrobbled) return;
+    if (state.scrobbled) {
+      scrobblerDebug(`[${name}] already scrobbled, skipping duplicate`);
+      return;
+    }
     const scrobbler = this.scrobblers.get(name);
     if (!scrobbler || !this.currentSongInfo) return;
+    scrobblerDebug(`[${name}] scrobbling "${this.currentSongInfo.title}"`);
     scrobbler.addScrobble(
       this.currentSongInfo,
       this.config,
@@ -246,6 +294,7 @@ export class ScrobbleManager {
     if (!this.currentSongInfo) return;
     this.eachService((name, scrobbler) => {
       if (this.config.scrobblers[name].loveOnLike) {
+        scrobblerDebug(`[${name}] love "${this.currentSongInfo!.title}"`);
         scrobbler.love(this.currentSongInfo!, this.config, this.setConfig);
       }
     });
@@ -255,6 +304,7 @@ export class ScrobbleManager {
     if (!this.currentSongInfo) return;
     this.eachService((name, scrobbler) => {
       if (this.config.scrobblers[name].loveOnLike) {
+        scrobblerDebug(`[${name}] unlove "${this.currentSongInfo!.title}"`);
         scrobbler.unlove(this.currentSongInfo!, this.config, this.setConfig);
       }
     });

--- a/src/plugins/scrobbler/scrobble-manager.ts
+++ b/src/plugins/scrobbler/scrobble-manager.ts
@@ -13,6 +13,8 @@ export const scrobblerDebug = (...args: unknown[]): void => {
   if (is.dev()) console.log('[YTMusic] [Scrobbler]', ...args);
 };
 
+const secs = (ms: number): string => `${Math.round(ms / 1000)}s`;
+
 interface ServiceTimer {
   scrobbled: boolean;
   remainingMs: number;
@@ -45,12 +47,6 @@ export class ScrobbleManager {
   onSongInfo(songInfo: SongInfo, event: SongInfoEvent): void {
     const elapsed = songInfo.elapsedSeconds ?? 0;
 
-    if (event === SongInfoEvent.Ended) {
-      scrobblerDebug('video ended event received');
-      if (this.songStarted) this.endedReached = true;
-      return;
-    }
-
     if (event === SongInfoEvent.TimeChanged) {
       this.replayCheck(elapsed);
     } else if (event === SongInfoEvent.VideoSrcChanged) {
@@ -60,6 +56,11 @@ export class ScrobbleManager {
     }
 
     this.lastElapsedSeconds = elapsed;
+  }
+
+  onEnded(): void {
+    scrobblerDebug('video ended event received');
+    if (this.songStarted) this.endedReached = true;
   }
 
   // A finished track ('ended') whose position then moves backward is a replay.
@@ -99,7 +100,7 @@ export class ScrobbleManager {
     const resolved = this.resolveSongInfo(songInfo);
     const key = resolved.videoId || `${resolved.artist}|${resolved.title}`;
     const skip = this.shouldSkipMedia(songInfo);
-    this.isPlaying = !songInfo.isPaused;
+    this.isPlaying = !(songInfo.isPaused ?? true);
 
     if (key !== this.currentKey) {
       this.stopTimers();
@@ -162,7 +163,7 @@ export class ScrobbleManager {
   }
 
   private handlePlayState(songInfo: SongInfo): void {
-    this.isPlaying = !songInfo.isPaused;
+    this.isPlaying = !(songInfo.isPaused ?? true);
     if (!this.currentSongInfo) return;
 
     const elapsed = songInfo.elapsedSeconds ?? 0;
@@ -204,7 +205,7 @@ export class ScrobbleManager {
         this.cancelTimer(name);
         state.timerStartedAt = Date.now();
         scrobblerDebug(
-          `[${name}] resumed, ${Math.trunc(state.remainingMs)}ms remaining`,
+          `[${name}] resumed, ${secs(state.remainingMs)} remaining`,
         );
         this.schedule(name, state.remainingMs);
       }
@@ -248,8 +249,8 @@ export class ScrobbleManager {
     if (this.isPlaying) {
       state.timerStartedAt = Date.now();
       scrobblerDebug(
-        `[${name}] scrobble in ${Math.trunc(state.remainingMs)}ms ` +
-          `(threshold=${Math.trunc(thresholdMs)}ms, elapsed=${Math.trunc(elapsedMs)}ms)`,
+        `[${name}] scrobble in ${secs(state.remainingMs)} ` +
+          `(threshold=${secs(thresholdMs)}, elapsed=${secs(elapsedMs)})`,
       );
       this.schedule(name, state.remainingMs);
     } else {
@@ -260,13 +261,14 @@ export class ScrobbleManager {
   private pauseTimers(): void {
     this.eachService((name) => {
       const state = this.timerFor(name);
+      if (state.scrobbled) return;
       this.cancelTimer(name);
       if (state.timerStartedAt !== 0) {
         state.remainingMs -= Date.now() - state.timerStartedAt;
         if (state.remainingMs < 0) state.remainingMs = 0;
         state.timerStartedAt = 0;
         scrobblerDebug(
-          `[${name}] timer paused, ${Math.trunc(state.remainingMs)}ms remaining`,
+          `[${name}] paused, ${secs(state.remainingMs)} remaining`,
         );
       }
     });
@@ -312,7 +314,11 @@ export class ScrobbleManager {
       this.setConfig,
       this.songStartedAtSeconds,
     );
+    // Done for this play: stop tracking so pause/resume no longer touch it.
+    this.cancelTimer(name);
     state.scrobbled = true;
+    state.remainingMs = 0;
+    state.timerStartedAt = 0;
   }
 
   love(): void {

--- a/src/plugins/scrobbler/scrobble-manager.ts
+++ b/src/plugins/scrobbler/scrobble-manager.ts
@@ -31,7 +31,6 @@ export class ScrobbleManager {
   private songStartedAtSeconds = 0;
   private songStarted = false;
   private isPlaying = false;
-  private lastElapsedSeconds = 0;
   private endedReached = false;
 
   constructor(
@@ -45,38 +44,15 @@ export class ScrobbleManager {
   }
 
   onSongInfo(songInfo: SongInfo, event: SongInfoEvent): void {
-    const elapsed = songInfo.elapsedSeconds ?? 0;
-
-    if (event === SongInfoEvent.TimeChanged) {
-      this.replayCheck(elapsed);
-    } else if (event === SongInfoEvent.VideoSrcChanged) {
+    if (event === SongInfoEvent.VideoSrcChanged) {
       this.handleMetadata(songInfo);
     } else if (event === SongInfoEvent.PlayOrPaused) {
       this.handlePlayState(songInfo);
     }
-
-    this.lastElapsedSeconds = elapsed;
   }
 
   onEnded(): void {
-    scrobblerDebug('video ended event received');
     if (this.songStarted) this.endedReached = true;
-  }
-
-  // A finished track ('ended') whose position then moves backward is a replay.
-  private replayCheck(elapsed: number): boolean {
-    if (!this.songStarted || !this.currentSongInfo) return false;
-    if (!this.endedReached || elapsed >= this.lastElapsedSeconds) return false;
-
-    scrobblerDebug(
-      `replay detected (${Math.trunc(this.lastElapsedSeconds)}s -> ${elapsed}s), re-arming`,
-    );
-    this.endedReached = false;
-    this.eachService((name) => {
-      this.timerFor(name).scrobbled = false;
-    });
-    this.onSongStart(elapsed);
-    return true;
   }
 
   private timerFor(name: ScrobblerName): ServiceTimer {
@@ -131,7 +107,19 @@ export class ScrobbleManager {
     }
 
     if (skip || !this.currentSongInfo) return;
-    if (this.replayCheck(songInfo.elapsedSeconds ?? 0)) return;
+
+    // Same videoId re-firing after the track ended is a repeat-one loop.
+    if (this.endedReached) {
+      this.endedReached = false;
+      scrobblerDebug(`replay detected (loop), re-arming "${resolved.title}"`);
+      this.currentSongInfo = resolved;
+      this.eachService((name) => {
+        this.timerFor(name).scrobbled = false;
+      });
+      if (this.isPlaying) this.onSongStart(songInfo.elapsedSeconds ?? 0);
+      else this.songStarted = false;
+      return;
+    }
 
     // Same song, metadata may have improved (e.g. duration was 0 initially).
     const improved = resolved.songDuration > this.currentSongInfo.songDuration;
@@ -168,7 +156,6 @@ export class ScrobbleManager {
 
     const elapsed = songInfo.elapsedSeconds ?? 0;
     if (this.isPlaying) {
-      if (this.replayCheck(elapsed)) return;
       if (!this.songStarted) this.onSongStart(elapsed);
       else this.onSongResume();
     } else {

--- a/src/plugins/scrobbler/scrobble-manager.ts
+++ b/src/plugins/scrobbler/scrobble-manager.ts
@@ -311,10 +311,25 @@ export class ScrobbleManager {
   love(): void {
     if (!this.currentSongInfo) return;
     this.eachService((name, scrobbler) => {
-      if (this.config.scrobblers[name].loveOnLike) {
-        scrobblerDebug(`[${name}] love "${this.currentSongInfo!.title}"`);
-        scrobbler.love(this.currentSongInfo!, this.config, this.setConfig);
+      const cfg = this.config.scrobblers[name];
+      if (!cfg.loveOnLike) return;
+
+      const forceScrobble =
+        name === 'listenbrainz' ||
+        this.config.scrobblers.lastfm.forceScrobbleOnLike;
+      const state = this.timerFor(name);
+      if (
+        forceScrobble &&
+        this.songStarted &&
+        !state.scrobbled &&
+        this.currentSongInfo!.songDuration > cfg.minSongDuration
+      ) {
+        scrobblerDebug(`[${name}] forcing scrobble on like`);
+        this.scrobble(name);
       }
+
+      scrobblerDebug(`[${name}] love "${this.currentSongInfo!.title}"`);
+      scrobbler.love(this.currentSongInfo!, this.config, this.setConfig);
     });
   }
 

--- a/src/plugins/scrobbler/scrobble-manager.ts
+++ b/src/plugins/scrobbler/scrobble-manager.ts
@@ -1,0 +1,297 @@
+import { MediaType, SongInfoEvent, type SongInfo } from '@/providers/song-info';
+
+import type { ScrobblerPluginConfig } from './index';
+import type { SetConfType } from './main';
+import type { ScrobblerBase } from './services/base';
+
+type ScrobblerName = keyof ScrobblerPluginConfig['scrobblers'];
+
+interface ServiceTimer {
+  scrobbled: boolean;
+  remainingMs: number;
+  timerStartedAt: number;
+  timer?: NodeJS.Timeout;
+}
+
+/**
+ * Stateful, per-service scrobble scheduler. Tracks separate timers and
+ * "already scrobbled" flags for each service so seeking, looping and
+ * pause/resume never cause duplicate or lost scrobbles.
+ */
+export class ScrobbleManager {
+  private readonly timers = new Map<ScrobblerName, ServiceTimer>();
+
+  private currentKey?: string;
+  private currentSongInfo?: SongInfo;
+  private songStartedAtSeconds = 0;
+  private songStarted = false;
+  private isPlaying = false;
+
+  constructor(
+    private readonly scrobblers: Map<string, ScrobblerBase>,
+    private config: ScrobblerPluginConfig,
+    private readonly setConfig: SetConfType,
+  ) {}
+
+  updateConfig(config: ScrobblerPluginConfig): void {
+    this.config = config;
+  }
+
+  onSongInfo(songInfo: SongInfo, event: SongInfoEvent): void {
+    if (event === SongInfoEvent.TimeChanged) return;
+
+    if (event === SongInfoEvent.VideoSrcChanged) {
+      this.handleMetadata(songInfo);
+    } else if (event === SongInfoEvent.PlayOrPaused) {
+      this.handlePlayState(songInfo);
+    }
+  }
+
+  private timerFor(name: ScrobblerName): ServiceTimer {
+    let state = this.timers.get(name);
+    if (!state) {
+      state = { scrobbled: false, remainingMs: 0, timerStartedAt: 0 };
+      this.timers.set(name, state);
+    }
+    return state;
+  }
+
+  private eachService(
+    fn: (name: ScrobblerName, scrobbler: ScrobblerBase) => void,
+  ): void {
+    for (const [name, scrobbler] of this.scrobblers) {
+      fn(name as ScrobblerName, scrobbler);
+    }
+  }
+
+  private handleMetadata(songInfo: SongInfo): void {
+    const resolved = this.resolveSongInfo(songInfo);
+    const key = resolved.videoId || `${resolved.artist}|${resolved.title}`;
+    const skip = this.shouldSkipMedia(songInfo);
+    this.isPlaying = !songInfo.isPaused;
+
+    if (key !== this.currentKey) {
+      this.stopTimers();
+      this.eachService((name) => {
+        this.timerFor(name).scrobbled = false;
+      });
+
+      this.currentKey = key;
+      this.songStarted = false;
+
+      // Skipped media clears the current song so later play/pause events
+      // never act on the previously playing track.
+      this.currentSongInfo = skip ? undefined : resolved;
+      if (!skip && this.isPlaying) {
+        this.onSongStart(songInfo.elapsedSeconds ?? 0);
+      }
+      return;
+    }
+
+    if (skip || !this.currentSongInfo) return;
+
+    // Same song, metadata may have improved (e.g. duration was 0 initially).
+    const improved = resolved.songDuration > this.currentSongInfo.songDuration;
+    this.currentSongInfo = resolved;
+
+    if (improved && this.songStarted && this.isPlaying) {
+      this.eachService((name, scrobbler) => {
+        const state = this.timerFor(name);
+        if (!state.scrobbled && !state.timer && state.timerStartedAt === 0) {
+          this.startTimer(name);
+        }
+        if (this.config.scrobblers[name].nowPlaying) {
+          scrobbler.setNowPlaying(resolved, this.config, this.setConfig);
+        }
+      });
+    }
+  }
+
+  private shouldSkipMedia(songInfo: SongInfo): boolean {
+    return (
+      !this.config.scrobbleOtherMedia &&
+      songInfo.mediaType !== MediaType.Audio &&
+      songInfo.mediaType !== MediaType.OriginalMusicVideo
+    );
+  }
+
+  private handlePlayState(songInfo: SongInfo): void {
+    this.isPlaying = !songInfo.isPaused;
+    if (!this.currentSongInfo) return;
+
+    if (this.isPlaying) {
+      if (!this.songStarted) this.onSongStart(songInfo.elapsedSeconds ?? 0);
+      else this.onSongResume();
+    } else {
+      this.onSongPause();
+    }
+  }
+
+  // Anchor the play start to when playback actually begins (minus any elapsed
+  // time already played), so the scrobble threshold is measured correctly even
+  // if the song was loaded paused or play was delayed.
+  private onSongStart(elapsedSeconds: number): void {
+    this.songStarted = true;
+    const nowSeconds = Date.now() / 1000;
+    this.songStartedAtSeconds = nowSeconds - elapsedSeconds;
+    this.eachService((name, scrobbler) => {
+      this.startTimer(name);
+      if (this.config.scrobblers[name].nowPlaying) {
+        scrobbler.setNowPlaying(
+          this.currentSongInfo!,
+          this.config,
+          this.setConfig,
+        );
+      }
+    });
+  }
+
+  private onSongResume(): void {
+    this.eachService((name) => {
+      const state = this.timerFor(name);
+      if (!state.scrobbled && state.remainingMs > 0) {
+        this.cancelTimer(name);
+        state.timerStartedAt = Date.now();
+        this.schedule(name, state.remainingMs);
+      }
+    });
+  }
+
+  private onSongPause(): void {
+    if (!this.songStarted) return;
+    this.pauseTimers();
+  }
+
+  private startTimer(name: ScrobblerName): void {
+    this.cancelTimer(name);
+    const state = this.timerFor(name);
+    const cfg = this.config.scrobblers[name];
+    const duration = this.currentSongInfo?.songDuration ?? 0;
+
+    if (duration <= cfg.minSongDuration) return;
+
+    const thresholdMs = Math.min(
+      duration * 1000 * (cfg.delayPercent / 100),
+      cfg.delaySeconds * 1000,
+    );
+    const startedAtMs = this.songStartedAtSeconds * 1000;
+    const elapsedMs = Math.max(0, Date.now() - startedAtMs);
+    state.remainingMs = thresholdMs - elapsedMs;
+
+    if (state.remainingMs <= 0) {
+      this.scrobble(name);
+      return;
+    }
+
+    if (this.isPlaying) {
+      state.timerStartedAt = Date.now();
+      this.schedule(name, state.remainingMs);
+    } else {
+      state.timerStartedAt = 0;
+    }
+  }
+
+  private pauseTimers(): void {
+    this.eachService((name) => {
+      const state = this.timerFor(name);
+      this.cancelTimer(name);
+      if (state.timerStartedAt !== 0) {
+        state.remainingMs -= Date.now() - state.timerStartedAt;
+        if (state.remainingMs < 0) state.remainingMs = 0;
+        state.timerStartedAt = 0;
+      }
+    });
+  }
+
+  private stopTimers(): void {
+    this.eachService((name) => {
+      const state = this.timerFor(name);
+      this.cancelTimer(name);
+      state.remainingMs = 0;
+      state.timerStartedAt = 0;
+    });
+  }
+
+  private schedule(name: ScrobblerName, delayMs: number): void {
+    const state = this.timerFor(name);
+    state.timer = setTimeout(() => {
+      state.timer = undefined;
+      this.scrobble(name);
+    }, delayMs);
+  }
+
+  private cancelTimer(name: ScrobblerName): void {
+    const state = this.timerFor(name);
+    if (state.timer) {
+      clearTimeout(state.timer);
+      state.timer = undefined;
+    }
+  }
+
+  private scrobble(name: ScrobblerName): void {
+    const state = this.timerFor(name);
+    if (state.scrobbled) return;
+    const scrobbler = this.scrobblers.get(name);
+    if (!scrobbler || !this.currentSongInfo) return;
+    scrobbler.addScrobble(
+      this.currentSongInfo,
+      this.config,
+      this.setConfig,
+      this.songStartedAtSeconds,
+    );
+    state.scrobbled = true;
+  }
+
+  love(): void {
+    if (!this.currentSongInfo) return;
+    this.eachService((name, scrobbler) => {
+      if (this.config.scrobblers[name].loveOnLike) {
+        scrobbler.love(this.currentSongInfo!, this.config, this.setConfig);
+      }
+    });
+  }
+
+  unlove(): void {
+    if (!this.currentSongInfo) return;
+    this.eachService((name, scrobbler) => {
+      if (this.config.scrobblers[name].loveOnLike) {
+        scrobbler.unlove(this.currentSongInfo!, this.config, this.setConfig);
+      }
+    });
+  }
+
+  get currentVideoId(): string | undefined {
+    return this.currentSongInfo?.videoId;
+  }
+
+  private resolveSongInfo(songInfo: SongInfo): SongInfo {
+    let title = songInfo.title;
+    let artist = songInfo.artist;
+    let album = songInfo.album ?? undefined;
+
+    if (this.config.parseTitle) {
+      const idx = title.indexOf(' - ');
+      if (idx > 0 && idx < title.length - 3) {
+        const parsedArtist = title.slice(0, idx).trim();
+        const parsedTrack = title.slice(idx + 3).trim();
+        if (parsedArtist && parsedTrack) {
+          artist = parsedArtist;
+          title = parsedTrack;
+        }
+      }
+    }
+
+    if (this.config.metadataCleanup && this.config.customRegex.trim()) {
+      try {
+        const re = new RegExp(this.config.customRegex, 'gi');
+        title = title.replace(re, '').trim();
+        artist = artist.replace(re, '').trim();
+        if (album) album = album.replace(re, '').trim() || undefined;
+      } catch {
+        // Invalid user regex; leave metadata untouched.
+      }
+    }
+
+    return { ...songInfo, title, artist, album };
+  }
+}

--- a/src/plugins/scrobbler/scrobble-manager.ts
+++ b/src/plugins/scrobbler/scrobble-manager.ts
@@ -8,7 +8,7 @@ import type { ScrobblerBase } from './services/base';
 
 type ScrobblerName = keyof ScrobblerPluginConfig['scrobblers'];
 
-// Debug logging is only emitted in development (`pnpm dev`).
+// Dev-only debug logging.
 export const scrobblerDebug = (...args: unknown[]): void => {
   if (is.dev()) console.log('[YTMusic] [Scrobbler]', ...args);
 };
@@ -20,11 +20,7 @@ interface ServiceTimer {
   timer?: NodeJS.Timeout;
 }
 
-/**
- * Stateful, per-service scrobble scheduler. Tracks separate timers and
- * "already scrobbled" flags for each service so seeking, looping and
- * pause/resume never cause duplicate or lost scrobbles.
- */
+// Per-service scrobble scheduler with independent timers and scrobbled flags.
 export class ScrobbleManager {
   private readonly timers = new Map<ScrobblerName, ServiceTimer>();
 
@@ -33,6 +29,8 @@ export class ScrobbleManager {
   private songStartedAtSeconds = 0;
   private songStarted = false;
   private isPlaying = false;
+  private lastElapsedSeconds = 0;
+  private endedReached = false;
 
   constructor(
     private readonly scrobblers: Map<string, ScrobblerBase>,
@@ -45,13 +43,39 @@ export class ScrobbleManager {
   }
 
   onSongInfo(songInfo: SongInfo, event: SongInfoEvent): void {
-    if (event === SongInfoEvent.TimeChanged) return;
+    const elapsed = songInfo.elapsedSeconds ?? 0;
 
-    if (event === SongInfoEvent.VideoSrcChanged) {
+    if (event === SongInfoEvent.Ended) {
+      scrobblerDebug('video ended event received');
+      if (this.songStarted) this.endedReached = true;
+      return;
+    }
+
+    if (event === SongInfoEvent.TimeChanged) {
+      this.replayCheck(elapsed);
+    } else if (event === SongInfoEvent.VideoSrcChanged) {
       this.handleMetadata(songInfo);
     } else if (event === SongInfoEvent.PlayOrPaused) {
       this.handlePlayState(songInfo);
     }
+
+    this.lastElapsedSeconds = elapsed;
+  }
+
+  // A finished track ('ended') whose position then moves backward is a replay.
+  private replayCheck(elapsed: number): boolean {
+    if (!this.songStarted || !this.currentSongInfo) return false;
+    if (!this.endedReached || elapsed >= this.lastElapsedSeconds) return false;
+
+    scrobblerDebug(
+      `replay detected (${Math.trunc(this.lastElapsedSeconds)}s -> ${elapsed}s), re-arming`,
+    );
+    this.endedReached = false;
+    this.eachService((name) => {
+      this.timerFor(name).scrobbled = false;
+    });
+    this.onSongStart(elapsed);
+    return true;
   }
 
   private timerFor(name: ScrobblerName): ServiceTimer {
@@ -85,9 +109,9 @@ export class ScrobbleManager {
 
       this.currentKey = key;
       this.songStarted = false;
+      this.endedReached = false;
 
-      // Skipped media clears the current song so later play/pause events
-      // never act on the previously playing track.
+      // Clear current song for skipped media so later events don't act on it.
       this.currentSongInfo = skip ? undefined : resolved;
 
       if (skip) {
@@ -106,6 +130,7 @@ export class ScrobbleManager {
     }
 
     if (skip || !this.currentSongInfo) return;
+    if (this.replayCheck(songInfo.elapsedSeconds ?? 0)) return;
 
     // Same song, metadata may have improved (e.g. duration was 0 initially).
     const improved = resolved.songDuration > this.currentSongInfo.songDuration;
@@ -140,17 +165,17 @@ export class ScrobbleManager {
     this.isPlaying = !songInfo.isPaused;
     if (!this.currentSongInfo) return;
 
+    const elapsed = songInfo.elapsedSeconds ?? 0;
     if (this.isPlaying) {
-      if (!this.songStarted) this.onSongStart(songInfo.elapsedSeconds ?? 0);
+      if (this.replayCheck(elapsed)) return;
+      if (!this.songStarted) this.onSongStart(elapsed);
       else this.onSongResume();
     } else {
       this.onSongPause();
     }
   }
 
-  // Anchor the play start to when playback actually begins (minus any elapsed
-  // time already played), so the scrobble threshold is measured correctly even
-  // if the song was loaded paused or play was delayed.
+  // Anchor start to actual playback moment (minus elapsed), not metadata load.
   private onSongStart(elapsedSeconds: number): void {
     this.songStarted = true;
     const nowSeconds = Date.now() / 1000;

--- a/src/plugins/scrobbler/scrobble-manager.ts
+++ b/src/plugins/scrobbler/scrobble-manager.ts
@@ -1,6 +1,13 @@
 import is from 'electron-is';
 
-import { MediaType, SongInfoEvent, type SongInfo } from '@/providers/song-info';
+import {
+  MediaType,
+  SongInfoEvent,
+  cleanupAlbum,
+  cleanupArtist,
+  cleanupTitle,
+  type SongInfo,
+} from '@/providers/song-info';
 
 import type { ScrobblerPluginConfig } from './index';
 import type { SetConfType } from './main';
@@ -355,14 +362,20 @@ export class ScrobbleManager {
       }
     }
 
-    if (this.config.metadataCleanup && this.config.customRegex.trim()) {
-      try {
-        const re = new RegExp(this.config.customRegex, 'gi');
-        title = title.replace(re, '').trim();
-        artist = artist.replace(re, '').trim();
-        if (album) album = album.replace(re, '').trim() || undefined;
-      } catch {
-        // Invalid user regex; leave metadata untouched.
+    if (this.config.metadataCleanup) {
+      title = cleanupTitle(title);
+      artist = cleanupArtist(artist);
+      if (album) album = cleanupAlbum(album) || undefined;
+
+      if (this.config.customRegex.trim()) {
+        try {
+          const re = new RegExp(this.config.customRegex, 'gi');
+          title = title.replace(re, '').trim();
+          artist = artist.replace(re, '').trim();
+          if (album) album = album.replace(re, '').trim() || undefined;
+        } catch {
+          // Invalid user regex; leave metadata untouched.
+        }
       }
     }
 

--- a/src/plugins/scrobbler/services/base.ts
+++ b/src/plugins/scrobbler/services/base.ts
@@ -20,5 +20,18 @@ export abstract class ScrobblerBase {
     songInfo: SongInfo,
     config: ScrobblerPluginConfig,
     setConfig: SetConfType,
+    startedAtSeconds: number,
+  ): void;
+
+  public abstract love(
+    songInfo: SongInfo,
+    config: ScrobblerPluginConfig,
+    setConfig: SetConfType,
+  ): void;
+
+  public abstract unlove(
+    songInfo: SongInfo,
+    config: ScrobblerPluginConfig,
+    setConfig: SetConfType,
   ): void;
 }

--- a/src/plugins/scrobbler/services/lastfm.ts
+++ b/src/plugins/scrobbler/services/lastfm.ts
@@ -100,15 +100,12 @@ export class LastFmScrobbler extends ScrobblerBase {
     config: ScrobblerPluginConfig,
     setConfig: SetConfType,
   ): void {
-    if (!config.scrobblers.lastfm.sessionKey) {
-      return;
-    }
-
-    // This sets the now playing status in last.fm
-    const data = {
-      method: 'track.updateNowPlaying',
-    };
-    this.postSongDataToAPI(songInfo, config, data, setConfig);
+    this.postSongDataToAPI(
+      songInfo,
+      config,
+      { method: 'track.updateNowPlaying' },
+      setConfig,
+    );
   }
 
   override addScrobble(
@@ -117,75 +114,54 @@ export class LastFmScrobbler extends ScrobblerBase {
     setConfig: SetConfType,
     startedAtSeconds: number,
   ): void {
-    if (!config.scrobblers.lastfm.sessionKey) {
-      return;
-    }
-
-    // This adds one scrobbled song to last.fm
-    const data = {
-      method: 'track.scrobble',
-      timestamp: Math.trunc(startedAtSeconds),
-    };
-    this.postSongDataToAPI(songInfo, config, data, setConfig);
+    this.postSongDataToAPI(
+      songInfo,
+      config,
+      { method: 'track.scrobble', timestamp: Math.trunc(startedAtSeconds) },
+      setConfig,
+    );
   }
 
   override love(
     songInfo: SongInfo,
     config: ScrobblerPluginConfig,
-    _setConfig: SetConfType,
+    setConfig: SetConfType,
   ): void {
-    this.postLoveToAPI('track.love', songInfo, config);
+    this.postLoveToAPI('track.love', songInfo, config, setConfig);
   }
 
   override unlove(
     songInfo: SongInfo,
     config: ScrobblerPluginConfig,
-    _setConfig: SetConfType,
+    setConfig: SetConfType,
   ): void {
-    this.postLoveToAPI('track.unlove', songInfo, config);
+    this.postLoveToAPI('track.unlove', songInfo, config, setConfig);
   }
 
-  private postLoveToAPI(
+  private async postLoveToAPI(
     method: string,
     songInfo: SongInfo,
     config: ScrobblerPluginConfig,
-  ): void {
-    const sessionKey = config.scrobblers.lastfm.sessionKey;
-    if (!sessionKey) {
-      return;
+    setConfig: SetConfType,
+  ): Promise<void> {
+    if (!config.scrobblers.lastfm.sessionKey) {
+      await this.createSession(config, setConfig);
     }
-
-    const track =
-      config.alternativeTitles && songInfo.alternativeTitle !== undefined
-        ? songInfo.alternativeTitle
-        : songInfo.title;
-
-    const artist =
-      config.alternativeArtist && songInfo.tags?.at(0) !== undefined
-        ? songInfo.tags?.at(0)
-        : songInfo.artist;
-
-    if (!track || !artist) {
-      return;
-    }
+    if (!config.scrobblers.lastfm.sessionKey) return;
 
     const postData: LastFmLoveData = {
-      track,
-      artist,
+      track: songInfo.title,
+      artist: songInfo.artist,
       api_key: config.scrobblers.lastfm.apiKey,
-      sk: sessionKey,
+      sk: config.scrobblers.lastfm.sessionKey,
       format: 'json',
       method,
     };
-    postData.api_sig = createApiSig(postData, config.scrobblers.lastfm.secret);
 
-    scrobblerDebug(`[lastfm] ${method}: "${track}" - "${artist}"`);
-    net
-      .fetch('https://ws.audioscrobbler.com/2.0/', {
-        method: 'POST',
-        body: createFormData(postData),
-      })
-      .catch(console.error);
+    scrobblerDebug(
+      `[lastfm] ${method}: "${songInfo.title}" - "${songInfo.artist}"`,
+    );
+    await this.postSigned(postData, config, setConfig);
   }
 
   private async postSongDataToAPI(
@@ -194,25 +170,15 @@ export class LastFmScrobbler extends ScrobblerBase {
     data: LastFmData,
     setConfig: SetConfType,
   ): Promise<void> {
-    // This sends a post request to the api, and adds the common data
     if (!config.scrobblers.lastfm.sessionKey) {
       await this.createSession(config, setConfig);
     }
-
-    const title =
-      config.alternativeTitles && songInfo.alternativeTitle !== undefined
-        ? songInfo.alternativeTitle
-        : songInfo.title;
-
-    const artist =
-      config.alternativeArtist && songInfo.tags?.at(0) !== undefined
-        ? songInfo.tags?.at(0)
-        : songInfo.artist;
+    if (!config.scrobblers.lastfm.sessionKey) return;
 
     const postData: LastFmSongData = {
-      track: title,
+      track: songInfo.title,
       duration: songInfo.songDuration,
-      artist: artist,
+      artist: songInfo.artist,
       ...(songInfo.album ? { album: songInfo.album } : undefined), // Will be undefined if current song is a video
       api_key: config.scrobblers.lastfm.apiKey,
       sk: config.scrobblers.lastfm.sessionKey,
@@ -220,39 +186,40 @@ export class LastFmScrobbler extends ScrobblerBase {
       ...data,
     };
 
+    scrobblerDebug(
+      `[lastfm] ${data.method}: "${songInfo.title}" - "${songInfo.artist}"`,
+    );
+    await this.postSigned(postData, config, setConfig);
+  }
+
+  private async postSigned(
+    postData: Record<string, unknown>,
+    config: ScrobblerPluginConfig,
+    setConfig: SetConfType,
+  ): Promise<void> {
     postData.api_sig = createApiSig(postData, config.scrobblers.lastfm.secret);
-    const formData = createFormData(postData);
-    scrobblerDebug(`[lastfm] ${data.method}: "${title}" - "${artist}"`);
-    net
-      .fetch('https://ws.audioscrobbler.com/2.0/', {
+
+    try {
+      await net.fetch('https://ws.audioscrobbler.com/2.0/', {
         method: 'POST',
-        body: formData,
-      })
-      .catch(
-        async (error: {
-          response?: {
-            data?: {
-              error: number;
-            };
-          };
-        }) => {
-          if (error?.response?.data?.error === 9) {
-            // Session key is invalid, so remove it from the config and reauthenticate
-            config.scrobblers.lastfm.sessionKey = undefined;
-            config.scrobblers.lastfm.token = await createToken(config);
-            authenticate(config, this.mainWindow).then((it) => {
-              if (it) {
-                this.createSession(config, setConfig);
-              } else {
-                // failed
-                setConfig(config);
-              }
-            });
-          } else {
-            console.error(error);
-          }
-        },
-      );
+        body: createFormData(postData),
+      });
+    } catch (error: unknown) {
+      const err = error as { response?: { data?: { error: number } } };
+      if (err?.response?.data?.error === 9) {
+        // Session key is invalid, so remove it from the config and reauthenticate
+        config.scrobblers.lastfm.sessionKey = undefined;
+        config.scrobblers.lastfm.token = await createToken(config);
+        const ok = await authenticate(config, this.mainWindow);
+        if (ok) {
+          await this.createSession(config, setConfig);
+        } else {
+          setConfig(config);
+        }
+      } else {
+        console.error(error);
+      }
+    }
   }
 }
 

--- a/src/plugins/scrobbler/services/lastfm.ts
+++ b/src/plugins/scrobbler/services/lastfm.ts
@@ -200,13 +200,17 @@ export class LastFmScrobbler extends ScrobblerBase {
     postData.api_sig = createApiSig(postData, config.scrobblers.lastfm.secret);
 
     try {
-      await net.fetch('https://ws.audioscrobbler.com/2.0/', {
+      const response = await net.fetch(config.scrobblers.lastfm.apiRoot, {
         method: 'POST',
         body: createFormData(postData),
       });
-    } catch (error: unknown) {
-      const err = error as { response?: { data?: { error: number } } };
-      if (err?.response?.data?.error === 9) {
+      const json = (await response.json().catch(() => undefined)) as
+        | { error?: number; message?: string }
+        | undefined;
+
+      if (response.ok && !json?.error) return;
+
+      if (json?.error === 9) {
         // Session key is invalid, so remove it from the config and reauthenticate
         config.scrobblers.lastfm.sessionKey = undefined;
         config.scrobblers.lastfm.token = await createToken(config);
@@ -217,8 +221,12 @@ export class LastFmScrobbler extends ScrobblerBase {
           setConfig(config);
         }
       } else {
-        console.error(error);
+        console.error(
+          `[lastfm] request failed: ${response.status} ${json?.message ?? ''}`,
+        );
       }
+    } catch (error) {
+      console.error(error);
     }
   }
 }

--- a/src/plugins/scrobbler/services/lastfm.ts
+++ b/src/plugins/scrobbler/services/lastfm.ts
@@ -16,6 +16,7 @@ interface LastFmData {
 }
 
 interface LastFmSongData {
+  [key: string]: unknown;
   track?: string;
   duration?: number;
   artist?: string;
@@ -25,6 +26,17 @@ interface LastFmSongData {
   format: string;
   method: string;
   timestamp?: number;
+  api_sig?: string;
+}
+
+interface LastFmLoveData {
+  [key: string]: unknown;
+  track: string;
+  artist: string;
+  api_key: string;
+  sk: string;
+  format: string;
+  method: string;
   api_sig?: string;
 }
 
@@ -101,6 +113,7 @@ export class LastFmScrobbler extends ScrobblerBase {
     songInfo: SongInfo,
     config: ScrobblerPluginConfig,
     setConfig: SetConfType,
+    startedAtSeconds: number,
   ): void {
     if (!config.scrobblers.lastfm.sessionKey) {
       return;
@@ -109,11 +122,67 @@ export class LastFmScrobbler extends ScrobblerBase {
     // This adds one scrobbled song to last.fm
     const data = {
       method: 'track.scrobble',
-      timestamp: Math.trunc(
-        (Date.now() - (songInfo.elapsedSeconds ?? 0)) / 1000,
-      ),
+      timestamp: Math.trunc(startedAtSeconds),
     };
     this.postSongDataToAPI(songInfo, config, data, setConfig);
+  }
+
+  override love(
+    songInfo: SongInfo,
+    config: ScrobblerPluginConfig,
+    _setConfig: SetConfType,
+  ): void {
+    this.postLoveToAPI('track.love', songInfo, config);
+  }
+
+  override unlove(
+    songInfo: SongInfo,
+    config: ScrobblerPluginConfig,
+    _setConfig: SetConfType,
+  ): void {
+    this.postLoveToAPI('track.unlove', songInfo, config);
+  }
+
+  private postLoveToAPI(
+    method: string,
+    songInfo: SongInfo,
+    config: ScrobblerPluginConfig,
+  ): void {
+    const sessionKey = config.scrobblers.lastfm.sessionKey;
+    if (!sessionKey) {
+      return;
+    }
+
+    const track =
+      config.alternativeTitles && songInfo.alternativeTitle !== undefined
+        ? songInfo.alternativeTitle
+        : songInfo.title;
+
+    const artist =
+      config.alternativeArtist && songInfo.tags?.at(0) !== undefined
+        ? songInfo.tags?.at(0)
+        : songInfo.artist;
+
+    if (!track || !artist) {
+      return;
+    }
+
+    const postData: LastFmLoveData = {
+      track,
+      artist,
+      api_key: config.scrobblers.lastfm.apiKey,
+      sk: sessionKey,
+      format: 'json',
+      method,
+    };
+    postData.api_sig = createApiSig(postData, config.scrobblers.lastfm.secret);
+
+    net
+      .fetch('https://ws.audioscrobbler.com/2.0/', {
+        method: 'POST',
+        body: createFormData(postData),
+      })
+      .catch(console.error);
   }
 
   private async postSongDataToAPI(
@@ -183,11 +252,11 @@ export class LastFmScrobbler extends ScrobblerBase {
   }
 }
 
-const createFormData = (parameters: LastFmSongData) => {
+const createFormData = (parameters: Record<string, unknown>) => {
   // Creates the body for in the post request
   const formData = new URLSearchParams();
   for (const key in parameters) {
-    formData.append(key, String(parameters[key as keyof LastFmSongData]));
+    formData.append(key, String(parameters[key]));
   }
 
   return formData;
@@ -211,7 +280,7 @@ const createQueryString = (
   return '?' + queryData.join('&');
 };
 
-const createApiSig = (parameters: LastFmSongData, secret: string) => {
+const createApiSig = (parameters: Record<string, unknown>, secret: string) => {
   // This function creates the api signature, see: https://www.last.fm/api/authspec
   let sig = '';
 
@@ -221,7 +290,7 @@ const createApiSig = (parameters: LastFmSongData, secret: string) => {
       if (key === 'format') {
         return;
       }
-      sig += key + value;
+      sig += key + String(value);
     });
 
   sig += secret;

--- a/src/plugins/scrobbler/services/lastfm.ts
+++ b/src/plugins/scrobbler/services/lastfm.ts
@@ -6,6 +6,8 @@ import { t } from '@/i18n';
 
 import { ScrobblerBase } from './base';
 
+import { scrobblerDebug } from '../scrobble-manager';
+
 import type { ScrobblerPluginConfig } from '../index';
 import type { SetConfType } from '../main';
 import type { SongInfo } from '@/providers/song-info';
@@ -177,6 +179,7 @@ export class LastFmScrobbler extends ScrobblerBase {
     };
     postData.api_sig = createApiSig(postData, config.scrobblers.lastfm.secret);
 
+    scrobblerDebug(`[lastfm] ${method}: "${track}" - "${artist}"`);
     net
       .fetch('https://ws.audioscrobbler.com/2.0/', {
         method: 'POST',
@@ -219,6 +222,7 @@ export class LastFmScrobbler extends ScrobblerBase {
 
     postData.api_sig = createApiSig(postData, config.scrobblers.lastfm.secret);
     const formData = createFormData(postData);
+    scrobblerDebug(`[lastfm] ${data.method}: "${title}" - "${artist}"`);
     net
       .fetch('https://ws.audioscrobbler.com/2.0/', {
         method: 'POST',

--- a/src/plugins/scrobbler/services/listenbrainz.ts
+++ b/src/plugins/scrobbler/services/listenbrainz.ts
@@ -97,8 +97,9 @@ export class ListenbrainzScrobbler extends ScrobblerBase {
   }
 }
 
-// ListenBrainz feedback needs a recording_msid, only known after a listen is
-// submitted. Cache it per song, bounded so it can't grow forever.
+// Feedback (love/unlove) needs a recording_msid, which is only returned when a
+// listen is submitted. Cache it per song so feedback can reference it later,
+// bounded so it can't grow forever.
 const MAX_MSID_ENTRIES = 200;
 const msidCache = new Map<string, string>();
 

--- a/src/plugins/scrobbler/services/listenbrainz.ts
+++ b/src/plugins/scrobbler/services/listenbrainz.ts
@@ -4,6 +4,8 @@ import { APPLICATION_NAME } from '@/i18n';
 
 import { ScrobblerBase } from './base';
 
+import { scrobblerDebug } from '../scrobble-manager';
+
 import type { ScrobblerPluginConfig } from '../index';
 import type { SetConfType } from '../main';
 import type { SongInfo } from '@/providers/song-info';
@@ -71,7 +73,10 @@ export class ListenbrainzScrobbler extends ScrobblerBase {
     body.payload[0].listened_at = Math.trunc(startedAtSeconds);
 
     submitListen(body, config).then((msid) => {
-      if (msid) rememberMsid(songKey(songInfo), msid);
+      if (msid) {
+        rememberMsid(songKey(songInfo), msid);
+        scrobblerDebug(`[listenbrainz] listen submitted, cached msid ${msid}`);
+      }
     });
   }
 
@@ -117,8 +122,14 @@ function submitFeedback(
   if (!apiRoot || !token) return;
 
   const msid = msidCache.get(songKey(songInfo));
-  if (!msid) return; // No recording id known yet; skip silently.
+  if (!msid) {
+    scrobblerDebug(
+      `[listenbrainz] no cached msid for "${songInfo.title}", skipping feedback`,
+    );
+    return;
+  }
 
+  scrobblerDebug(`[listenbrainz] feedback score=${score} for msid ${msid}`);
   net
     .fetch(apiRoot + 'feedback/recording-feedback', {
       method: 'POST',

--- a/src/plugins/scrobbler/services/listenbrainz.ts
+++ b/src/plugins/scrobbler/services/listenbrainz.ts
@@ -52,8 +52,13 @@ export class ListenbrainzScrobbler extends ScrobblerBase {
       return;
     }
 
-    const body = createRequestBody('playing_now', songInfo, config);
-    submitListen(body, config);
+    const body = createRequestBody('playing_now', songInfo);
+    submitListen(body, config, true).then((msid) => {
+      if (msid) {
+        rememberMsid(songKey(songInfo), msid);
+        scrobblerDebug(`[listenbrainz] now playing, cached msid ${msid}`);
+      }
+    });
   }
 
   override addScrobble(
@@ -69,15 +74,13 @@ export class ListenbrainzScrobbler extends ScrobblerBase {
       return;
     }
 
-    const body = createRequestBody('single', songInfo, config);
+    const body = createRequestBody('single', songInfo);
     body.payload[0].listened_at = Math.trunc(startedAtSeconds);
 
-    submitListen(body, config).then((msid) => {
-      if (msid) {
-        rememberMsid(songKey(songInfo), msid);
-        scrobblerDebug(`[listenbrainz] listen submitted, cached msid ${msid}`);
-      }
-    });
+    // return_msid is only honored by ListenBrainz for listen_type=playing_now,
+    // so a 'single' submission never returns a recording_msid; the msid cache
+    // is instead populated by setNowPlaying, which fires earlier anyway.
+    submitListen(body, config, false);
   }
 
   override love(
@@ -146,21 +149,10 @@ function submitFeedback(
 function createRequestBody(
   listenType: string,
   songInfo: SongInfo,
-  config: ScrobblerPluginConfig,
 ): ListenbrainzRequestBody {
-  const title =
-    config.alternativeTitles && songInfo.alternativeTitle !== undefined
-      ? songInfo.alternativeTitle
-      : songInfo.title;
-
-  const artist =
-    config.alternativeArtist && songInfo.tags?.at(0) !== undefined
-      ? songInfo.tags?.at(0)
-      : songInfo.artist;
-
   const trackMetadata = {
-    artist_name: artist,
-    track_name: title,
+    artist_name: songInfo.artist,
+    track_name: songInfo.title,
     release_name: songInfo.album ?? undefined,
     additional_info: {
       media_player: `${APPLICATION_NAME} Desktop App`,
@@ -183,23 +175,29 @@ function createRequestBody(
 async function submitListen(
   body: ListenbrainzRequestBody,
   config: ScrobblerPluginConfig,
+  requestMsid: boolean,
 ): Promise<string | undefined> {
   try {
-    const response = await net.fetch(
-      config.scrobblers.listenbrainz.apiRoot + 'submit-listens',
-      {
-        method: 'POST',
-        body: JSON.stringify(body),
-        headers: {
-          'Authorization': 'Token ' + config.scrobblers.listenbrainz.token,
-          'Content-Type': 'application/json',
-        },
+    const url =
+      config.scrobblers.listenbrainz.apiRoot +
+      'submit-listens' +
+      (requestMsid ? '?return_msid=true' : '');
+    const response = await net.fetch(url, {
+      method: 'POST',
+      body: JSON.stringify(body),
+      headers: {
+        'Authorization': 'Token ' + config.scrobblers.listenbrainz.token,
+        'Content-Type': 'application/json',
       },
-    );
-    const json = (await response.json()) as {
-      payload?: { latest_listen_recording_msid?: string }[];
-    };
-    return json?.payload?.[0]?.latest_listen_recording_msid;
+    });
+    if (!response.ok) {
+      console.error(
+        `[listenbrainz] submit-listens failed: ${response.status} ${await response.text()}`,
+      );
+      return undefined;
+    }
+    const json = (await response.json()) as { recording_msid?: string };
+    return json.recording_msid;
   } catch (error) {
     console.error(error);
     return undefined;

--- a/src/plugins/scrobbler/services/listenbrainz.ts
+++ b/src/plugins/scrobbler/services/listenbrainz.ts
@@ -58,6 +58,7 @@ export class ListenbrainzScrobbler extends ScrobblerBase {
     songInfo: SongInfo,
     config: ScrobblerPluginConfig,
     _setConfig: SetConfType,
+    startedAtSeconds: number,
   ): void {
     if (
       !config.scrobblers.listenbrainz.apiRoot ||
@@ -67,10 +68,67 @@ export class ListenbrainzScrobbler extends ScrobblerBase {
     }
 
     const body = createRequestBody('single', songInfo, config);
-    body.payload[0].listened_at = Math.trunc(Date.now() / 1000);
+    body.payload[0].listened_at = Math.trunc(startedAtSeconds);
 
-    submitListen(body, config);
+    submitListen(body, config).then((msid) => {
+      if (msid) rememberMsid(songKey(songInfo), msid);
+    });
   }
+
+  override love(
+    songInfo: SongInfo,
+    config: ScrobblerPluginConfig,
+    _setConfig: SetConfType,
+  ): void {
+    submitFeedback(songInfo, config, 1);
+  }
+
+  override unlove(
+    songInfo: SongInfo,
+    config: ScrobblerPluginConfig,
+    _setConfig: SetConfType,
+  ): void {
+    submitFeedback(songInfo, config, 0);
+  }
+}
+
+// ListenBrainz feedback needs a recording_msid, only known after a listen is
+// submitted. Cache it per song, bounded so it can't grow forever.
+const MAX_MSID_ENTRIES = 200;
+const msidCache = new Map<string, string>();
+
+const songKey = (songInfo: SongInfo): string =>
+  songInfo.videoId || `${songInfo.artist}|${songInfo.title}`;
+
+function rememberMsid(key: string, msid: string): void {
+  if (msidCache.has(key)) msidCache.delete(key);
+  msidCache.set(key, msid);
+  while (msidCache.size > MAX_MSID_ENTRIES) {
+    msidCache.delete(msidCache.keys().next().value!);
+  }
+}
+
+function submitFeedback(
+  songInfo: SongInfo,
+  config: ScrobblerPluginConfig,
+  score: number,
+): void {
+  const { apiRoot, token } = config.scrobblers.listenbrainz;
+  if (!apiRoot || !token) return;
+
+  const msid = msidCache.get(songKey(songInfo));
+  if (!msid) return; // No recording id known yet; skip silently.
+
+  net
+    .fetch(apiRoot + 'feedback/recording-feedback', {
+      method: 'POST',
+      body: JSON.stringify({ recording_msid: msid, score }),
+      headers: {
+        'Authorization': 'Token ' + token,
+        'Content-Type': 'application/json',
+      },
+    })
+    .catch(console.error);
 }
 
 function createRequestBody(
@@ -110,18 +168,28 @@ function createRequestBody(
   };
 }
 
-function submitListen(
+async function submitListen(
   body: ListenbrainzRequestBody,
   config: ScrobblerPluginConfig,
-) {
-  net
-    .fetch(config.scrobblers.listenbrainz.apiRoot + 'submit-listens', {
-      method: 'POST',
-      body: JSON.stringify(body),
-      headers: {
-        'Authorization': 'Token ' + config.scrobblers.listenbrainz.token,
-        'Content-Type': 'application/json',
+): Promise<string | undefined> {
+  try {
+    const response = await net.fetch(
+      config.scrobblers.listenbrainz.apiRoot + 'submit-listens',
+      {
+        method: 'POST',
+        body: JSON.stringify(body),
+        headers: {
+          'Authorization': 'Token ' + config.scrobblers.listenbrainz.token,
+          'Content-Type': 'application/json',
+        },
       },
-    })
-    .catch(console.error);
+    );
+    const json = (await response.json()) as {
+      payload?: { latest_listen_recording_msid?: string }[];
+    };
+    return json?.payload?.[0]?.latest_listen_recording_msid;
+  } catch (error) {
+    console.error(error);
+    return undefined;
+  }
 }

--- a/src/providers/song-info-front.ts
+++ b/src/providers/song-info-front.ts
@@ -242,6 +242,12 @@ export const setupSongInfo = (api: MusicPlayer) => {
     pause: (e: Event) => playPausedHandler(e, 'pause'),
   };
 
+  api.addEventListener('onStateChange', () => {
+    if (api.getPlayerState() === 0) {
+      window.ipcRenderer.send('peard:video-ended');
+    }
+  });
+
   const videoEventDispatcher = async (
     name: string,
     videoData: VideoDataChangeValue,

--- a/src/providers/song-info-front.ts
+++ b/src/providers/song-info-front.ts
@@ -1,4 +1,5 @@
 import { LikeType, type GetState } from '@/types/datahost-get-state';
+import { PlayerState } from '@/types/player-state';
 
 import { singleton } from './decorators';
 
@@ -12,6 +13,14 @@ import type {
 import type { VideoDataChanged } from '@/types/video-data-changed';
 
 const DATAUPDATED_FALLBACK_TIMEOUT_MS = 1500;
+
+/**
+ * A track is considered "paused" for everything except active playback and
+ * buffering. Buffering is transient and resumes on its own, so it is treated as
+ * playing; paused, cued, unstarted and ended all count as paused.
+ */
+const isPausedState = (state: PlayerState): boolean =>
+  state !== PlayerState.Playing && state !== PlayerState.Buffering;
 
 let songInfo: SongInfo = {} as SongInfo;
 export const getSongInfo = () => songInfo;
@@ -225,27 +234,17 @@ export const setupSongInfo = (api: MusicPlayer) => {
     setupSeekedListener();
   });
 
-  const playPausedHandler = (e: Event, status: string) => {
-    if (
-      e.target instanceof HTMLVideoElement &&
-      Math.round(e.target.currentTime) > 0
-    ) {
-      window.ipcRenderer.send('peard:play-or-paused', {
-        isPaused: status === 'pause',
-        elapsedSeconds: Math.floor(e.target.currentTime),
-      });
-    }
-  };
-
-  const playPausedHandlers = {
-    playing: (e: Event) => playPausedHandler(e, 'playing'),
-    pause: (e: Event) => playPausedHandler(e, 'pause'),
-  };
-
   api.addEventListener('onStateChange', () => {
-    if (api.getPlayerState() === 0) {
+    const state = api.getPlayerState() as PlayerState;
+    if (state === PlayerState.Ended) {
       window.ipcRenderer.send('peard:video-ended');
+      return;
     }
+    window.ipcRenderer.send('peard:play-or-paused', {
+      isPaused: isPausedState(state),
+      elapsedSeconds: Math.floor(api.getCurrentTime()),
+      playerState: state,
+    });
   });
 
   const videoEventDispatcher = async (
@@ -284,11 +283,6 @@ export const setupSongInfo = (api: MusicPlayer) => {
       const video = document.querySelector<HTMLVideoElement>('video');
       video?.dispatchEvent(srcChangedEvent);
 
-      for (const status of ['playing', 'pause'] as const) {
-        // for fix issue that pause event not fired
-        video?.addEventListener(status, playPausedHandlers[status]);
-      }
-
       clearVideoTimeout(videoData.videoId);
       waitingEvent.add(videoData.videoId);
 
@@ -307,10 +301,6 @@ export const setupSongInfo = (api: MusicPlayer) => {
   const video = document.querySelector('video');
 
   if (video) {
-    for (const status of ['playing', 'pause'] as const) {
-      video.addEventListener(status, playPausedHandlers[status]);
-    }
-
     if (!isNaN(video.duration)) {
       const {
         title,
@@ -355,8 +345,10 @@ export const setupSongInfo = (api: MusicPlayer) => {
       playerOverlay?.playerOverlayRenderer?.browserMediaSession?.browserMediaSessionRenderer?.album?.runs?.at(
         0,
       )?.text;
-    data.videoDetails.elapsedSeconds = 0;
-    data.videoDetails.isPaused = false;
+    const playerState = api.getPlayerState() as PlayerState;
+    data.videoDetails.elapsedSeconds = Math.floor(api.getCurrentTime());
+    data.videoDetails.isPaused = isPausedState(playerState);
+    data.videoDetails.playerState = playerState;
 
     window.ipcRenderer.send('peard:video-src-changed', data);
   }

--- a/src/providers/song-info.ts
+++ b/src/providers/song-info.ts
@@ -175,6 +175,7 @@ export enum SongInfoEvent {
   VideoSrcChanged = 'peard:video-src-changed',
   PlayOrPaused = 'peard:play-or-paused',
   TimeChanged = 'peard:time-changed',
+  Ended = 'peard:video-ended',
 }
 
 // This variable will be filled with the callbacks once they register
@@ -251,6 +252,13 @@ const registerProvider = (win: BrowserWindow) => {
       for (const c of callbacks) {
         c(tempSongInfo, SongInfoEvent.TimeChanged);
       }
+    }
+  });
+
+  ipcMain.on('peard:video-ended', () => {
+    if (!songInfo) return;
+    for (const c of callbacks) {
+      c(songInfo, SongInfoEvent.Ended);
     }
   });
 };

--- a/src/providers/song-info.ts
+++ b/src/providers/song-info.ts
@@ -107,14 +107,16 @@ const handleData = async (
 
   const { videoDetails } = data;
   if (videoDetails) {
-    songInfo.title = cleanupName(videoDetails.title);
-    songInfo.artist = cleanupName(videoDetails.author);
+    songInfo.title = cleanupTitle(videoDetails.title);
+    songInfo.artist = cleanupArtist(videoDetails.author);
     songInfo.views = Number(videoDetails.viewCount);
     songInfo.songDuration = Number(videoDetails.lengthSeconds);
     songInfo.elapsedSeconds = videoDetails.elapsedSeconds;
     songInfo.isPaused = videoDetails.isPaused;
     songInfo.videoId = videoDetails.videoId;
-    songInfo.album = videoDetails.album; // Will be undefined if video exist
+    songInfo.album = videoDetails.album
+      ? cleanupAlbum(videoDetails.album)
+      : videoDetails.album; // Will be undefined if video exist
 
     switch (videoDetails?.musicVideoType) {
       case 'MUSIC_VIDEO_TYPE_ATV':
@@ -130,7 +132,7 @@ const handleData = async (
         songInfo.mediaType = MediaType.PodcastEpisode;
         // HACK: Podcast's participant is not the artist
         if (!config.get('options.usePodcastParticipantAsArtist')) {
-          songInfo.artist = cleanupName(
+          songInfo.artist = cleanupArtist(
             data.microformat.microformatDataRenderer.pageOwnerDetails.name,
           );
         }
@@ -144,7 +146,7 @@ const handleData = async (
             ?.at(0)
             ?.params?.find((it) => it.key === 'ipcc')?.value ?? '1') != '0'
         ) {
-          songInfo.artist = cleanupName(
+          songInfo.artist = cleanupArtist(
             data.microformat.microformatDataRenderer.pageOwnerDetails.name,
           );
         }
@@ -253,12 +255,8 @@ const registerProvider = (win: BrowserWindow) => {
   });
 };
 
-const suffixesToRemove = [
-  // Artist names
-  /\s*(- topic)$/i,
-  /\s*vevo$/i,
-
-  // Video titles
+// Suffixes stripped from song/video titles.
+const titleSuffixes = [
   /\s*[(|[]official(.*?)[)|\]]/i, // (Official Music Video), [Official Visualizer], etc...
   /\s*[(|[]((lyrics?|visualizer|audio)\s*(video)?)[)|\]]/i,
   /\s*[(|[](performance video)[)|\]]/i,
@@ -267,18 +265,38 @@ const suffixesToRemove = [
   /\s*[(|[](HD|HQ)\s*?(?:audio)?[)|\]]$/i,
   /\s*[(|[](live)[)|\]]$/i,
   /\s*[(|[]4K\s*?(?:upgrade)?[)|\]]$/i,
+  /\s*[(|[](\d{4}\s+)?remaster(ed)?(\s+\d{4})?[)|\]]/i,
+  /\s*[(|[](mono|stereo)[)|\]]/i,
 ];
 
-export function cleanupName(name: string): string {
+// Suffixes stripped from artist names.
+const artistSuffixes = [/\s*(- topic)$/i, /\s*vevo$/i];
+
+// Suffixes stripped from album names.
+const albumSuffixes = [/\s*[(|[](\d{4}\s+)?remaster(ed)?(\s+\d{4})?[)|\]]/i];
+
+function applySuffixes(name: string, suffixes: RegExp[]): string {
   if (!name) {
     return name;
   }
 
-  for (const suffix of suffixesToRemove) {
+  for (const suffix of suffixes) {
     name = name.replace(suffix, '');
   }
 
   return name;
+}
+
+export function cleanupTitle(name: string): string {
+  return applySuffixes(name, titleSuffixes);
+}
+
+export function cleanupArtist(name: string): string {
+  return applySuffixes(name, artistSuffixes);
+}
+
+export function cleanupAlbum(name: string): string {
+  return applySuffixes(name, albumSuffixes);
 }
 
 export const setupSongInfo = registerProvider;

--- a/src/providers/song-info.ts
+++ b/src/providers/song-info.ts
@@ -4,6 +4,7 @@ import { type BrowserWindow, ipcMain, nativeImage, net } from 'electron';
 import * as config from '@/config';
 
 import type { GetPlayerResponse } from '@/types/get-player-response';
+import type { PlayerState } from '@/types/player-state';
 
 export enum MediaType {
   /**
@@ -35,6 +36,7 @@ export interface SongInfo {
   imageSrc?: string | null;
   image?: Electron.NativeImage | null;
   isPaused?: boolean;
+  playerState?: PlayerState;
   songDuration: number;
   elapsedSeconds?: number;
   url?: string;
@@ -78,6 +80,7 @@ const handleData = async (
     imageSrc: '',
     image: null,
     isPaused: undefined,
+    playerState: undefined,
     songDuration: 0,
     elapsedSeconds: 0,
     url: '',
@@ -113,6 +116,7 @@ const handleData = async (
     songInfo.songDuration = Number(videoDetails.lengthSeconds);
     songInfo.elapsedSeconds = videoDetails.elapsedSeconds;
     songInfo.isPaused = videoDetails.isPaused;
+    songInfo.playerState = videoDetails.playerState;
     songInfo.videoId = videoDetails.videoId;
     songInfo.album = videoDetails.album
       ? cleanupAlbum(videoDetails.album)
@@ -175,7 +179,6 @@ export enum SongInfoEvent {
   VideoSrcChanged = 'peard:video-src-changed',
   PlayOrPaused = 'peard:play-or-paused',
   TimeChanged = 'peard:time-changed',
-  Ended = 'peard:video-ended',
 }
 
 // This variable will be filled with the callbacks once they register
@@ -216,7 +219,12 @@ const registerProvider = (win: BrowserWindow) => {
       {
         isPaused,
         elapsedSeconds,
-      }: { isPaused: boolean; elapsedSeconds: number },
+        playerState,
+      }: {
+        isPaused: boolean;
+        elapsedSeconds: number;
+        playerState?: PlayerState;
+      },
     ) => {
       const tempSongInfo = await dataMutex.runExclusive<SongInfo | null>(() => {
         if (!songInfo) {
@@ -225,6 +233,7 @@ const registerProvider = (win: BrowserWindow) => {
 
         songInfo.isPaused = isPaused;
         songInfo.elapsedSeconds = elapsedSeconds;
+        songInfo.playerState = playerState;
 
         return songInfo;
       });
@@ -252,13 +261,6 @@ const registerProvider = (win: BrowserWindow) => {
       for (const c of callbacks) {
         c(tempSongInfo, SongInfoEvent.TimeChanged);
       }
-    }
-  });
-
-  ipcMain.on('peard:video-ended', () => {
-    if (!songInfo) return;
-    for (const c of callbacks) {
-      c(songInfo, SongInfoEvent.Ended);
     }
   });
 };

--- a/src/types/get-player-response.ts
+++ b/src/types/get-player-response.ts
@@ -1,3 +1,5 @@
+import type { PlayerState } from './player-state';
+
 export interface GetPlayerResponse {
   responseContext: ResponseContext;
   playabilityStatus: PlayabilityStatus;
@@ -469,6 +471,7 @@ export interface GetPlayerResponseVideoDetails {
   isLiveContent: boolean;
   elapsedSeconds: number;
   isPaused: boolean;
+  playerState?: PlayerState;
 
   // music only
   album?: string | null;

--- a/src/types/player-state.ts
+++ b/src/types/player-state.ts
@@ -1,0 +1,9 @@
+// https://developers.google.com/youtube/iframe_api_reference#getPlayerState
+export enum PlayerState {
+  Unstarted = -1,
+  Ended = 0,
+  Playing = 1,
+  Paused = 2,
+  Buffering = 3,
+  Cued = 5,
+}


### PR DESCRIPTION
# Scrobbler parity with Morphe

## Why
The existing scrobbler used a single shared `setTimeout` per song, fired every enabled service together, and derived play/pause from a DOM listener with a `currentTime > 0` guard. This meant:
- No per-service "already scrobbled" guard -> seeking back after a scrobble could double-scrobble.
- No pause/resume time accounting -> pausing lost progress toward the threshold.
- Play/pause at `currentTime = 0` was silently dropped, so **clicking play right at app launch did nothing** until you seeked.
- Repeat-one looping a song only ever scrobbled it once.
- The Last.fm scrobble timestamp was computed from `Date.now() - elapsedSeconds` without unit conversion.
- No love/unlove, no min-duration guard, no per-service timing config, no metadata cleanup beyond a single global suffix regex.
- Name cleanup logic differs between Pear Desktop and Morphe which could lead to duplicates. 

## What changed
### `scrobble-manager.ts` - new stateful per-service scheduler
Replaces the single shared timer in `main.ts` with a class that tracks, per enabled service (`lastfm` / `listenbrainz`):
- `scrobbled` - guards against double-scrobbling the same play.
- `remainingMs` / `timerStartedAt` - lets pause preserve exact progress and resume pick up where it left off, instead of restarting the threshold.
- An independent `setTimeout`, so Last.fm and ListenBrainz can have different delay/duration settings without interfering with each other.

### DOM `ended`/`playing`/`pause` replaced with player state machine
YTM streams via MSE, so the `<video>` element never fires a real `ended`, and the old `playing`/`pause` listener dropped events at `currentTime = 0`, which led to clicking play at launch, or right after a loop, going unnoticed.

Both are now driven by the player API's own state machine, the same signal source `music-together` already used.

A new shared `src/types/player-state.ts` enum documents this. **Paused is defined as "anything except playing or buffering"** - buffering is transient and self-resolving, so treating it as paused would stall/restart timers on every rebuffer. The raw state is now also carried on `SongInfo`/`GetPlayerResponse` for any future consumer that wants more than the boolean.

This is a **shared-provider change** - every plugin consuming `isPaused` gets more accurate play/pause as a side effect, with no shape change to the existing IPC events.

### Repeat-one loop detection
Now player state `ENDED` + next `video-src-changed` are tracked, keyed by `videoId`. 

When state hits `0`, a `endedReached` flag is armed. The *next* `video-src-changed` for that song either carries the **same** `videoId` (a loop restarting) or a **different** one (the next track). 

### `services/base.ts`, `lastfm.ts`, `listenbrainz.ts`
- `love()` / `unlove()` added to the base class and both services.
  - Last.fm: `track.love` / `track.unlove`.
  - ListenBrainz: `feedback/recording-feedback` (score `1`/`0`)
  - Wired to the existing `peard:like-changed` IPC.
- `addScrobble` now takes the manager's `startedAtSeconds` instead of deriving a timestamp from `Date.now()`/`elapsedSeconds` - fixes the Last.fm timestamp bug mentioned above.
- Per-service config: `nowPlaying`, `minSongDuration`, `delayPercent`, `delaySeconds`, `loveOnLike`.

### `song-info.ts` metadata cleanup
The single `cleanupName()` was split up into `cleanupTitle` / `cleanupArtist` / `cleanupAlbum`, each with its own regex list, mirroring Morphe's per-field cleanup.

### Debug logging
`scrobblerDebug()` gated on `is.dev()` (silent in production), covering every scheduling decision for debugging purposes.

## Possible issues
- **The player-state-based play/pause change is shared infrastructure.** It should be a strict improvement for every consumer, but it does change the signal source for play/pause detection app-wide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit
* **New Features**
  * Expanded Scrobbler controls for Last.fm and ListenBrainz: now playing, love-on-like, and configurable scrobble timing (minimum duration + percent/seconds delays).
  * Added metadata preprocessing options, including per-field cleanup and a custom cleanup regex with dedicated editing prompts.
* **Bug Fixes**
  * Improved metadata normalization for downloaded tags (title/artist cleaned independently).
  * More reliable scrobble scheduling and repeat handling, with deduped like/unlike events and playback-state–based tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->