### PR TITLE
fix (ad-block) : add adblock plugin using @ghostery/adblocker-electron

### DIFF
--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -219,6 +219,14 @@
       "description": "If an ad play it mutes the audio and sets playback speed to 16x",
       "name": "Ad Speedup"
     },
+    "adblock": {
+      "description": "Block video and audio ads on YouTube Music",
+      "menu": {
+        "additional-lists": "Additional filter lists",
+        "lists-placeholder": "Comma-separated list of filter list URLs"
+      },
+      "name": "AdBlock"
+    },
     "album-actions": {
       "description": "Adds Undislike, Dislike, Like, and Unlike buttons to apply this to all songs in a playlist or album",
       "name": "Album Actions"

--- a/src/plugins/adblock/blocker.ts
+++ b/src/plugins/adblock/blocker.ts
@@ -2,6 +2,7 @@ import { ElectronBlocker } from '@ghostery/adblocker-electron';
 import { net } from 'electron';
 
 let blocker: ElectronBlocker | undefined;
+let generation = 0;
 
 export const DEFAULT_LISTS = [
   'https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/filters.txt',
@@ -15,8 +16,9 @@ export const loadAdblockerEngine = async (
   session: Electron.Session,
   additionalBlockLists: string[] = [],
 ) => {
+  const gen = ++generation;
   try {
-    blocker = await ElectronBlocker.fromLists(
+    const b = await ElectronBlocker.fromLists(
       (url: string) => net.fetch(url),
       [...DEFAULT_LISTS, ...additionalBlockLists],
       {
@@ -25,13 +27,23 @@ export const loadAdblockerEngine = async (
       },
       undefined,
     );
+    if (gen !== generation) {
+      b.disableBlockingInSession(session);
+      return;
+    }
+    const prev = blocker;
+    blocker = b;
     blocker.enableBlockingInSession(session);
+    if (prev) prev.disableBlockingInSession(session);
   } catch (error) {
-    console.error('[AdBlock] Error loading blocker engine', error);
+    if (gen === generation) {
+      console.error('[AdBlock] Error loading blocker engine', error);
+    }
   }
 };
 
 export const unloadAdblockerEngine = (session: Electron.Session) => {
+  generation++;
   if (blocker) {
     blocker.disableBlockingInSession(session);
     blocker = undefined;

--- a/src/plugins/adblock/blocker.ts
+++ b/src/plugins/adblock/blocker.ts
@@ -1,0 +1,39 @@
+import { ElectronBlocker } from '@ghostery/adblocker-electron';
+import { net } from 'electron';
+
+let blocker: ElectronBlocker | undefined;
+
+export const DEFAULT_LISTS = [
+  'https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/filters.txt',
+  'https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/badware.txt',
+  'https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/privacy.txt',
+  'https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/filters-2021.txt',
+  'https://raw.githubusercontent.com/easylist/easylist/master/easylist/easylist.txt',
+];
+
+export const loadAdblockerEngine = async (
+  session: Electron.Session,
+  additionalBlockLists: string[] = [],
+) => {
+  try {
+    blocker = await ElectronBlocker.fromLists(
+      (url: string) => net.fetch(url),
+      [...DEFAULT_LISTS, ...additionalBlockLists],
+      {
+        enableCompression: true,
+        loadNetworkFilters: true,
+      },
+      undefined,
+    );
+    blocker.enableBlockingInSession(session);
+  } catch (error) {
+    console.error('[AdBlock] Error loading blocker engine', error);
+  }
+};
+
+export const unloadAdblockerEngine = (session: Electron.Session) => {
+  if (blocker) {
+    blocker.disableBlockingInSession(session);
+    blocker = undefined;
+  }
+};

--- a/src/plugins/adblock/index.ts
+++ b/src/plugins/adblock/index.ts
@@ -1,0 +1,118 @@
+import prompt from 'custom-electron-prompt';
+import { contextBridge, webFrame, type BrowserWindow } from 'electron';
+
+import { t } from '@/i18n';
+import promptOptions from '@/providers/prompt-options';
+import { createPlugin } from '@/utils';
+
+import { loadAdblockerEngine, unloadAdblockerEngine } from './blocker';
+
+export interface AdBlockConfig {
+  enabled: boolean;
+  additionalBlockLists: string[];
+}
+
+export default createPlugin<
+  {
+    mainWindow: BrowserWindow | null;
+  },
+  unknown,
+  unknown,
+  AdBlockConfig
+>({
+  name: () => t('plugins.adblock.name'),
+  description: () => t('plugins.adblock.description'),
+  restartNeeded: false,
+  config: {
+    enabled: true,
+    additionalBlockLists: [],
+  } as AdBlockConfig,
+  menu: ({ getConfig, setConfig, window }) => {
+    const promptAdditionalLists = async () => {
+      const config = await getConfig();
+      const res = await prompt(
+        {
+          title: t('plugins.adblock.menu.additional-lists'),
+          value: config.additionalBlockLists.join(', '),
+          type: 'input',
+          ...promptOptions(),
+        },
+        window,
+      );
+      if (typeof res === 'string') {
+        setConfig({
+          additionalBlockLists: res
+            .split(',')
+            .map((s: string) => s.trim())
+            .filter(Boolean),
+        });
+      }
+    };
+
+    return [
+      {
+        label: t('plugins.adblock.menu.additional-lists'),
+        click: promptAdditionalLists,
+      },
+    ];
+  },
+  backend: {
+    mainWindow: null,
+    async start({ getConfig, window }) {
+      const config = await getConfig();
+      this.mainWindow = window;
+
+      await loadAdblockerEngine(
+        window.webContents.session,
+        config.additionalBlockLists,
+      );
+    },
+    stop({ window }) {
+      unloadAdblockerEngine(window.webContents.session);
+    },
+    async onConfigChange(newConfig) {
+      if (this.mainWindow) {
+        unloadAdblockerEngine(this.mainWindow.webContents.session);
+        await loadAdblockerEngine(
+          this.mainWindow.webContents.session,
+          newConfig.additionalBlockLists,
+        );
+      }
+    },
+  },
+  preload: {
+    start() {
+      const script = `const _prunerFn = window._pruner;
+    window._pruner = undefined;
+    JSON.parse = new Proxy(JSON.parse, {
+      apply() {
+        return _prunerFn(Reflect.apply(...arguments));
+      },
+    });
+    Response.prototype.json = new Proxy(Response.prototype.json, {
+      apply() {
+        return Reflect.apply(...arguments).then((o) => _prunerFn(o));
+      },
+    }); 0`;
+
+      contextBridge.exposeInMainWorld('_pruner', (o: Record<string, unknown>) => {
+        delete o.playerAds;
+        delete o.adPlacements;
+        delete o.adSlots;
+        if (o.playerResponse as Record<string, unknown> | undefined) {
+          delete (o.playerResponse as Record<string, unknown>).playerAds;
+          delete (o.playerResponse as Record<string, unknown>).adPlacements;
+          delete (o.playerResponse as Record<string, unknown>).adSlots;
+        }
+        if (o.ytInitialPlayerResponse as Record<string, unknown> | undefined) {
+          delete (o.ytInitialPlayerResponse as Record<string, unknown>).playerAds;
+          delete (o.ytInitialPlayerResponse as Record<string, unknown>).adPlacements;
+          delete (o.ytInitialPlayerResponse as Record<string, unknown>).adSlots;
+        }
+        return o;
+      });
+
+      webFrame.executeJavaScript(script);
+    },
+  },
+});

--- a/src/plugins/adblock/index.ts
+++ b/src/plugins/adblock/index.ts
@@ -72,7 +72,6 @@ export default createPlugin<
     },
     async onConfigChange(newConfig) {
       if (this.mainWindow) {
-        unloadAdblockerEngine(this.mainWindow.webContents.session);
         await loadAdblockerEngine(
           this.mainWindow.webContents.session,
           newConfig.additionalBlockLists,
@@ -95,21 +94,23 @@ export default createPlugin<
       },
     }); 0`;
 
-      contextBridge.exposeInMainWorld('_pruner', (o: Record<string, unknown>) => {
-        delete o.playerAds;
-        delete o.adPlacements;
-        delete o.adSlots;
-        if (o.playerResponse as Record<string, unknown> | undefined) {
-          delete (o.playerResponse as Record<string, unknown>).playerAds;
-          delete (o.playerResponse as Record<string, unknown>).adPlacements;
-          delete (o.playerResponse as Record<string, unknown>).adSlots;
+      contextBridge.exposeInMainWorld('_pruner', (o: unknown) => {
+        if (o === null || typeof o !== 'object') return o;
+        const payload = o as Record<string, unknown>;
+        delete payload.playerAds;
+        delete payload.adPlacements;
+        delete payload.adSlots;
+        if (payload.playerResponse as Record<string, unknown> | undefined) {
+          delete (payload.playerResponse as Record<string, unknown>).playerAds;
+          delete (payload.playerResponse as Record<string, unknown>).adPlacements;
+          delete (payload.playerResponse as Record<string, unknown>).adSlots;
         }
-        if (o.ytInitialPlayerResponse as Record<string, unknown> | undefined) {
-          delete (o.ytInitialPlayerResponse as Record<string, unknown>).playerAds;
-          delete (o.ytInitialPlayerResponse as Record<string, unknown>).adPlacements;
-          delete (o.ytInitialPlayerResponse as Record<string, unknown>).adSlots;
+        if (payload.ytInitialPlayerResponse as Record<string, unknown> | undefined) {
+          delete (payload.ytInitialPlayerResponse as Record<string, unknown>).playerAds;
+          delete (payload.ytInitialPlayerResponse as Record<string, unknown>).adPlacements;
+          delete (payload.ytInitialPlayerResponse as Record<string, unknown>).adSlots;
         }
-        return o;
+        return payload;
       });
 
       webFrame.executeJavaScript(script);


### PR DESCRIPTION
AdBlock Plugin
    
    Blocks video/audio ads on YouTube Music using the existing @ghostery/adblocker-electron dependency.
    
    How it works
    
    Two layers:
    
    1. Backend (main process) — Loads Ghostery's ElectronBlocker engine with YouTube-specific filter lists (uBlock Origin filters + EasyList) and blocks ad network requests at the Chromium level via enableBlockingInSession().
    
    2. Preload (renderer world) — Uses contextBridge.exposeInMainWorld + webFrame.executeJavaScript to intercept JSON.parse and Response.prototype.json in the main world, stripping playerAds, adPlacements, and adSlots from YouTube's API responses.
    
    Default filter lists
    
    - uBlock Origin general filters
    - uBlock Origin badware risks
    - uBlock Origin privacy trackers
    - uBlock Origin YouTube supplement (filters-2021)
    - EasyList
    
    Menu
    
    - Configurable additional filter list URLs via custom-electron-prompt
    
    Notes
    
    - Follows the same contextBridge + webFrame.executeJavaScript pattern as the existing do-not-track plugin's InPlayer blocker.
    - Enabled by default.
    - restartNeeded: false — toggles on/off without restart.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an AdBlock plugin to block ads during browsing.
  * Enabled loading filter lists from remote sources, with support for adding extra blocklist URLs.
  * Added AdBlock settings UI (menu label, description, and lists input placeholder).
  * Filtered ad-related fields from supported JSON response data before it reaches the renderer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->