### PR TITLE
feat(plugins): add Cinemode plugin to auto-switch to video mode

### DIFF
--- a/src/plugins/cinemode/index.ts
+++ b/src/plugins/cinemode/index.ts
@@ -1,0 +1,25 @@
+import { t } from '@/i18n';
+import { createPlugin } from '@/utils';
+
+import { startCinemodeObserver } from './observer';
+
+export default createPlugin({
+  name: () => t('Cinemode'),
+  description: () =>
+    t(
+      'Forces the player to always run in video mode. Useful for avoiding Youtube Music from switching modified songs to their original versions.',
+    ),
+  restartNeeded: false,
+  config: {
+    enabled: true,
+  },
+
+  renderer() {
+    console.log('cinemode renderer');
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', startCinemodeObserver);
+    } else {
+      startCinemodeObserver();
+    }
+  },
+});

--- a/src/plugins/cinemode/observer.ts
+++ b/src/plugins/cinemode/observer.ts
@@ -1,0 +1,25 @@
+import { forceVideoMode } from './toggle';
+
+/**
+ * Initializes a MutationObserver on the player bar to catch track changes.
+ */
+export function startCinemodeObserver() {
+  const playerBar = document.querySelector('ytmusic-player-bar');
+  if (!playerBar) {
+    setTimeout(startCinemodeObserver, 1000);
+    return;
+  }
+
+  const observer = new MutationObserver(() => {
+    forceVideoMode();
+  });
+
+  observer.observe(playerBar, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ['title', 'src'],
+  });
+
+  forceVideoMode();
+}

--- a/src/plugins/cinemode/toggle.ts
+++ b/src/plugins/cinemode/toggle.ts
@@ -1,0 +1,18 @@
+/**
+ * Searches for the video button and forces it to be selected if it is not already.
+ */
+export function forceVideoMode() {
+  const avToggle = document.querySelector('ytmusic-av-toggle');
+  if (!avToggle) return;
+
+  const videoButton = document.querySelector('button.video-button');
+  if (!videoButton) return;
+
+  const hasVideo = avToggle.hasAttribute('selected-item-has-video');
+  const isSelected = videoButton.getAttribute('aria-pressed') === 'true';
+
+  if (!isSelected && hasVideo) {
+    (videoButton as HTMLElement).click();
+    console.log('[Cinemode] Video mode selected.');
+  }
+}


### PR DESCRIPTION
## Description
Adds a new plugin called **Cinemode** that automatically switches playback to "Video" mode when a new track plays (if video mode is available).
## Motivation
For Premium users, YouTube Music defaults to "Song" mode. While you can click "Video" mode button and it persists, it only does so until the playlist hits a track without a music video, then it defaults back to "Song" mode until the user clicks the "Video" button again.
## Changes
- Added `src/plugins/cinemode`
## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Cinemode, which automatically keeps playback in video mode when available.
  - Video mode is applied when the player loads and maintained as tracks or playback details change.
  - Added a plugin setting to enable the feature by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->