### PR TITLE
feat(api-server): expose real-time audio spectrum over REST and WebSocket

### DIFF
--- a/src/plugins/api-server/backend/main.ts
+++ b/src/plugins/api-server/backend/main.ts
@@ -89,7 +89,11 @@ export const backend = createBackend<BackendType, APIServerConfig>({
 
   startSpectrumPolling(config) {
     this.stopSpectrumPolling();
-    if (!config.spectrumEnabled || !this.backendCtx) return;
+    if (!config.spectrumEnabled || !this.backendCtx) {
+      // Drop cached frames so GET /spectrum returns 204 while disabled.
+      this.spectrum = undefined;
+      return;
+    }
 
     const fps = Math.min(60, Math.max(5, Math.round(config.spectrumFps ?? 20)));
     this.spectrumTimer = setInterval(
@@ -233,6 +237,7 @@ export const backend = createBackend<BackendType, APIServerConfig>({
   },
   end() {
     this.stopSpectrumPolling();
+    this.spectrum = undefined;
     this.server?.close();
     this.server = undefined;
   },

--- a/src/plugins/api-server/backend/main.ts
+++ b/src/plugins/api-server/backend/main.ts
@@ -19,6 +19,7 @@ import { JWTPayloadSchema } from './scheme';
 
 import { type APIServerConfig, AuthStrategy } from '../config';
 
+import type { SpectrumData } from './routes/websocket';
 import type { BackendType } from './types';
 import type {
   LikeType,
@@ -30,6 +31,7 @@ import type { MiddlewareHandler } from 'hono';
 export const backend = createBackend<BackendType, APIServerConfig>({
   async start(ctx) {
     const config = await ctx.getConfig();
+    this.backendCtx = ctx;
 
     this.init(ctx);
     registerCallback((songInfo) => {
@@ -55,31 +57,60 @@ export const backend = createBackend<BackendType, APIServerConfig>({
       (newVolumeState: VolumeState) => (this.volumeState = newVolumeState),
     );
 
+    ctx.ipc.on(
+      'peard:audio-spectrum',
+      (spectrum: SpectrumData) => (this.spectrum = spectrum),
+    );
+
     this.run(config);
+    this.startSpectrumPolling(config);
   },
   stop() {
+    this.stopSpectrumPolling();
     this.end();
   },
   onConfigChange(config) {
     const old = this.oldConfig;
-    if (
-      old?.hostname === config.hostname &&
-      old?.port === config.port &&
-      old?.useHttps === config.useHttps &&
-      old?.certPath === config.certPath &&
-      old?.keyPath === config.keyPath
-    ) {
-      this.oldConfig = config;
-      return;
+    const serverChanged =
+      old?.hostname != config.hostname ||
+      old?.port != config.port ||
+      old?.useHttps != config.useHttps ||
+      old?.certPath != config.certPath ||
+      old?.keyPath != config.keyPath;
+
+    if (serverChanged) {
+      this.end();
+      this.run(config);
     }
 
-    this.end();
-    this.run(config);
+    this.startSpectrumPolling(config);
     this.oldConfig = config;
+  },
+
+  startSpectrumPolling(config) {
+    this.stopSpectrumPolling();
+    if (!config.spectrumEnabled || !this.backendCtx) return;
+
+    const fps = Math.min(60, Math.max(5, Math.round(config.spectrumFps ?? 20)));
+    this.spectrumTimer = setInterval(
+      () => {
+        if (!this.backendCtx || this.backendCtx.window.isDestroyed()) return;
+        this.backendCtx.ipc.send('peard:request-spectrum');
+      },
+      Math.round(1000 / fps),
+    );
+  },
+
+  stopSpectrumPolling() {
+    if (this.spectrumTimer) {
+      clearInterval(this.spectrumTimer);
+      this.spectrumTimer = undefined;
+    }
   },
 
   // Custom
   init(backendCtx) {
+    this.backendCtx = backendCtx;
     this.app = new Hono();
 
     this.app.use('*', cors());
@@ -137,6 +168,7 @@ export const backend = createBackend<BackendType, APIServerConfig>({
           'document.querySelector("#like-button-renderer")?.likeStatus',
         ) as Promise<LikeType>,
       () => this.volumeState,
+      () => this.spectrum,
     );
     registerAuth(this.app, backendCtx);
     registerWebsocket(this.app, backendCtx, upgradeWebSocket);
@@ -200,6 +232,7 @@ export const backend = createBackend<BackendType, APIServerConfig>({
     }
   },
   end() {
+    this.stopSpectrumPolling();
     this.server?.close();
     this.server = undefined;
   },

--- a/src/plugins/api-server/backend/routes/control.ts
+++ b/src/plugins/api-server/backend/routes/control.ts
@@ -27,6 +27,7 @@ import {
 
 import type { APIServerConfig } from '../../config';
 import type { HonoApp } from '../types';
+import type { SpectrumData } from './websocket';
 import type { SongInfo } from '@/providers/song-info';
 import type { BackendContext } from '@/types/contexts';
 import type { QueueResponse } from '@/types/music-player-desktop-internal';
@@ -298,6 +299,30 @@ const routes = {
             }),
           },
         },
+      },
+    },
+  }),
+  getSpectrum: createRoute({
+    method: 'get',
+    path: `/api/${API_VERSION}/spectrum`,
+    summary: 'get audio spectrum',
+    description:
+      'Get the most recent audio spectrum frame. Bands are log-spaced and each value is 0-255. Returns 204 if spectrum streaming is disabled or no audio has played yet.',
+    responses: {
+      200: {
+        description: 'Success',
+        content: {
+          'application/json': {
+            schema: z.object({
+              bands: z.array(z.number()),
+              peak: z.number(),
+              timestamp: z.number(),
+            }),
+          },
+        },
+      },
+      204: {
+        description: 'No spectrum data',
       },
     },
   }),
@@ -576,6 +601,7 @@ export const register = (
   repeatModeGetter: () => PromiseOrValue<RepeatMode | undefined>,
   likeTypeGetter: () => PromiseOrValue<LikeType | undefined>,
   volumeStateGetter: () => PromiseOrValue<VolumeState | undefined>,
+  spectrumGetter: () => PromiseOrValue<SpectrumData | undefined>,
 ) => {
   const controller = getSongControls(window);
 
@@ -695,6 +721,17 @@ export const register = (
     return ctx.json(
       (await volumeStateGetter()) ?? { state: 0, isMuted: false },
     );
+  });
+  app.openapi(routes.getSpectrum, async (ctx) => {
+    const spectrum = await spectrumGetter();
+
+    if (!spectrum) {
+      ctx.status(204);
+      return ctx.body(null);
+    }
+
+    ctx.status(200);
+    return ctx.json(spectrum);
   });
   app.openapi(routes.setFullscreen, (ctx) => {
     const { state } = ctx.req.valid('json');

--- a/src/plugins/api-server/backend/routes/websocket.ts
+++ b/src/plugins/api-server/backend/routes/websocket.ts
@@ -28,7 +28,16 @@ enum DataTypes {
   VolumeChanged = 'VOLUME_CHANGED',
   RepeatChanged = 'REPEAT_CHANGED',
   ShuffleChanged = 'SHUFFLE_CHANGED',
+  Spectrum = 'SPECTRUM',
 }
+
+export type SpectrumData = {
+  /** Log-spaced frequency bands, each 0-255. */
+  bands: number[];
+  /** Highest band value in this frame, 0-255. */
+  peak: number;
+  timestamp: number;
+};
 
 type PlayerState = {
   song?: SongInfo;
@@ -51,11 +60,20 @@ export const register = (
   let lastSongInfo: SongInfo | undefined = undefined;
 
   const sockets = new Set<WSContext<WebSocketLike>>();
+  // Spectrum is high-frequency, so it's opt-in per socket.
+  const spectrumSockets = new Set<WSContext<WebSocketLike>>();
 
   const send = (type: DataTypes, state: Partial<PlayerState>) => {
     sockets.forEach((socket) =>
       socket.send(JSON.stringify({ type, ...state })),
     );
+  };
+
+  const sendSpectrum = (data: SpectrumData) => {
+    if (spectrumSockets.size == 0) return;
+
+    const payload = JSON.stringify({ type: DataTypes.Spectrum, ...data });
+    spectrumSockets.forEach((socket) => socket.send(payload));
   };
 
   const createPlayerState = ({
@@ -126,6 +144,10 @@ export const register = (
     send(DataTypes.ShuffleChanged, { shuffle });
   });
 
+  ipc.on('peard:audio-spectrum', (data: SpectrumData) => {
+    sendSpectrum(data);
+  });
+
   app.openapi(
     createRoute({
       method: 'get',
@@ -163,14 +185,22 @@ export const register = (
 
           try {
             const payload = await verify(token, config.secret, 'HS256');
-            const parsedPayload = await JWTPayloadSchema.safeParseAsync(payload);
+            const parsedPayload =
+              await JWTPayloadSchema.safeParseAsync(payload);
 
-            if (!parsedPayload.success || !config.authorizedClients.includes(parsedPayload.data.id)) {
+            if (
+              !parsedPayload.success ||
+              !config.authorizedClients.includes(parsedPayload.data.id)
+            ) {
               ws.close(1008, 'Unauthorized');
               return;
             }
           } catch (err) {
-            console.error(LoggerPrefix, 'WebSocket authentication failed:', err);
+            console.error(
+              LoggerPrefix,
+              'WebSocket authentication failed:',
+              err,
+            );
             ws.close(1008, 'Unauthorized');
             return;
           }
@@ -191,8 +221,29 @@ export const register = (
         );
       },
 
+      onMessage(event, ws) {
+        // Clients opt in/out of the spectrum stream:
+        //   { "type": "SUBSCRIBE_SPECTRUM" } / { "type": "UNSUBSCRIBE_SPECTRUM" }
+        if (typeof event.data != 'string') return;
+        const raw = event.data;
+
+        let message: { type?: string } | undefined;
+        try {
+          message = JSON.parse(raw) as { type?: string };
+        } catch {
+          return;
+        }
+
+        if (message?.type == 'SUBSCRIBE_SPECTRUM') {
+          spectrumSockets.add(ws);
+        } else if (message?.type == 'UNSUBSCRIBE_SPECTRUM') {
+          spectrumSockets.delete(ws);
+        }
+      },
+
       onClose(_, ws) {
         sockets.delete(ws);
+        spectrumSockets.delete(ws);
       },
     })) as (ctx: Context, next: Next) => Promise<Response>,
   );

--- a/src/plugins/api-server/backend/types.ts
+++ b/src/plugins/api-server/backend/types.ts
@@ -2,6 +2,7 @@ import { type serve } from '@hono/node-server';
 import { type OpenAPIHono as Hono } from '@hono/zod-openapi';
 
 import type { APIServerConfig } from '../config';
+import type { SpectrumData } from './routes/websocket';
 import type { SongInfo } from '@/providers/song-info';
 import type { BackendContext } from '@/types/contexts';
 import type { RepeatMode, VolumeState } from '@/types/datahost-get-state';
@@ -14,8 +15,14 @@ export type BackendType = {
   songInfo?: SongInfo;
   currentRepeatMode?: RepeatMode;
   volumeState?: VolumeState;
+  spectrum?: SpectrumData;
+  /** Main-process timer — not throttled when Pear is unfocused. */
+  spectrumTimer?: ReturnType<typeof setInterval>;
+  backendCtx?: BackendContext<APIServerConfig>;
 
   init: (ctx: BackendContext<APIServerConfig>) => void;
   run: (config: APIServerConfig) => void;
   end: () => void;
+  startSpectrumPolling: (config: APIServerConfig) => void;
+  stopSpectrumPolling: () => void;
 };

--- a/src/plugins/api-server/config.ts
+++ b/src/plugins/api-server/config.ts
@@ -14,6 +14,13 @@ export interface APIServerConfig {
   useHttps: boolean;
   certPath: string;
   keyPath: string;
+
+  /** Stream real-time audio spectrum data over the API. */
+  spectrumEnabled: boolean;
+  /** Number of log-spaced frequency bands to report. */
+  spectrumBands: number;
+  /** How many spectrum frames per second to emit. */
+  spectrumFps: number;
 }
 
 export const defaultAPIServerConfig: APIServerConfig = {
@@ -27,4 +34,8 @@ export const defaultAPIServerConfig: APIServerConfig = {
   useHttps: false,
   certPath: '',
   keyPath: '',
+
+  spectrumEnabled: true,
+  spectrumBands: 16,
+  spectrumFps: 20,
 };

--- a/src/plugins/api-server/index.ts
+++ b/src/plugins/api-server/index.ts
@@ -4,6 +4,11 @@ import { createPlugin } from '@/utils';
 import { backend } from './backend';
 import { defaultAPIServerConfig } from './config';
 import { onMenu } from './menu';
+import {
+  onRendererConfigChange,
+  onRendererLoad,
+  onRendererUnload,
+} from './renderer';
 
 export default createPlugin({
   name: () => t('plugins.api-server.name'),
@@ -14,4 +19,10 @@ export default createPlugin({
   menu: onMenu,
 
   backend,
+
+  renderer: {
+    start: onRendererLoad,
+    onConfigChange: onRendererConfigChange,
+    stop: onRendererUnload,
+  },
 });

--- a/src/plugins/api-server/renderer.ts
+++ b/src/plugins/api-server/renderer.ts
@@ -127,6 +127,10 @@ const audioCanPlayListener = (e: CustomEvent<Compressor>) => {
   }
 };
 
+const onRequestSpectrum = () => {
+  sampleAndSend();
+};
+
 export const onRendererLoad = async ({
   getConfig,
   ipc,
@@ -135,9 +139,7 @@ export const onRendererLoad = async ({
   rendererIpc = ipc;
 
   // Main process drives the sample rate so background throttling doesn't apply.
-  ipc.on('peard:request-spectrum', () => {
-    sampleAndSend();
-  });
+  ipc.on('peard:request-spectrum', onRequestSpectrum);
 
   document.addEventListener('peard:audio-can-play', audioCanPlayListener, {
     passive: true,
@@ -150,6 +152,7 @@ export const onRendererConfigChange = (newConfig: APIServerConfig) => {
 
 export const onRendererUnload = () => {
   document.removeEventListener('peard:audio-can-play', audioCanPlayListener);
+  rendererIpc?.removeAllListeners('peard:request-spectrum');
 
   if (connectedSource && analyser) {
     try {

--- a/src/plugins/api-server/renderer.ts
+++ b/src/plugins/api-server/renderer.ts
@@ -32,12 +32,18 @@ const computeBands = (bandCount: number): number[] => {
   const binCount = freqData.length;
   const hzPerBin = analyser.context.sampleRate / analyser.fftSize;
   const minHz = 40;
-  const maxHz = Math.min(14_000, analyser.context.sampleRate / 2);
+  // Rightmost bars should track presence that exists in typical streaming
+  // audio — the final log band is wide in Hz, so keep maxHz modest.
+  const maxHz = Math.min(4_200, analyser.context.sampleRate / 2);
   const frequencyRatio = maxHz / minHz;
-  // Soften the extreme low end a bit so kicks don't dominate every bar.
-  const shelf = Array.from({ length: bandCount }, (_, i) =>
-    i < 3 ? 0.72 + i * 0.08 : 1,
-  );
+  // Soften kicks; lift highs — music energy falls with Hz, and wide
+  // log HF bands dilute RMS so the right side otherwise stays dark.
+  const shelf = Array.from({ length: bandCount }, (_, i) => {
+    const t = i / Math.max(1, bandCount - 1);
+    const bass = i < 3 ? 0.72 + i * 0.08 : 1;
+    const treble = 1 + 1.4 * t * t + (t > 0.6 ? 0.7 * ((t - 0.6) / 0.4) : 0);
+    return bass * treble;
+  });
 
   const bands = Array.from({ length: bandCount }, () => 0);
   let framePeak = 1;
@@ -53,14 +59,30 @@ const computeBands = (bandCount: number): number[] => {
     );
 
     let energy = 0;
+    let binPeak = 0;
+    let topSum = 0;
+    let topCount = 0;
+    const mix = i / Math.max(1, bandCount - 1);
+    // For upper bands, only the louder bins count toward "upper" energy.
+    const loudFloor = mix > 0.55 ? 8 : 0;
     for (let bin = start; bin < end; bin++) {
       const v = freqData[bin];
       energy += v * v;
+      if (v > binPeak) binPeak = v;
+      if (v >= loudFloor) {
+        topSum += v;
+        topCount += 1;
+      }
     }
 
-    const rms = Math.sqrt(energy / (end - start)) * shelf[i];
-    bands[i] = rms;
-    if (rms > framePeak) framePeak = rms;
+    const rms = Math.sqrt(energy / (end - start));
+    const upper = topCount > 0 ? topSum / topCount : binPeak;
+    // Prefer peak-ish measure on the right so sparse HF isn't RMS-diluted.
+    const peakW = 0.2 + 0.75 * mix * mix;
+    const level =
+      (rms * (1 - peakW) + Math.max(binPeak * 0.85, upper) * peakW) * shelf[i];
+    bands[i] = level;
+    if (level > framePeak) framePeak = level;
   }
 
   // Slow AGC — track loudness, keep clear headroom above recent peaks.
@@ -110,7 +132,8 @@ const audioCanPlayListener = (e: CustomEvent<Compressor>) => {
     analyser = ctx.createAnalyser();
     analyser.fftSize = 2048;
     analyser.smoothingTimeConstant = 0.55;
-    analyser.minDecibels = -80;
+    // Slightly deeper floor so quiet HF registers in byte data.
+    analyser.minDecibels = -90;
     analyser.maxDecibels = -25;
     freqData = new Uint8Array(analyser.frequencyBinCount);
     connectedSource = null;

--- a/src/plugins/api-server/renderer.ts
+++ b/src/plugins/api-server/renderer.ts
@@ -1,0 +1,167 @@
+import type { APIServerConfig } from './config';
+import type { RendererContext } from '@/types/contexts';
+
+/**
+ * Exposes real-time audio spectrum samples to the backend.
+ * Sampling is driven by the main process (not a renderer timer) so it
+ * stays responsive when the Pear window is unfocused / backgrounded.
+ */
+
+let config: APIServerConfig | undefined;
+let rendererIpc: RendererContext<APIServerConfig>['ipc'] | undefined;
+
+let analyser: AnalyserNode | null = null;
+let audioContext: AudioContext | null = null;
+let freqData: Uint8Array<ArrayBuffer> | null = null;
+let connectedSource: MediaElementAudioSourceNode | null = null;
+
+/** Rolling peak used to leave headroom so bars don't sit pegged. */
+let rollingPeak = 48;
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(max, Math.max(min, value));
+
+/**
+ * Collapse FFT bins into log-spaced bands (0-255).
+ */
+const computeBands = (bandCount: number): number[] => {
+  if (!analyser || !freqData) return [];
+
+  analyser.getByteFrequencyData(freqData);
+
+  const binCount = freqData.length;
+  const hzPerBin = analyser.context.sampleRate / analyser.fftSize;
+  const minHz = 40;
+  const maxHz = Math.min(14_000, analyser.context.sampleRate / 2);
+  const frequencyRatio = maxHz / minHz;
+  // Soften the extreme low end a bit so kicks don't dominate every bar.
+  const shelf = Array.from({ length: bandCount }, (_, i) =>
+    i < 3 ? 0.72 + i * 0.08 : 1,
+  );
+
+  const bands = Array.from({ length: bandCount }, () => 0);
+  let framePeak = 1;
+
+  for (let i = 0; i < bandCount; i++) {
+    const lowHz = minHz * Math.pow(frequencyRatio, i / bandCount);
+    const highHz = minHz * Math.pow(frequencyRatio, (i + 1) / bandCount);
+    const start = clamp(Math.floor(lowHz / hzPerBin), 1, binCount - 1);
+    const end = clamp(
+      Math.max(Math.ceil(highHz / hzPerBin), start + 1),
+      2,
+      binCount,
+    );
+
+    let energy = 0;
+    for (let bin = start; bin < end; bin++) {
+      const v = freqData[bin];
+      energy += v * v;
+    }
+
+    const rms = Math.sqrt(energy / (end - start)) * shelf[i];
+    bands[i] = rms;
+    if (rms > framePeak) framePeak = rms;
+  }
+
+  // Slow AGC — track loudness, keep clear headroom above recent peaks.
+  rollingPeak = Math.max(28, rollingPeak * 0.9 + framePeak * 0.1);
+  const scale = 145 / rollingPeak;
+
+  for (let i = 0; i < bandCount; i++) {
+    // Mild compression keeps dynamics without slamming the ceiling.
+    const shaped = Math.pow(Math.max(0, bands[i] * scale) / 255, 1.05) * 255;
+    bands[i] = Math.round(clamp(shaped, 0, 185));
+  }
+
+  return bands;
+};
+
+const sampleAndSend = () => {
+  if (!config?.spectrumEnabled || !analyser || !rendererIpc) return;
+
+  // Chromium can suspend AudioContext when unfocused — keep it alive.
+  if (audioContext?.state == 'suspended') {
+    void audioContext.resume();
+  }
+
+  const bandCount = clamp(Math.round(config.spectrumBands ?? 16), 4, 64);
+  const bands = computeBands(bandCount);
+  if (!bands.length) return;
+
+  let peak = 0;
+  for (const value of bands) {
+    if (value > peak) peak = value;
+  }
+
+  rendererIpc.send('peard:audio-spectrum', {
+    bands,
+    peak,
+    timestamp: Date.now(),
+  });
+};
+
+const audioCanPlayListener = (e: CustomEvent<Compressor>) => {
+  const { audioContext: ctx, audioSource } = e.detail;
+  if (!ctx || !audioSource) return;
+
+  audioContext = ctx;
+
+  if (!analyser || analyser.context != ctx) {
+    analyser = ctx.createAnalyser();
+    analyser.fftSize = 2048;
+    analyser.smoothingTimeConstant = 0.55;
+    analyser.minDecibels = -80;
+    analyser.maxDecibels = -25;
+    freqData = new Uint8Array(analyser.frequencyBinCount);
+    connectedSource = null;
+    rollingPeak = 48;
+  }
+
+  if (connectedSource != audioSource) {
+    audioSource.connect(analyser);
+    connectedSource = audioSource;
+  }
+
+  if (ctx.state == 'suspended') {
+    void ctx.resume();
+  }
+};
+
+export const onRendererLoad = async ({
+  getConfig,
+  ipc,
+}: RendererContext<APIServerConfig>) => {
+  config = await getConfig();
+  rendererIpc = ipc;
+
+  // Main process drives the sample rate so background throttling doesn't apply.
+  ipc.on('peard:request-spectrum', () => {
+    sampleAndSend();
+  });
+
+  document.addEventListener('peard:audio-can-play', audioCanPlayListener, {
+    passive: true,
+  });
+};
+
+export const onRendererConfigChange = (newConfig: APIServerConfig) => {
+  config = newConfig;
+};
+
+export const onRendererUnload = () => {
+  document.removeEventListener('peard:audio-can-play', audioCanPlayListener);
+
+  if (connectedSource && analyser) {
+    try {
+      connectedSource.disconnect(analyser);
+    } catch {
+      // already disconnected
+    }
+  }
+
+  analyser = null;
+  audioContext = null;
+  freqData = null;
+  connectedSource = null;
+  rendererIpc = undefined;
+};


### PR DESCRIPTION
## Summary
- Hook the player Web Audio graph (`peard:audio-can-play`) with an `AnalyserNode` and publish log-spaced frequency bands (0–255).
- Add `GET /api/v1/spectrum` and an opt-in WebSocket `SPECTRUM` stream (`SUBSCRIBE_SPECTRUM` / `UNSUBSCRIBE_SPECTRUM`).
- Drive sampling from the main process so it stays responsive when the Pear window is unfocused.

## API
- **REST:** `GET /api/v1/spectrum` → `{ bands, peak, timestamp }` (204 if no data yet)
- **WebSocket:** send `{ type: SUBSCRIBE_SPECTRUM }` to receive `{ type: SPECTRUM, bands, peak, timestamp }` frames
- **Config:** `spectrumEnabled` (default true), `spectrumBands` (16), `spectrumFps` (20)

## Test plan
- [ ] Enable API Server, play audio, confirm `GET /api/v1/spectrum` returns non-empty bands that move with the track
- [ ] Connect WebSocket, send `SUBSCRIBE_SPECTRUM`, confirm frames at ~configured fps
- [ ] Unfocus / minimize Pear and confirm spectrum updates continue (no Chromium background throttle)
- [ ] Send `UNSUBSCRIBE_SPECTRUM` and confirm frames stop for that socket
- [ ] Disable `spectrumEnabled` and confirm REST returns 204 / WS stops emitting


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added real-time audio spectrum streaming with new configuration: enablement, band count, and update rate.
  - Added `GET /api/{API_VERSION}/spectrum` to fetch the latest spectrum frame; returns no content when disabled/unavailable.
  - Added optional WebSocket spectrum subscriptions for live spectrum updates.
  - Spectrum frames now include band levels, a rolling peak metric, and timestamps, and are integrated into the server start/stop lifecycle.
- **Improvements**
  - Spectrum polling and streaming adapt to configuration changes automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->