### PR TITLE
feat(api-server): add endpoint to add songs to playlists

### DIFF
--- a/src/plugins/api-server/backend/routes/control.ts
+++ b/src/plugins/api-server/backend/routes/control.ts
@@ -10,10 +10,12 @@ import {
 
 import { API_VERSION } from '../api-version';
 import {
+  AddSongsToPlaylistSchema,
   AddSongToQueueSchema,
   GoBackSchema,
   GoForwardScheme,
   MoveSongInQueueSchema,
+  PlaylistParamsSchema,
   QueueParamsSchema,
   SearchSchema,
   SeekSchema,
@@ -471,6 +473,38 @@ const routes = {
       },
     },
   }),
+  addSongsToPlaylist: createRoute({
+    method: 'post',
+    path: `/api/${API_VERSION}/playlists/{playlistId}/songs`,
+    summary: 'add songs to playlist',
+    description: 'Add one or more songs to a playlist',
+    request: {
+      params: PlaylistParamsSchema,
+      body: {
+        description: 'video ids of the songs to add',
+        content: {
+          'application/json': {
+            schema: AddSongsToPlaylistSchema,
+          },
+        },
+      },
+    },
+    responses: {
+      204: {
+        description: 'Success',
+      },
+      500: {
+        description: 'Failed to add songs to playlist',
+        content: {
+          'application/json': {
+            schema: z.object({
+              error: z.string(),
+            }),
+          },
+        },
+      },
+    },
+  }),
   moveSongInQueue: createRoute({
     method: 'patch',
     path: `/api/${API_VERSION}/queue/{index}`,
@@ -831,6 +865,24 @@ export const register = (
 
     ctx.status(204);
     return ctx.body(null);
+  });
+  app.openapi(routes.addSongsToPlaylist, async (ctx) => {
+    const { playlistId } = ctx.req.valid('param');
+    const { videoIds } = ctx.req.valid('json');
+
+    try {
+      await controller.addSongsToPlaylist(playlistId, videoIds);
+      ctx.status(204);
+      return ctx.body(null);
+    } catch (error) {
+      ctx.status(500);
+      return ctx.json({
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Failed to add songs to playlist',
+      });
+    }
   });
   app.openapi(routes.moveSongInQueue, (ctx) => {
     const index = Number(ctx.req.param('index'));

--- a/src/plugins/api-server/backend/scheme/index.ts
+++ b/src/plugins/api-server/backend/scheme/index.ts
@@ -8,3 +8,4 @@ export * from './set-volume';
 export * from './set-fullscreen';
 export * from './queue';
 export * from './search';
+export * from './playlist';

--- a/src/plugins/api-server/backend/scheme/playlist.ts
+++ b/src/plugins/api-server/backend/scheme/playlist.ts
@@ -1,0 +1,9 @@
+import { z } from '@hono/zod-openapi';
+
+export const PlaylistParamsSchema = z.object({
+  playlistId: z.string().trim().min(1),
+});
+
+export const AddSongsToPlaylistSchema = z.object({
+  videoIds: z.array(z.string().trim().min(1)).min(1),
+});

--- a/src/providers/song-controls.ts
+++ b/src/providers/song-controls.ts
@@ -1,4 +1,6 @@
 // This is used for to control the songs
+import { randomUUID } from 'node:crypto';
+
 import { type BrowserWindow, ipcMain } from 'electron';
 
 import { LikeType } from '@/types/datahost-get-state';
@@ -115,6 +117,30 @@ export const getSongControls = (win: BrowserWindow) => {
         queueInsertPosition,
       );
     },
+    addSongsToPlaylist: (playlistId: string, videoIds: string[]) =>
+      new Promise<void>((resolve, reject) => {
+        const responseChannel = `peard:add-songs-to-playlist-response:${randomUUID()}`;
+        const timeout = setTimeout(() => {
+          ipcMain.removeAllListeners(responseChannel);
+          reject(new Error('Adding songs to playlist timed out'));
+        }, 10_000);
+
+        ipcMain.once(responseChannel, (_, error?: string) => {
+          clearTimeout(timeout);
+          if (error) {
+            reject(new Error(error));
+          } else {
+            resolve();
+          }
+        });
+
+        win.webContents.send(
+          'peard:add-songs-to-playlist',
+          responseChannel,
+          playlistId,
+          videoIds,
+        );
+      }),
     moveSongInQueue: (
       fromIndex: ArgsType<number>,
       toIndex: ArgsType<number>,

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -244,6 +244,39 @@ async function onApiLoaded() {
     },
   );
   window.ipcRenderer.on(
+    'peard:add-songs-to-playlist',
+    async (
+      _,
+      responseChannel: string,
+      playlistId: string,
+      videoIds: string[],
+    ) => {
+      const app = document.querySelector<MusicPlayerAppElement>('ytmusic-app');
+      if (!app) {
+        window.ipcRenderer.send(responseChannel, 'YouTube Music is not ready');
+        return;
+      }
+
+      try {
+        await app.networkManager.fetch('/browse/edit_playlist', {
+          playlistId,
+          actions: videoIds.map((addedVideoId) => ({
+            action: 'ACTION_ADD_VIDEO',
+            addedVideoId,
+          })),
+        });
+        window.ipcRenderer.send(responseChannel);
+      } catch (error) {
+        window.ipcRenderer.send(
+          responseChannel,
+          error instanceof Error
+            ? error.message
+            : 'Failed to add songs to playlist',
+        );
+      }
+    },
+  );
+  window.ipcRenderer.on(
     'peard:move-in-queue',
     (_, fromIndex: number, toIndex: number) => {
       const queue = document.querySelector<QueueElement>('#queue');


### PR DESCRIPTION
## Description

Adds `POST /api/v1/playlists/{playlistId}/songs` to the API Server. The endpoint accepts one or more YouTube Music `videoIds` and adds them to the requested playlist.

The implementation uses the authenticated `ytmusic-app.networkManager` already used by the renderer, so API clients do not need to handle YouTube cookies or credentials themselves.

## Motivation

External controllers can manage playback and the queue, but cannot save a song to a user playlist. This also provides the API building block needed for shortcuts such as #2725.

## Changes

- Add OpenAPI schemas for playlist IDs and video IDs
- Bridge the API request to the renderer through the existing song controls provider
- Wait for the YouTube Music mutation before returning `204`
- Return an error instead of reporting success when the player is unavailable or the mutation fails

## Validation

- `pnpm lint`
- `oxfmt --check` on the changed files
- `pnpm typecheck`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an API endpoint for adding multiple songs to a playlist in one request.
  - Added playlist and song input validation.
  - Added support for adding songs to playlists through the application interface.
  - Added clear success, error, and timeout handling for playlist updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->