### PR TITLE
feat(playback-speed): add pitch preservation toggle (#4588)

### DIFF
--- a/src/plugins/playback-speed/index.ts
+++ b/src/plugins/playback-speed/index.ts
@@ -1,6 +1,5 @@
 import { t } from '@/i18n';
 import { createPlugin } from '@/utils';
-
 import { onPlayerApiReady, onUnload } from './renderer';
 
 export default createPlugin({
@@ -9,6 +8,20 @@ export default createPlugin({
   restartNeeded: false,
   config: {
     enabled: false,
+    varispeed: false,
+  },
+  menu: async ({ getConfig, setConfig }) => {
+    const cfg = await getConfig();
+    return [
+      {
+        label: "Link Pitch",
+        type: 'checkbox',
+        checked: cfg.varispeed,
+        click: (item) => {
+          setConfig({ varispeed: item.checked });
+        },
+      }
+    ];
   },
   renderer: {
     stop: onUnload,

--- a/src/plugins/playback-speed/renderer.tsx
+++ b/src/plugins/playback-speed/renderer.tsx
@@ -52,6 +52,7 @@ export const onPlayerApiReady = async (
 ) => {
   const config = await context.getConfig();
   setVarispeed(config.varispeed);
+  linkPitch();
 
   context.ipc.on('config-changed', (id: string, newConfig: PlaybackSpeedConfig) => {
     if (id === 'playback-speed') {

--- a/src/plugins/playback-speed/renderer.tsx
+++ b/src/plugins/playback-speed/renderer.tsx
@@ -2,6 +2,9 @@ import { createSignal } from 'solid-js';
 import { render } from 'solid-js/web';
 
 import { t } from '@/i18n';
+import type { RendererContext } from '@/types/contexts';
+import type { MusicPlayer } from '@/types/music-player';
+import type { PluginConfig } from '@/types/plugins';
 import {
   isMusicOrVideoTrack,
   isPlayerMenu,
@@ -9,6 +12,10 @@ import {
 import { getSongMenu } from '@/providers/dom-elements';
 
 import { PlaybackSpeedSlider } from './components/slider';
+
+interface PlaybackSpeedConfig extends PluginConfig {
+  varispeed: boolean;
+}
 
 const MIN_PLAYBACK_SPEED = 0.07;
 const MAX_PLAYBACK_SPEED = 16;
@@ -25,19 +32,44 @@ const forcePlaybackRate = (e: Event) => {
 const roundToTwo = (n: number) => Math.round(n * 1e2) / 1e2;
 
 const [speed, setSpeed] = createSignal(1);
+const [varispeed, setVarispeed] = createSignal(false);
 const sliderContainer = document.createElement('div');
 
-export const onPlayerApiReady = () => {
+export const linkPitch = () => {
+      const videoElement = document.querySelector<HTMLVideoElement>('video');
+      if (videoElement) {
+        if(varispeed()){
+          videoElement.preservesPitch = false;
+        }else{
+          videoElement.preservesPitch = true;
+        }
+      }
+}
+
+export const onPlayerApiReady = async (
+  playerApi: MusicPlayer,
+  context: RendererContext<PlaybackSpeedConfig>,
+) => {
+  const config = await context.getConfig();
+  setVarispeed(config.varispeed);
+
+  context.ipc.on('config-changed', (id: string, newConfig: PlaybackSpeedConfig) => {
+    if (id === 'playback-speed') {
+      setVarispeed(newConfig.varispeed);
+      linkPitch();
+    }
+  });
+
   const observePopupContainer = () => {
     const updatePlayBackSpeed = () => {
       const videoElement = document.querySelector<HTMLVideoElement>('video');
       if (videoElement) {
         videoElement.playbackRate = speed();
+        linkPitch();
       }
 
       setSpeed(speed());
     };
-
     render(
       () => (
         <PlaybackSpeedSlider


### PR DESCRIPTION
Implemented optional toggle on the `preservesPitch` option of the  `HTMLVideoElement`, resulting in a vinyl-style pitch change in relation to the playback speed.

I had it implemented using IPC to allow toggling it to be propagated instantly (without the need for restart).

Fixes #4588 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a **Link Pitch** option to playback speed controls.
  - When enabled, playback speed changes preserve the original audio pitch.
  - The setting is available in the playback speed menu and responds immediately to configuration updates.
- **Bug Fixes**
  - Improved playback speed behavior so pitch-linking is correctly initialized and reapplied when settings change during playback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->