### PR TITLE
feat: add canonical shared-link option

### DIFF
--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -34,6 +34,7 @@ export interface DefaultConfig {
     startingPage: string;
     overrideUserAgent: boolean;
     usePodcastParticipantAsArtist: boolean;
+    stripMusicFromSharedLinks: boolean;
     themes: string[];
     customWindowTitle?: string;
   };
@@ -71,6 +72,7 @@ export const defaultConfig: DefaultConfig = {
     startingPage: '',
     overrideUserAgent: false,
     usePodcastParticipantAsArtist: false,
+    stripMusicFromSharedLinks: false,
     themes: [],
   },
   'plugins': {},

--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -133,6 +133,7 @@
           },
           "resume-on-start": "Resume last song when app starts",
           "single-instance-lock": "Single Instance Lock",
+          "strip-music-from-shared-links": "Strip 'music.' from shared links",
           "start-at-login": "Start at login",
           "starting-page": {
             "label": "Starting page",

--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -133,12 +133,12 @@
           },
           "resume-on-start": "Resume last song when app starts",
           "single-instance-lock": "Single Instance Lock",
-          "strip-music-from-shared-links": "Strip 'music.' from shared links",
           "start-at-login": "Start at login",
           "starting-page": {
             "label": "Starting page",
             "unset": "Unset"
           },
+          "strip-music-from-shared-links": "Strip 'music.' from shared links",
           "tray": {
             "label": "Tray",
             "submenu": {

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -20,6 +20,7 @@ import { getAllMenuTemplate, loadAllMenuPlugins } from './loader/menu';
 import { restart } from './providers/app-controls';
 import { startingPages } from './providers/extracted-data';
 import promptOptions from './providers/prompt-options';
+import { stripMusicSubdomain } from './providers/share-url';
 
 import packageJson from '../package.json';
 
@@ -172,6 +173,21 @@ export const mainMenuTemplate = async (
           checked: config.get('options.resumeOnStart'),
           click(item: MenuItem) {
             config.setMenuOption('options.resumeOnStart', item.checked);
+          },
+        },
+        {
+          label: t('main.menu.options.submenu.strip-music-from-shared-links'),
+          type: 'checkbox',
+          checked: config.get('options.stripMusicFromSharedLinks'),
+          click(item: MenuItem) {
+            config.setMenuOption(
+              'options.stripMusicFromSharedLinks',
+              item.checked,
+            );
+            win.webContents.send(
+              'peard:strip-music-from-shared-links',
+              item.checked,
+            );
           },
         },
         {
@@ -676,7 +692,11 @@ export const mainMenuTemplate = async (
           label: t('main.menu.navigation.submenu.copy-current-url'),
           click() {
             const currentURL = win.webContents.getURL();
-            clipboard.writeText(currentURL);
+            clipboard.writeText(
+              config.get('options.stripMusicFromSharedLinks')
+                ? stripMusicSubdomain(currentURL)
+                : currentURL,
+            );
           },
         },
         {

--- a/src/providers/share-url.ts
+++ b/src/providers/share-url.ts
@@ -1,0 +1,59 @@
+const MUSIC_HOST_PATTERN = /^(https?:\/\/)music\.youtube\.com(?=[:/?#]|$)/i;
+
+export const stripMusicSubdomain = (url: string) =>
+  url.replace(MUSIC_HOST_PATTERN, '$1youtube.com');
+
+export const rewriteShareUrlInput = (root: ParentNode) => {
+  const input = root.querySelector<HTMLInputElement>('#share-url');
+  if (!input) return false;
+
+  const canonicalUrl = stripMusicSubdomain(input.value);
+  if (canonicalUrl === input.value) return false;
+
+  input.value = canonicalUrl;
+  return true;
+};
+
+export const createShareUrlRewriter = (
+  root: Document = document,
+  Observer: typeof MutationObserver = MutationObserver,
+) => {
+  let observer: MutationObserver | undefined;
+  let pendingRewrite: ReturnType<typeof setTimeout> | undefined;
+
+  const rewrite = () => rewriteShareUrlInput(root);
+  const rewriteBeforeClick = () => rewrite();
+  const rewriteAfterChange = () => {
+    if (pendingRewrite) clearTimeout(pendingRewrite);
+    pendingRewrite = setTimeout(() => {
+      pendingRewrite = undefined;
+      rewrite();
+    }, 0);
+  };
+
+  return {
+    start() {
+      if (observer) return;
+
+      observer = new Observer(rewrite);
+      observer.observe(root.documentElement, {
+        childList: true,
+        subtree: true,
+      });
+      root.addEventListener('click', rewriteBeforeClick, true);
+      root.addEventListener('change', rewriteAfterChange, true);
+      rewrite();
+    },
+    stop() {
+      observer?.disconnect();
+      observer = undefined;
+      root.removeEventListener('click', rewriteBeforeClick, true);
+      root.removeEventListener('change', rewriteAfterChange, true);
+
+      if (pendingRewrite) {
+        clearTimeout(pendingRewrite);
+        pendingRewrite = undefined;
+      }
+    },
+  };
+};

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -18,6 +18,7 @@ import {
   loadAllRendererPlugins,
 } from './loader/renderer';
 import { startingPages } from './providers/extracted-data';
+import { createShareUrlRewriter } from './providers/share-url';
 import { setupSongInfo } from './providers/song-info-front';
 
 import type { MusicPlayer } from '@/types/music-player';
@@ -448,6 +449,20 @@ const preload = async () => {
 };
 
 const main = async () => {
+  const shareUrlRewriter = createShareUrlRewriter();
+  const setShareUrlRewriterEnabled = (enabled: boolean) => {
+    if (enabled) shareUrlRewriter.start();
+    else shareUrlRewriter.stop();
+  };
+
+  setShareUrlRewriterEnabled(
+    window.mainConfig.get('options.stripMusicFromSharedLinks'),
+  );
+  window.ipcRenderer.on(
+    'peard:strip-music-from-shared-links',
+    (_event, enabled: boolean) => setShareUrlRewriterEnabled(enabled),
+  );
+
   await loadAllRendererPlugins();
   isPluginLoaded = true;
 

--- a/tests/share-url.test.ts
+++ b/tests/share-url.test.ts
@@ -1,0 +1,77 @@
+import { expect, test } from '@playwright/test';
+import { Window } from 'happy-dom';
+
+import { defaultConfig } from '../src/config/defaults';
+import {
+  createShareUrlRewriter,
+  rewriteShareUrlInput,
+  stripMusicSubdomain,
+} from '../src/providers/share-url';
+
+test('shared-link normalization is disabled by default', () => {
+  expect(defaultConfig.options.stripMusicFromSharedLinks).toBe(false);
+});
+
+test('stripMusicSubdomain preserves the rest of a YouTube Music URL', () => {
+  expect(
+    stripMusicSubdomain(
+      'https://music.youtube.com/watch?v=abc123&list=PL123#playing',
+    ),
+  ).toBe('https://youtube.com/watch?v=abc123&list=PL123#playing');
+});
+
+test('stripMusicSubdomain leaves unrelated and malformed URLs unchanged', () => {
+  for (const url of [
+    'https://youtube.com/watch?v=abc123',
+    'https://www.youtube.com/watch?v=abc123',
+    'https://notmusic.youtube.com/watch?v=abc123',
+    'music.youtube.com/watch?v=abc123',
+  ]) {
+    expect(stripMusicSubdomain(url)).toBe(url);
+  }
+});
+
+test('rewriteShareUrlInput updates the visible share field once', () => {
+  const window = new Window();
+  const input = window.document.createElement('input');
+  input.id = 'share-url';
+  input.value = 'https://music.youtube.com/watch?v=abc123';
+  window.document.body.append(input);
+
+  expect(rewriteShareUrlInput(window.document as unknown as Document)).toBe(
+    true,
+  );
+  expect(input.value).toBe('https://youtube.com/watch?v=abc123');
+  expect(rewriteShareUrlInput(window.document as unknown as Document)).toBe(
+    false,
+  );
+});
+
+test('share URL rewriting starts and stops with the setting', () => {
+  const window = new Window();
+  const document = window.document as unknown as Document;
+  const input = window.document.createElement('input');
+  input.id = 'share-url';
+  input.value = 'https://music.youtube.com/watch?v=abc123';
+  window.document.body.append(input);
+
+  const rewriter = createShareUrlRewriter(
+    document,
+    window.MutationObserver as unknown as typeof MutationObserver,
+  );
+  rewriter.start();
+  expect(input.value).toBe('https://youtube.com/watch?v=abc123');
+
+  input.value = 'https://music.youtube.com/watch?v=def456';
+  window.document.body.dispatchEvent(
+    new window.Event('click', { bubbles: true }),
+  );
+  expect(input.value).toBe('https://youtube.com/watch?v=def456');
+
+  rewriter.stop();
+  input.value = 'https://music.youtube.com/watch?v=ghi789';
+  window.document.body.dispatchEvent(
+    new window.Event('click', { bubbles: true }),
+  );
+  expect(input.value).toBe('https://music.youtube.com/watch?v=ghi789');
+});


### PR DESCRIPTION
## What changed

- add a default-off “Strip 'music.' from shared links” option
- rewrite only the visible YouTube Music share URL and **Navigation > Copy current URL** output
- preserve app navigation/origin, CORS behavior, internal APIs, path, query, and fragment
- add focused regression coverage for opt-in, exact-host, unrelated-host, idempotence, and runtime start/stop behavior

Closes #4577

## Validation

- `pnpm typecheck`
- `pnpm lint` (passes; only existing unrelated warnings)
- `pnpm build`
- `pnpm test` — 11 passed
- changed-file `oxfmt --check`
- `git diff --check`

## AI assistance

Implemented and validated with OpenAI Codex. No human review is claimed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to strip the `music.` subdomain from shared links (default: off).
  * When enabled, copying the current URL uses the standardized YouTube URL while preserving query parameters and fragments.
  * Share URL fields are automatically normalized while the option is enabled.
  * Added a menu checkbox to control this behavior.
* **Tests**
  * Added Playwright coverage for URL normalization, share input rewriting behavior, and start/stop toggling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->