### PR TITLE
feat(api-server): playlist playback, queue ops and player-state endpoints

### DIFF
--- a/src/plugins/api-server/backend/routes/control.ts
+++ b/src/plugins/api-server/backend/routes/control.ts
@@ -620,6 +620,13 @@ export const register = (
     ctx.status(204);
     return ctx.body(null);
   });
+  app.openapi(routes.playPlaylist, (ctx) => {
+    const { playlistId, videoId } = ctx.req.valid('json');
+    controller.playPlaylist(playlistId, videoId);
+
+    ctx.status(204);
+    return ctx.body(null);
+  });
   app.openapi(routes.pause, (ctx) => {
     controller.pause();
 

--- a/src/plugins/api-server/backend/routes/control.ts
+++ b/src/plugins/api-server/backend/routes/control.ts
@@ -66,6 +66,29 @@ const routes = {
       },
     },
   }),
+    playPlaylist: createRoute({
+    method: 'post',
+    path: `/api/${API_VERSION}/playPlaylist`,
+    summary: 'play playlist',
+    description: 'Plays a playlist given its ID and optionally a video ID',
+    request: {
+      body: {
+        content: {
+          'application/json': {
+            schema: z.object({
+              playlistId: z.string().describe('Playlist ID'),
+              videoId: z.string().optional().describe('Video ID (optional)'),
+            }),
+          },
+        },
+      },
+    },
+    responses: {
+      204: {
+        description: 'Success',
+      },
+    },
+  }),
   pause: createRoute({
     method: 'post',
     path: `/api/${API_VERSION}/pause`,

--- a/src/plugins/api-server/backend/routes/control.ts
+++ b/src/plugins/api-server/backend/routes/control.ts
@@ -11,12 +11,20 @@ import {
 import { API_VERSION } from '../api-version';
 import {
   AddSongsToPlaylistSchema,
+  AddSongsToQueueSchema,
   AddSongToQueueSchema,
   GoBackSchema,
   GoForwardScheme,
   MoveSongInQueueSchema,
+  PlayAlbumSchema,
+  PlayArtistSchema,
+  PlayerStateSchema,
+  PlaylistIdParamsSchema,
+  PlaylistInfoSchema,
   PlaylistParamsSchema,
+  PlayPlaylistSchema,
   QueueParamsSchema,
+  ReorderQueueSchema,
   SearchSchema,
   SeekSchema,
   SetFullscreenSchema,
@@ -68,7 +76,7 @@ const routes = {
       },
     },
   }),
-    playPlaylist: createRoute({
+  playPlaylist: createRoute({
     method: 'post',
     path: `/api/${API_VERSION}/playPlaylist`,
     summary: 'play playlist',
@@ -77,10 +85,49 @@ const routes = {
       body: {
         content: {
           'application/json': {
-            schema: z.object({
-              playlistId: z.string().describe('Playlist ID'),
-              videoId: z.string().optional().describe('Video ID (optional)'),
-            }),
+            schema: PlayPlaylistSchema,
+          },
+        },
+      },
+    },
+    responses: {
+      204: {
+        description: 'Success',
+      },
+    },
+  }),
+  playArtist: createRoute({
+    method: 'post',
+    path: `/api/${API_VERSION}/playArtist`,
+    summary: 'play artist',
+    description:
+      'Plays top songs / shuffle playlist for an artist given a channel ID',
+    request: {
+      body: {
+        content: {
+          'application/json': {
+            schema: PlayArtistSchema,
+          },
+        },
+      },
+    },
+    responses: {
+      204: {
+        description: 'Success',
+      },
+    },
+  }),
+  playAlbum: createRoute({
+    method: 'post',
+    path: `/api/${API_VERSION}/playAlbum`,
+    summary: 'play album',
+    description:
+      'Plays an album given a browse ID (MPREb_...) or audio playlist ID (OLAK5uy_...)',
+    request: {
+      body: {
+        content: {
+          'application/json': {
+            schema: PlayAlbumSchema,
           },
         },
       },
@@ -496,6 +543,69 @@ const routes = {
       },
     },
   }),
+  addManyToQueue: createRoute({
+    method: 'post',
+    path: `/api/${API_VERSION}/queue/add-many`,
+    summary: 'add many songs to queue',
+    description: 'Add multiple songs to the queue in one request',
+    request: {
+      body: {
+        description: 'video ids of the songs to add',
+        content: {
+          'application/json': {
+            schema: AddSongsToQueueSchema,
+          },
+        },
+      },
+    },
+    responses: {
+      204: {
+        description: 'Success',
+      },
+    },
+  }),
+  reorderQueue: createRoute({
+    method: 'post',
+    path: `/api/${API_VERSION}/queue/reorder`,
+    summary: 'reorder queue',
+    description:
+      'Reorder the queue using fromIndex/toIndex or a full order permutation',
+    request: {
+      body: {
+        content: {
+          'application/json': {
+            schema: ReorderQueueSchema,
+          },
+        },
+      },
+    },
+    responses: {
+      204: {
+        description: 'Success',
+      },
+      400: {
+        description: 'Invalid reorder payload',
+        content: {
+          'application/json': {
+            schema: z.object({
+              error: z.string(),
+            }),
+          },
+        },
+      },
+    },
+  }),
+  clearQueuePost: createRoute({
+    method: 'post',
+    path: `/api/${API_VERSION}/queue/clear`,
+    summary: 'clear queue',
+    description: 'Clear the queue (POST alias of DELETE /queue)',
+    responses: {
+      204: {
+        description: 'Success',
+      },
+    },
+  }),
   addSongsToPlaylist: createRoute({
     method: 'post',
     path: `/api/${API_VERSION}/playlists/{playlistId}/songs`,
@@ -596,6 +706,52 @@ const routes = {
       },
     },
   }),
+  playerState: createRoute({
+    method: 'get',
+    path: `/api/${API_VERSION}/player-state`,
+    summary: 'get player state',
+    description:
+      'Get combined player state: playing/paused, volume, repeat, shuffle, current song and time',
+    responses: {
+      200: {
+        description: 'Success',
+        content: {
+          'application/json': {
+            schema: PlayerStateSchema,
+          },
+        },
+      },
+    },
+  }),
+  playlistInfo: createRoute({
+    method: 'get',
+    path: `/api/${API_VERSION}/playlist/{id}`,
+    summary: 'get playlist info',
+    description: 'Get playlist name, track count and tracks',
+    request: {
+      params: PlaylistIdParamsSchema,
+    },
+    responses: {
+      200: {
+        description: 'Success',
+        content: {
+          'application/json': {
+            schema: PlaylistInfoSchema,
+          },
+        },
+      },
+      500: {
+        description: 'Failed to get playlist info',
+        content: {
+          'application/json': {
+            schema: z.object({
+              error: z.string(),
+            }),
+          },
+        },
+      },
+    },
+  }),
   search: createRoute({
     method: 'post',
     path: `/api/${API_VERSION}/search`,
@@ -657,6 +813,20 @@ export const register = (
   app.openapi(routes.playPlaylist, (ctx) => {
     const { playlistId, videoId } = ctx.req.valid('json');
     controller.playPlaylist(playlistId, videoId);
+
+    ctx.status(204);
+    return ctx.body(null);
+  });
+  app.openapi(routes.playArtist, (ctx) => {
+    const { channelId } = ctx.req.valid('json');
+    controller.playArtist(channelId);
+
+    ctx.status(204);
+    return ctx.body(null);
+  });
+  app.openapi(routes.playAlbum, (ctx) => {
+    const { albumId } = ctx.req.valid('json');
+    controller.playAlbum(albumId);
 
     ctx.status(204);
     return ctx.body(null);
@@ -896,6 +1066,33 @@ export const register = (
     ctx.status(204);
     return ctx.body(null);
   });
+  app.openapi(routes.addManyToQueue, (ctx) => {
+    const { videoIds, insertPosition } = ctx.req.valid('json');
+    controller.addSongsToQueue(videoIds, insertPosition);
+
+    ctx.status(204);
+    return ctx.body(null);
+  });
+  app.openapi(routes.reorderQueue, (ctx) => {
+    const body = ctx.req.valid('json');
+
+    if (Array.isArray(body.order) && body.order.length >= 2) {
+      controller.reorderQueue(body.order);
+    } else if (
+      typeof body.fromIndex === 'number' &&
+      typeof body.toIndex === 'number'
+    ) {
+      controller.moveSongInQueue(body.fromIndex, body.toIndex);
+    } else {
+      ctx.status(400);
+      return ctx.json({
+        error: 'Provide fromIndex+toIndex or an order array',
+      });
+    }
+
+    ctx.status(204);
+    return ctx.body(null);
+  });
   app.openapi(routes.addSongsToPlaylist, async (ctx) => {
     const { playlistId } = ctx.req.valid('param');
     const { videoIds } = ctx.req.valid('json');
@@ -941,6 +1138,71 @@ export const register = (
 
     ctx.status(204);
     return ctx.body(null);
+  });
+  app.openapi(routes.clearQueuePost, (ctx) => {
+    controller.clearQueue();
+
+    ctx.status(204);
+    return ctx.body(null);
+  });
+  app.openapi(routes.playerState, async (ctx) => {
+    const song = await songInfoGetter();
+    const volumeState = (await volumeStateGetter()) ?? {
+      state: 0,
+      isMuted: false,
+    };
+    const repeat = (await repeatModeGetter()) ?? null;
+
+    const shuffle = await new Promise<boolean | null>((resolve) => {
+      const timeout = setTimeout(() => resolve(null), 1500);
+      ipcMain.once(
+        'peard:get-shuffle-response',
+        (_, isShuffled: boolean | undefined) => {
+          clearTimeout(timeout);
+          resolve(!!isShuffled);
+        },
+      );
+      controller.requestShuffleInformation();
+    });
+
+    const bodySong = song
+      ? (() => {
+          const copy = { ...song };
+          delete copy.image;
+          return copy;
+        })()
+      : null;
+
+    ctx.status(200);
+    return ctx.json({
+      isPlaying: song ? !song.isPaused : false,
+      isPaused: song?.isPaused ?? true,
+      volume: volumeState.state,
+      isMuted: volumeState.isMuted,
+      repeat,
+      shuffle,
+      song: bodySong,
+      elapsedSeconds: song?.elapsedSeconds ?? null,
+      songDuration: song?.songDuration ?? null,
+    });
+  });
+  app.openapi(routes.playlistInfo, async (ctx) => {
+    const { id } = ctx.req.valid('param');
+
+    try {
+      const info = await controller.getPlaylistInfo(id);
+      return ctx.json(info as z.infer<typeof PlaylistInfoSchema>, 200);
+    } catch (error) {
+      return ctx.json(
+        {
+          error:
+            error instanceof Error
+              ? error.message
+              : 'Failed to get playlist info',
+        },
+        500,
+      );
+    }
   });
   app.openapi(routes.search, async (ctx) => {
     const { query, params, continuation } = ctx.req.valid('json');

--- a/src/plugins/api-server/backend/routes/control.ts
+++ b/src/plugins/api-server/backend/routes/control.ts
@@ -23,6 +23,7 @@ import {
   PlaylistInfoSchema,
   PlaylistParamsSchema,
   PlayPlaylistSchema,
+  UserPlaylistsSchema,
   QueueParamsSchema,
   ReorderQueueSchema,
   SearchSchema,
@@ -752,6 +753,33 @@ const routes = {
       },
     },
   }),
+  userPlaylists: createRoute({
+    method: 'get',
+    path: `/api/${API_VERSION}/playlists`,
+    summary: 'get user playlists',
+    description:
+      'List playlists from the signed-in YouTube Music library (FEmusic_liked_playlists)',
+    responses: {
+      200: {
+        description: 'Success',
+        content: {
+          'application/json': {
+            schema: UserPlaylistsSchema,
+          },
+        },
+      },
+      500: {
+        description: 'Failed to get user playlists',
+        content: {
+          'application/json': {
+            schema: z.object({
+              error: z.string(),
+            }),
+          },
+        },
+      },
+    },
+  }),
   search: createRoute({
     method: 'post',
     path: `/api/${API_VERSION}/search`,
@@ -1199,6 +1227,22 @@ export const register = (
             error instanceof Error
               ? error.message
               : 'Failed to get playlist info',
+        },
+        500,
+      );
+    }
+  });
+  app.openapi(routes.userPlaylists, async (ctx) => {
+    try {
+      const data = await controller.getUserPlaylists();
+      return ctx.json(data as z.infer<typeof UserPlaylistsSchema>, 200);
+    } catch (error) {
+      return ctx.json(
+        {
+          error:
+            error instanceof Error
+              ? error.message
+              : 'Failed to get user playlists',
         },
         500,
       );

--- a/src/plugins/api-server/backend/routes/control.ts
+++ b/src/plugins/api-server/backend/routes/control.ts
@@ -10,10 +10,12 @@ import {
 
 import { API_VERSION } from '../api-version';
 import {
+  AddSongsToPlaylistSchema,
   AddSongToQueueSchema,
   GoBackSchema,
   GoForwardScheme,
   MoveSongInQueueSchema,
+  PlaylistParamsSchema,
   QueueParamsSchema,
   SearchSchema,
   SeekSchema,
@@ -494,6 +496,38 @@ const routes = {
       },
     },
   }),
+  addSongsToPlaylist: createRoute({
+    method: 'post',
+    path: `/api/${API_VERSION}/playlists/{playlistId}/songs`,
+    summary: 'add songs to playlist',
+    description: 'Add one or more songs to a playlist',
+    request: {
+      params: PlaylistParamsSchema,
+      body: {
+        description: 'video ids of the songs to add',
+        content: {
+          'application/json': {
+            schema: AddSongsToPlaylistSchema,
+          },
+        },
+      },
+    },
+    responses: {
+      204: {
+        description: 'Success',
+      },
+      500: {
+        description: 'Failed to add songs to playlist',
+        content: {
+          'application/json': {
+            schema: z.object({
+              error: z.string(),
+            }),
+          },
+        },
+      },
+    },
+  }),
   moveSongInQueue: createRoute({
     method: 'patch',
     path: `/api/${API_VERSION}/queue/{index}`,
@@ -861,6 +895,24 @@ export const register = (
 
     ctx.status(204);
     return ctx.body(null);
+  });
+  app.openapi(routes.addSongsToPlaylist, async (ctx) => {
+    const { playlistId } = ctx.req.valid('param');
+    const { videoIds } = ctx.req.valid('json');
+
+    try {
+      await controller.addSongsToPlaylist(playlistId, videoIds);
+      ctx.status(204);
+      return ctx.body(null);
+    } catch (error) {
+      ctx.status(500);
+      return ctx.json({
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Failed to add songs to playlist',
+      });
+    }
   });
   app.openapi(routes.moveSongInQueue, (ctx) => {
     const index = Number(ctx.req.param('index'));

--- a/src/plugins/api-server/backend/scheme/index.ts
+++ b/src/plugins/api-server/backend/scheme/index.ts
@@ -8,3 +8,4 @@ export * from './set-volume';
 export * from './set-fullscreen';
 export * from './queue';
 export * from './search';
+export * from './playlist';

--- a/src/plugins/api-server/backend/scheme/index.ts
+++ b/src/plugins/api-server/backend/scheme/index.ts
@@ -9,3 +9,4 @@ export * from './set-fullscreen';
 export * from './queue';
 export * from './search';
 export * from './playlist';
+export * from './player-state';

--- a/src/plugins/api-server/backend/scheme/player-state.ts
+++ b/src/plugins/api-server/backend/scheme/player-state.ts
@@ -1,0 +1,15 @@
+import { z } from '@hono/zod-openapi';
+
+import { SongInfoSchema } from './song-info';
+
+export const PlayerStateSchema = z.object({
+  isPlaying: z.boolean(),
+  isPaused: z.boolean(),
+  volume: z.number(),
+  isMuted: z.boolean(),
+  repeat: z.enum(['ONE', 'NONE', 'ALL']).nullable(),
+  shuffle: z.boolean().nullable(),
+  song: SongInfoSchema.nullable(),
+  elapsedSeconds: z.number().nullable(),
+  songDuration: z.number().nullable(),
+});

--- a/src/plugins/api-server/backend/scheme/playlist.ts
+++ b/src/plugins/api-server/backend/scheme/playlist.ts
@@ -1,0 +1,9 @@
+import { z } from '@hono/zod-openapi';
+
+export const PlaylistParamsSchema = z.object({
+  playlistId: z.string().trim().min(1),
+});
+
+export const AddSongsToPlaylistSchema = z.object({
+  videoIds: z.array(z.string().trim().min(1)).min(1),
+});

--- a/src/plugins/api-server/backend/scheme/playlist.ts
+++ b/src/plugins/api-server/backend/scheme/playlist.ts
@@ -52,3 +52,14 @@ export const PlaylistInfoSchema = z.object({
   trackCount: z.number().int().nonnegative(),
   tracks: z.array(PlaylistTrackSchema),
 });
+
+export const UserPlaylistSchema = z.object({
+  id: z.string(),
+  name: z.string().nullable(),
+  trackCount: z.number().int().nonnegative().nullable().optional(),
+  author: z.string().nullable().optional(),
+});
+
+export const UserPlaylistsSchema = z.object({
+  playlists: z.array(UserPlaylistSchema),
+});

--- a/src/plugins/api-server/backend/scheme/playlist.ts
+++ b/src/plugins/api-server/backend/scheme/playlist.ts
@@ -4,6 +4,51 @@ export const PlaylistParamsSchema = z.object({
   playlistId: z.string().trim().min(1),
 });
 
+export const PlaylistIdParamsSchema = z.object({
+  id: z.string().trim().min(1),
+});
+
 export const AddSongsToPlaylistSchema = z.object({
   videoIds: z.array(z.string().trim().min(1)).min(1),
+});
+
+export const PlayPlaylistSchema = z.object({
+  playlistId: z.string().trim().min(1).describe('Playlist ID'),
+  videoId: z
+    .string()
+    .trim()
+    .min(1)
+    .optional()
+    .describe('Video ID (optional)'),
+});
+
+export const PlayArtistSchema = z.object({
+  channelId: z
+    .string()
+    .trim()
+    .min(1)
+    .describe('Artist channel / browse ID (e.g. UC...)'),
+});
+
+export const PlayAlbumSchema = z.object({
+  albumId: z
+    .string()
+    .trim()
+    .min(1)
+    .describe('Album browse ID (MPREb_...) or audio playlist ID (OLAK5uy_...)'),
+});
+
+export const PlaylistTrackSchema = z.object({
+  videoId: z.string().nullable(),
+  title: z.string().nullable(),
+  artists: z.array(z.string()).optional(),
+  album: z.string().nullable().optional(),
+  duration: z.string().nullable().optional(),
+});
+
+export const PlaylistInfoSchema = z.object({
+  id: z.string(),
+  name: z.string().nullable(),
+  trackCount: z.number().int().nonnegative(),
+  tracks: z.array(PlaylistTrackSchema),
 });

--- a/src/plugins/api-server/backend/scheme/queue.ts
+++ b/src/plugins/api-server/backend/scheme/queue.ts
@@ -11,9 +11,31 @@ export const AddSongToQueueSchema = z.object({
     .optional()
     .default('INSERT_AT_END'),
 });
+export const AddSongsToQueueSchema = z.object({
+  videoIds: z.array(z.string().trim().min(1)).min(1),
+  insertPosition: z
+    .enum(['INSERT_AT_END', 'INSERT_AFTER_CURRENT_VIDEO'])
+    .optional()
+    .default('INSERT_AT_END'),
+});
 export const MoveSongInQueueSchema = z.object({
   toIndex: z.number(),
 });
+export const ReorderQueueSchema = z
+  .object({
+    fromIndex: z.number().int().nonnegative().optional(),
+    toIndex: z.number().int().nonnegative().optional(),
+    order: z.array(z.number().int().nonnegative()).min(2).optional(),
+  })
+  .refine(
+    (value) =>
+      (typeof value.fromIndex === 'number' &&
+        typeof value.toIndex === 'number') ||
+      (Array.isArray(value.order) && value.order.length >= 2),
+    {
+      message: 'Provide fromIndex+toIndex or an order array',
+    },
+  );
 export const SetQueueIndexSchema = z.object({
   index: z.number().int().nonnegative(),
 });

--- a/src/providers/song-controls.ts
+++ b/src/providers/song-controls.ts
@@ -1,4 +1,6 @@
 // This is used for to control the songs
+import { randomUUID } from 'node:crypto';
+
 import { type BrowserWindow, ipcMain } from 'electron';
 
 import { LikeType } from '@/types/datahost-get-state';
@@ -115,6 +117,30 @@ export const getSongControls = (win: BrowserWindow) => {
         queueInsertPosition,
       );
     },
+    addSongsToPlaylist: (playlistId: string, videoIds: string[]) =>
+      new Promise<void>((resolve, reject) => {
+        const responseChannel = `peard:add-songs-to-playlist-response:${randomUUID()}`;
+        const timeout = setTimeout(() => {
+          ipcMain.removeAllListeners(responseChannel);
+          reject(new Error('Adding songs to playlist timed out'));
+        }, 10_000);
+
+        ipcMain.once(responseChannel, (_, error?: string) => {
+          clearTimeout(timeout);
+          if (error) {
+            reject(new Error(error));
+          } else {
+            resolve();
+          }
+        });
+
+        win.webContents.send(
+          'peard:add-songs-to-playlist',
+          responseChannel,
+          playlistId,
+          videoIds,
+        );
+      }),
     moveSongInQueue: (
       fromIndex: ArgsType<number>,
       toIndex: ArgsType<number>,

--- a/src/providers/song-controls.ts
+++ b/src/providers/song-controls.ts
@@ -146,5 +146,16 @@ export const getSongControls = (win: BrowserWindow) => {
         });
         win.webContents.send('peard:search', query, params, continuation);
       }),
+        playPlaylist: (playlistId: ArgsType<string>, videoId?: ArgsType<string>) => {
+      const pid = parseStringFromArgsType(playlistId);
+      const vid = videoId ? parseStringFromArgsType(videoId) : null;
+      if (pid) {
+        let url = `https://music.youtube.com/playlist?list=${pid}`;
+        if (vid) {
+          url += `&v=${vid}`;
+        }
+        win.webContents.loadURL(url);
+      }
+    },
   };
 };

--- a/src/providers/song-controls.ts
+++ b/src/providers/song-controls.ts
@@ -212,14 +212,10 @@ export const getSongControls = (win: BrowserWindow) => {
       videoId?: ArgsType<string>,
     ) => {
       const pid = parseStringFromArgsType(playlistId);
+      if (!pid) return;
+
       const vid = videoId ? parseStringFromArgsType(videoId) : null;
-      if (pid) {
-        let url = `https://music.youtube.com/playlist?list=${pid}`;
-        if (vid) {
-          url += `&v=${vid}`;
-        }
-        win.webContents.loadURL(url);
-      }
+      win.webContents.send('peard:play-playlist', pid, vid ?? undefined);
     },
     playArtist: (channelId: ArgsType<string>) => {
       const id = parseStringFromArgsType(channelId);
@@ -231,12 +227,10 @@ export const getSongControls = (win: BrowserWindow) => {
       const id = parseStringFromArgsType(albumId);
       if (!id) return;
 
-      // Album audio playlists can be started like regular playlists.
+      // Album audio playlists / playlist IDs play via the same watch URL flow.
       if (id.startsWith('OLAK5uy') || id.startsWith('PL')) {
         const playlistId = id.startsWith('VL') ? id.slice(2) : id;
-        win.webContents.loadURL(
-          `https://music.youtube.com/playlist?list=${playlistId}`,
-        );
+        win.webContents.send('peard:play-playlist', playlistId);
         return;
       }
 

--- a/src/providers/song-controls.ts
+++ b/src/providers/song-controls.ts
@@ -117,6 +117,14 @@ export const getSongControls = (win: BrowserWindow) => {
         queueInsertPosition,
       );
     },
+    addSongsToQueue: (videoIds: string[], queueInsertPosition: string) => {
+      if (!Array.isArray(videoIds) || videoIds.length === 0) return;
+      win.webContents.send(
+        'peard:add-many-to-queue',
+        videoIds,
+        queueInsertPosition,
+      );
+    },
     addSongsToPlaylist: (playlistId: string, videoIds: string[]) =>
       new Promise<void>((resolve, reject) => {
         const responseChannel = `peard:add-songs-to-playlist-response:${randomUUID()}`;
@@ -141,6 +149,29 @@ export const getSongControls = (win: BrowserWindow) => {
           videoIds,
         );
       }),
+    getPlaylistInfo: (playlistId: string) =>
+      new Promise<unknown>((resolve, reject) => {
+        const responseChannel = `peard:get-playlist-info-response:${randomUUID()}`;
+        const timeout = setTimeout(() => {
+          ipcMain.removeAllListeners(responseChannel);
+          reject(new Error('Getting playlist info timed out'));
+        }, 15_000);
+
+        ipcMain.once(responseChannel, (_, error?: string, data?: unknown) => {
+          clearTimeout(timeout);
+          if (error) {
+            reject(new Error(error));
+          } else {
+            resolve(data);
+          }
+        });
+
+        win.webContents.send(
+          'peard:get-playlist-info',
+          responseChannel,
+          playlistId,
+        );
+      }),
     moveSongInQueue: (
       fromIndex: ArgsType<number>,
       toIndex: ArgsType<number>,
@@ -150,6 +181,10 @@ export const getSongControls = (win: BrowserWindow) => {
       if (fromIndexValue === null || toIndexValue === null) return;
 
       win.webContents.send('peard:move-in-queue', fromIndexValue, toIndexValue);
+    },
+    reorderQueue: (order: number[]) => {
+      if (!Array.isArray(order) || order.length < 2) return;
+      win.webContents.send('peard:reorder-queue', order);
     },
     removeSongFromQueue: (index: ArgsType<number>) => {
       const indexValue = parseNumberFromArgsType(index);
@@ -172,7 +207,10 @@ export const getSongControls = (win: BrowserWindow) => {
         });
         win.webContents.send('peard:search', query, params, continuation);
       }),
-        playPlaylist: (playlistId: ArgsType<string>, videoId?: ArgsType<string>) => {
+    playPlaylist: (
+      playlistId: ArgsType<string>,
+      videoId?: ArgsType<string>,
+    ) => {
       const pid = parseStringFromArgsType(playlistId);
       const vid = videoId ? parseStringFromArgsType(videoId) : null;
       if (pid) {
@@ -182,6 +220,27 @@ export const getSongControls = (win: BrowserWindow) => {
         }
         win.webContents.loadURL(url);
       }
+    },
+    playArtist: (channelId: ArgsType<string>) => {
+      const id = parseStringFromArgsType(channelId);
+      if (!id) return;
+
+      win.webContents.send('peard:play-artist', id);
+    },
+    playAlbum: (albumId: ArgsType<string>) => {
+      const id = parseStringFromArgsType(albumId);
+      if (!id) return;
+
+      // Album audio playlists can be started like regular playlists.
+      if (id.startsWith('OLAK5uy') || id.startsWith('PL')) {
+        const playlistId = id.startsWith('VL') ? id.slice(2) : id;
+        win.webContents.loadURL(
+          `https://music.youtube.com/playlist?list=${playlistId}`,
+        );
+        return;
+      }
+
+      win.webContents.send('peard:play-album', id);
     },
   };
 };

--- a/src/providers/song-controls.ts
+++ b/src/providers/song-controls.ts
@@ -172,6 +172,25 @@ export const getSongControls = (win: BrowserWindow) => {
           playlistId,
         );
       }),
+    getUserPlaylists: () =>
+      new Promise<unknown>((resolve, reject) => {
+        const responseChannel = `peard:get-user-playlists-response:${randomUUID()}`;
+        const timeout = setTimeout(() => {
+          ipcMain.removeAllListeners(responseChannel);
+          reject(new Error('Getting user playlists timed out'));
+        }, 15_000);
+
+        ipcMain.once(responseChannel, (_, error?: string, data?: unknown) => {
+          clearTimeout(timeout);
+          if (error) {
+            reject(new Error(error));
+          } else {
+            resolve(data);
+          }
+        });
+
+        win.webContents.send('peard:get-user-playlists', responseChannel);
+      }),
     moveSongInQueue: (
       fromIndex: ArgsType<number>,
       toIndex: ArgsType<number>,

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -244,6 +244,39 @@ async function onApiLoaded() {
     },
   );
   window.ipcRenderer.on(
+    'peard:add-songs-to-playlist',
+    async (
+      _,
+      responseChannel: string,
+      playlistId: string,
+      videoIds: string[],
+    ) => {
+      const app = document.querySelector<MusicPlayerAppElement>('ytmusic-app');
+      if (!app) {
+        window.ipcRenderer.send(responseChannel, 'YouTube Music is not ready');
+        return;
+      }
+
+      try {
+        await app.networkManager.fetch('/browse/edit_playlist', {
+          playlistId,
+          actions: videoIds.map((addedVideoId) => ({
+            action: 'ACTION_ADD_VIDEO',
+            addedVideoId,
+          })),
+        });
+        window.ipcRenderer.send(responseChannel);
+      } catch (error) {
+        window.ipcRenderer.send(
+          responseChannel,
+          error instanceof Error
+            ? error.message
+            : 'Failed to add songs to playlist',
+        );
+      }
+    },
+  );
+  window.ipcRenderer.on(
     'peard:move-in-queue',
     (_, fromIndex: number, toIndex: number) => {
       const queue = document.querySelector<QueueElement>('#queue');

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -36,6 +36,174 @@ let firstDataLoaded = false;
 
 registerWindowDefaultTrustedTypePolicy();
 
+type PlayableEndpoint = {
+  videoId?: string;
+  playlistId?: string;
+};
+
+const findPlayableEndpoint = (
+  value: unknown,
+  depth = 0,
+): PlayableEndpoint | null => {
+  if (!value || typeof value !== 'object' || depth > 12) return null;
+
+  const record = value as Record<string, unknown>;
+
+  const watchEndpoint = record.watchEndpoint as
+    | { videoId?: string; playlistId?: string }
+    | undefined;
+  if (watchEndpoint?.videoId || watchEndpoint?.playlistId) {
+    return {
+      videoId: watchEndpoint.videoId,
+      playlistId: watchEndpoint.playlistId,
+    };
+  }
+
+  const watchPlaylistEndpoint = record.watchPlaylistEndpoint as
+    | { playlistId?: string }
+    | undefined;
+  if (watchPlaylistEndpoint?.playlistId) {
+    return { playlistId: watchPlaylistEndpoint.playlistId };
+  }
+
+  for (const child of Object.values(record)) {
+    const found = findPlayableEndpoint(child, depth + 1);
+    if (found) return found;
+  }
+
+  return null;
+};
+
+const getTextRuns = (value: unknown): string | null => {
+  if (!value || typeof value !== 'object') return null;
+  const runs = (value as { runs?: Array<{ text?: string }> }).runs;
+  if (!Array.isArray(runs)) return null;
+  const text = runs
+    .map((run) => run?.text ?? '')
+    .join('')
+    .trim();
+  return text || null;
+};
+
+const parsePlaylistInfo = (playlistId: string, data: unknown) => {
+  const id = playlistId.startsWith('VL') ? playlistId.slice(2) : playlistId;
+  let name: string | null = null;
+  const tracks: Array<{
+    videoId: string | null;
+    title: string | null;
+    artists?: string[];
+    album?: string | null;
+    duration?: string | null;
+  }> = [];
+
+  const visit = (value: unknown, depth = 0) => {
+    if (!value || typeof value !== 'object' || depth > 14) return;
+
+    const record = value as Record<string, unknown>;
+
+    if (!name) {
+      const header =
+        (record.musicDetailHeaderRenderer as Record<string, unknown> | undefined) ??
+        (
+          record.musicEditablePlaylistDetailHeaderRenderer as
+            | { header?: { musicDetailHeaderRenderer?: Record<string, unknown> } }
+            | undefined
+        )?.header?.musicDetailHeaderRenderer;
+      if (header) {
+        name = getTextRuns(header.title);
+      }
+    }
+
+    const renderer = record.playlistPanelVideoRenderer as
+      | Record<string, unknown>
+      | undefined;
+    const flexible = record.musicResponsiveListItemRenderer as
+      | Record<string, unknown>
+      | undefined;
+
+    if (renderer) {
+      tracks.push({
+        videoId: (renderer.videoId as string | undefined) ?? null,
+        title: getTextRuns(renderer.title),
+        artists: getTextRuns(renderer.shortBylineText)
+          ? [getTextRuns(renderer.shortBylineText)!]
+          : undefined,
+        duration: getTextRuns(renderer.lengthText),
+      });
+    } else if (flexible) {
+      const videoId =
+        (flexible.playlistItemData as { videoId?: string } | undefined)
+          ?.videoId ??
+        (
+          flexible.navigationEndpoint as
+            | { watchEndpoint?: { videoId?: string } }
+            | undefined
+        )?.watchEndpoint?.videoId ??
+        null;
+      const flexColumns = flexible.flexColumns as
+        | Array<{
+            musicResponsiveListItemFlexColumnRenderer?: {
+              text?: unknown;
+            };
+          }>
+        | undefined;
+      const title = getTextRuns(
+        flexColumns?.[0]?.musicResponsiveListItemFlexColumnRenderer?.text,
+      );
+      const artistsText = getTextRuns(
+        flexColumns?.[1]?.musicResponsiveListItemFlexColumnRenderer?.text,
+      );
+      const fixedColumns = flexible.fixedColumns as
+        | Array<{
+            musicResponsiveListItemFixedColumnRenderer?: {
+              text?: unknown;
+            };
+          }>
+        | undefined;
+      const duration = getTextRuns(
+        fixedColumns?.[0]?.musicResponsiveListItemFixedColumnRenderer?.text,
+      );
+
+      if (videoId || title) {
+        tracks.push({
+          videoId,
+          title,
+          artists: artistsText
+            ? artistsText
+                .split('•')[0]
+                ?.split(',')
+                .map((part) => part.trim())
+                .filter(Boolean)
+            : undefined,
+          duration,
+        });
+      }
+    }
+
+    for (const child of Object.values(record)) {
+      visit(child, depth + 1);
+    }
+  };
+
+  visit(data);
+
+  // Deduplicate accidental deep-walk duplicates while preserving order.
+  const seen = new Set<string>();
+  const uniqueTracks = tracks.filter((track) => {
+    const key = `${track.videoId ?? ''}:${track.title ?? ''}:${track.duration ?? ''}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+
+  return {
+    id,
+    name,
+    trackCount: uniqueTracks.length,
+    tracks: uniqueTracks,
+  };
+};
+
 async function listenForApiLoad() {
   if (!isApiLoaded) {
     api = document.querySelector('#movie_player');
@@ -244,6 +412,61 @@ async function onApiLoaded() {
     },
   );
   window.ipcRenderer.on(
+    'peard:add-many-to-queue',
+    (_, videoIds: string[], queueInsertPosition: string) => {
+      const queue = document.querySelector<QueueElement>('#queue');
+      const app = document.querySelector<MusicPlayerAppElement>('ytmusic-app');
+      if (!app || !Array.isArray(videoIds) || videoIds.length === 0) return;
+
+      const store = queue?.queue.store.store;
+      if (!store) return;
+
+      app.networkManager
+        .fetch('/music/get_queue', {
+          queueContextParams: store.getState().queue.queueContextParams,
+          queueInsertPosition,
+          videoIds,
+        })
+        .then((result) => {
+          if (
+            result &&
+            typeof result === 'object' &&
+            'queueDatas' in result &&
+            Array.isArray(result.queueDatas)
+          ) {
+            const queueItems = store.getState().queue.items;
+            const queueItemsLength = queueItems.length ?? 0;
+            queue?.dispatch({
+              type: 'ADD_ITEMS',
+              payload: {
+                nextQueueItemId: store.getState().queue.nextQueueItemId,
+                index:
+                  queueInsertPosition === 'INSERT_AFTER_CURRENT_VIDEO'
+                    ? queueItems.findIndex(
+                        (it) =>
+                          (
+                            it.playlistPanelVideoRenderer ||
+                            it.playlistPanelVideoWrapperRenderer
+                              ?.primaryRenderer.playlistPanelVideoRenderer
+                          )?.selected,
+                      ) + 1 || queueItemsLength
+                    : queueItemsLength,
+                items: result.queueDatas
+                  .map((it) =>
+                    typeof it === 'object' && it && 'content' in it
+                      ? it.content
+                      : null,
+                  )
+                  .filter(Boolean),
+                shuffleEnabled: false,
+                shouldAssignIds: true,
+              },
+            });
+          }
+        });
+    },
+  );
+  window.ipcRenderer.on(
     'peard:add-songs-to-playlist',
     async (
       _,
@@ -277,6 +500,90 @@ async function onApiLoaded() {
     },
   );
   window.ipcRenderer.on(
+    'peard:get-playlist-info',
+    async (_, responseChannel: string, playlistId: string) => {
+      const app = document.querySelector<MusicPlayerAppElement>('ytmusic-app');
+      if (!app) {
+        window.ipcRenderer.send(responseChannel, 'YouTube Music is not ready');
+        return;
+      }
+
+      try {
+        const browseId = playlistId.startsWith('VL')
+          ? playlistId
+          : `VL${playlistId}`;
+        const data = await app.networkManager.fetch<unknown, { browseId: string }>(
+          '/browse',
+          { browseId },
+        );
+        window.ipcRenderer.send(
+          responseChannel,
+          undefined,
+          parsePlaylistInfo(playlistId, data),
+        );
+      } catch (error) {
+        window.ipcRenderer.send(
+          responseChannel,
+          error instanceof Error
+            ? error.message
+            : 'Failed to get playlist info',
+        );
+      }
+    },
+  );
+  window.ipcRenderer.on('peard:play-artist', async (_, channelId: string) => {
+    const app = document.querySelector<MusicPlayerAppElement>('ytmusic-app');
+    if (!app) return;
+
+    try {
+      const data = await app.networkManager.fetch<unknown, { browseId: string }>(
+        '/browse',
+        { browseId: channelId },
+      );
+      const endpoint = findPlayableEndpoint(data);
+      if (!endpoint) return;
+
+      if ('videoId' in endpoint && endpoint.videoId) {
+        const list = endpoint.playlistId
+          ? `&list=${endpoint.playlistId}`
+          : '';
+        window.location.href = `https://music.youtube.com/watch?v=${endpoint.videoId}${list}`;
+        return;
+      }
+
+      if (endpoint.playlistId) {
+        window.location.href = `https://music.youtube.com/playlist?list=${endpoint.playlistId}`;
+      }
+    } catch {
+      // ignore browse failures
+    }
+  });
+  window.ipcRenderer.on('peard:play-album', async (_, albumId: string) => {
+    const app = document.querySelector<MusicPlayerAppElement>('ytmusic-app');
+    if (!app) return;
+
+    try {
+      const data = await app.networkManager.fetch<unknown, { browseId: string }>(
+        '/browse',
+        { browseId: albumId },
+      );
+      const endpoint = findPlayableEndpoint(data);
+      if (!endpoint?.playlistId && !endpoint?.videoId) return;
+
+      if (endpoint.videoId) {
+        const list = endpoint.playlistId
+          ? `&list=${endpoint.playlistId}`
+          : '';
+        window.location.href = `https://music.youtube.com/watch?v=${endpoint.videoId}${list}`;
+        return;
+      }
+
+      window.location.href = `https://music.youtube.com/playlist?list=${endpoint.playlistId}`;
+    } catch {
+      // ignore browse failures
+    }
+  });
+  window.ipcRenderer.on(
     'peard:move-in-queue',
     (_, fromIndex: number, toIndex: number) => {
       const queue = document.querySelector<QueueElement>('#queue');
@@ -289,6 +596,24 @@ async function onApiLoaded() {
       });
     },
   );
+  window.ipcRenderer.on('peard:reorder-queue', (_, order: number[]) => {
+    const queue = document.querySelector<QueueElement>('#queue');
+    if (!queue || !Array.isArray(order) || order.length < 2) return;
+
+    // Apply permutation as successive moves using current positions.
+    const current = order.map((_, index) => index);
+    for (let target = 0; target < order.length; target++) {
+      const desired = order[target];
+      const fromIndex = current.indexOf(desired);
+      if (fromIndex === -1 || fromIndex === target) continue;
+      queue.dispatch({
+        type: 'MOVE_ITEM',
+        payload: { fromIndex, toIndex: target },
+      });
+      const [moved] = current.splice(fromIndex, 1);
+      current.splice(target, 0, moved);
+    }
+  });
   window.ipcRenderer.on('peard:remove-from-queue', (_, index: number) => {
     const queue = document.querySelector<QueueElement>('#queue');
     queue?.dispatch({

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -253,6 +253,154 @@ const parsePlaylistInfo = (playlistId: string, data: unknown) => {
   };
 };
 
+const normalizePlaylistId = (browseId: string): string | null => {
+  if (!browseId) return null;
+  if (browseId === 'FEmusic_liked_playlists') return null;
+  if (browseId.startsWith('VL')) return browseId.slice(2);
+  // Library playlists / liked music use VL… or LM / PL…
+  if (
+    browseId.startsWith('PL') ||
+    browseId.startsWith('OLAK5uy') ||
+    browseId === 'LM' ||
+    browseId.startsWith('RD')
+  ) {
+    return browseId;
+  }
+  return null;
+};
+
+const parseTrackCountFromSubtitle = (subtitle: string | null): number | null => {
+  if (!subtitle) return null;
+  const match = subtitle.match(
+    /(\d[\d.,]*)\s+(songs?|canciones?|titres?|titoli|liederen|musiques?)/i,
+  );
+  if (!match?.[1]) return null;
+  const count = Number(match[1].replaceAll(/[.,](?=\d{3}\b)/g, '').replace(',', '.'));
+  // Prefer integer song counts; if decimal parsing looks wrong, strip non-digits.
+  if (Number.isFinite(count) && Number.isInteger(count)) return count;
+  const digits = Number(match[1].replaceAll(/\D/g, ''));
+  return Number.isFinite(digits) ? digits : null;
+};
+
+const parseUserPlaylists = (data: unknown) => {
+  const playlists: Array<{
+    id: string;
+    name: string | null;
+    trackCount?: number | null;
+    author?: string | null;
+  }> = [];
+  const seen = new Set<string>();
+
+  const visit = (value: unknown, depth = 0) => {
+    if (!value || typeof value !== 'object' || depth > 16) return;
+    const record = value as Record<string, unknown>;
+
+    const twoRow = record.musicTwoRowItemRenderer as
+      | Record<string, unknown>
+      | undefined;
+    const listItem = record.musicResponsiveListItemRenderer as
+      | Record<string, unknown>
+      | undefined;
+
+    const extractFromRenderer = (renderer: Record<string, unknown>) => {
+      const browseId =
+        (
+          renderer.navigationEndpoint as
+            | { browseEndpoint?: { browseId?: string } }
+            | undefined
+        )?.browseEndpoint?.browseId ??
+        (
+          (
+            renderer.menu as
+              | {
+                  menuRenderer?: {
+                    items?: Array<{
+                      menuNavigationItemRenderer?: {
+                        navigationEndpoint?: {
+                          browseEndpoint?: { browseId?: string };
+                        };
+                      };
+                    }>;
+                  };
+                }
+              | undefined
+          )?.menuRenderer?.items ?? []
+        )
+          .map(
+            (item) =>
+              item.menuNavigationItemRenderer?.navigationEndpoint
+                ?.browseEndpoint?.browseId,
+          )
+          .find((id): id is string => Boolean(id));
+
+      if (!browseId) return;
+      const id = normalizePlaylistId(browseId);
+      if (!id || seen.has(id)) return;
+
+      const name =
+        getTextRuns(renderer.title) ??
+        getTextRuns(
+          (
+            (renderer.flexColumns as
+              | Array<{
+                  musicResponsiveListItemFlexColumnRenderer?: {
+                    text?: unknown;
+                  };
+                }>
+              | undefined)?.[0]?.musicResponsiveListItemFlexColumnRenderer
+          )?.text,
+        );
+
+      const subtitle =
+        getTextRuns(renderer.subtitle) ??
+        getTextRuns(
+          (
+            (renderer.flexColumns as
+              | Array<{
+                  musicResponsiveListItemFlexColumnRenderer?: {
+                    text?: unknown;
+                  };
+                }>
+              | undefined)?.[1]?.musicResponsiveListItemFlexColumnRenderer
+          )?.text,
+        );
+
+      const subtitleParts = subtitle
+        ? subtitle
+            .split('•')
+            .map((part) => part.trim())
+            .filter(Boolean)
+        : [];
+      const trackCount = parseTrackCountFromSubtitle(subtitle);
+      const author =
+        subtitleParts.find(
+          (part) =>
+            !/\d[\d.,]*\s+(songs?|canciones?|titres?|titoli|liederen|musiques?)/i.test(
+              part,
+            ),
+        ) ?? null;
+
+      seen.add(id);
+      playlists.push({
+        id,
+        name,
+        trackCount,
+        author,
+      });
+    };
+
+    if (twoRow) extractFromRenderer(twoRow);
+    if (listItem) extractFromRenderer(listItem);
+
+    for (const child of Object.values(record)) {
+      visit(child, depth + 1);
+    }
+  };
+
+  visit(data);
+  return { playlists };
+};
+
 async function listenForApiLoad() {
   if (!isApiLoaded) {
     api = document.querySelector('#movie_player');
@@ -541,6 +689,35 @@ async function onApiLoaded() {
           error instanceof Error
             ? error.message
             : 'Failed to get playlist info',
+        );
+      }
+    },
+  );
+  window.ipcRenderer.on(
+    'peard:get-user-playlists',
+    async (_, responseChannel: string) => {
+      const app = document.querySelector<MusicPlayerAppElement>('ytmusic-app');
+      if (!app) {
+        window.ipcRenderer.send(responseChannel, 'YouTube Music is not ready');
+        return;
+      }
+
+      try {
+        const data = await app.networkManager.fetch<
+          unknown,
+          { browseId: string }
+        >('/browse', { browseId: 'FEmusic_liked_playlists' });
+        window.ipcRenderer.send(
+          responseChannel,
+          undefined,
+          parseUserPlaylists(data),
+        );
+      } catch (error) {
+        window.ipcRenderer.send(
+          responseChannel,
+          error instanceof Error
+            ? error.message
+            : 'Failed to get user playlists',
         );
       }
     },

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -41,11 +41,12 @@ type PlayableEndpoint = {
   playlistId?: string;
 };
 
-const findPlayableEndpoint = (
+const collectPlayableEndpoints = (
   value: unknown,
   depth = 0,
-): PlayableEndpoint | null => {
-  if (!value || typeof value !== 'object' || depth > 12) return null;
+  out: PlayableEndpoint[] = [],
+): PlayableEndpoint[] => {
+  if (!value || typeof value !== 'object' || depth > 14) return out;
 
   const record = value as Record<string, unknown>;
 
@@ -53,25 +54,66 @@ const findPlayableEndpoint = (
     | { videoId?: string; playlistId?: string }
     | undefined;
   if (watchEndpoint?.videoId || watchEndpoint?.playlistId) {
-    return {
+    out.push({
       videoId: watchEndpoint.videoId,
       playlistId: watchEndpoint.playlistId,
-    };
+    });
   }
 
   const watchPlaylistEndpoint = record.watchPlaylistEndpoint as
     | { playlistId?: string }
     | undefined;
   if (watchPlaylistEndpoint?.playlistId) {
-    return { playlistId: watchPlaylistEndpoint.playlistId };
+    out.push({ playlistId: watchPlaylistEndpoint.playlistId });
   }
 
   for (const child of Object.values(record)) {
-    const found = findPlayableEndpoint(child, depth + 1);
-    if (found) return found;
+    collectPlayableEndpoints(child, depth + 1, out);
   }
 
-  return null;
+  return out;
+};
+
+const scorePlayableEndpoint = (
+  endpoint: PlayableEndpoint,
+  preferAlbum = false,
+): number => {
+  let score = 0;
+  const playlistId = endpoint.playlistId ?? '';
+
+  if (playlistId.startsWith('OLAK5uy') || playlistId.startsWith('VLOLAK5uy')) {
+    score += 100;
+  }
+  if (preferAlbum && playlistId.includes('OLAK')) {
+    score += 40;
+  }
+  if (endpoint.videoId && playlistId) {
+    score += 20;
+  }
+  if (playlistId.startsWith('RD')) {
+    score -= 50;
+  } else if (playlistId) {
+    score += 10;
+  }
+  if (endpoint.videoId) {
+    score += 5;
+  }
+
+  return score;
+};
+
+const findPlayableEndpoint = (
+  value: unknown,
+  preferAlbum = false,
+): PlayableEndpoint | null => {
+  const endpoints = collectPlayableEndpoints(value);
+  if (endpoints.length === 0) return null;
+
+  return [...endpoints].sort(
+    (a, b) =>
+      scorePlayableEndpoint(b, preferAlbum) -
+      scorePlayableEndpoint(a, preferAlbum),
+  )[0]!;
 };
 
 const getTextRuns = (value: unknown): string | null => {
@@ -108,9 +150,16 @@ const parsePlaylistInfo = (playlistId: string, data: unknown) => {
           record.musicEditablePlaylistDetailHeaderRenderer as
             | { header?: { musicDetailHeaderRenderer?: Record<string, unknown> } }
             | undefined
-        )?.header?.musicDetailHeaderRenderer;
+        )?.header?.musicDetailHeaderRenderer ??
+        (record.musicResponsiveHeaderRenderer as
+          | Record<string, unknown>
+          | undefined);
       if (header) {
-        name = getTextRuns(header.title);
+        name =
+          getTextRuns(header.title) ??
+          getTextRuns(
+            (header as { header?: { title?: unknown } }).header?.title,
+          );
       }
     }
 
@@ -356,114 +405,79 @@ async function onApiLoaded() {
     } satisfies QueueResponse);
   });
 
+  const addVideosToQueue = (
+    videoIds: string[],
+    queueInsertPosition: string,
+  ) => {
+    const queue = document.querySelector<QueueElement>('#queue');
+    const app = document.querySelector<MusicPlayerAppElement>('ytmusic-app');
+    if (!app || !Array.isArray(videoIds) || videoIds.length === 0) return;
+
+    const store = queue?.queue.store.store;
+    if (!store) return;
+
+    const payload: {
+      queueInsertPosition: string;
+      videoIds: string[];
+    } = {
+      queueInsertPosition,
+      videoIds,
+    };
+
+    app.networkManager
+      .fetch('/music/get_queue', payload)
+      .then((result) => {
+        if (
+          result &&
+          typeof result === 'object' &&
+          'queueDatas' in result &&
+          Array.isArray(result.queueDatas)
+        ) {
+          const queueItems = store.getState().queue.items;
+          const queueItemsLength = queueItems.length ?? 0;
+          queue?.dispatch({
+            type: 'ADD_ITEMS',
+            payload: {
+              nextQueueItemId: store.getState().queue.nextQueueItemId,
+              index:
+                queueInsertPosition === 'INSERT_AFTER_CURRENT_VIDEO'
+                  ? queueItems.findIndex(
+                      (it) =>
+                        (
+                          it.playlistPanelVideoRenderer ||
+                          it.playlistPanelVideoWrapperRenderer
+                            ?.primaryRenderer.playlistPanelVideoRenderer
+                        )?.selected,
+                    ) + 1 || queueItemsLength
+                  : queueItemsLength,
+              items: result.queueDatas
+                .map((it) =>
+                  typeof it === 'object' && it && 'content' in it
+                    ? it.content
+                    : null,
+                )
+                .filter(Boolean),
+              shuffleEnabled: false,
+              shouldAssignIds: true,
+            },
+          });
+        }
+      })
+      .catch(() => {
+        // ignore get_queue failures
+      });
+  };
+
   window.ipcRenderer.on(
     'peard:add-to-queue',
     (_, videoId: string, queueInsertPosition: string) => {
-      const queue = document.querySelector<QueueElement>('#queue');
-      const app = document.querySelector<MusicPlayerAppElement>('ytmusic-app');
-      if (!app) return;
-
-      const store = queue?.queue.store.store;
-      if (!store) return;
-
-      app.networkManager
-        .fetch('/music/get_queue', {
-          queueContextParams: store.getState().queue.queueContextParams,
-          queueInsertPosition,
-          videoIds: [videoId],
-        })
-        .then((result) => {
-          if (
-            result &&
-            typeof result === 'object' &&
-            'queueDatas' in result &&
-            Array.isArray(result.queueDatas)
-          ) {
-            const queueItems = store.getState().queue.items;
-            const queueItemsLength = queueItems.length ?? 0;
-            queue?.dispatch({
-              type: 'ADD_ITEMS',
-              payload: {
-                nextQueueItemId: store.getState().queue.nextQueueItemId,
-                index:
-                  queueInsertPosition === 'INSERT_AFTER_CURRENT_VIDEO'
-                    ? queueItems.findIndex(
-                        (it) =>
-                          (
-                            it.playlistPanelVideoRenderer ||
-                            it.playlistPanelVideoWrapperRenderer
-                              ?.primaryRenderer.playlistPanelVideoRenderer
-                          )?.selected,
-                      ) + 1 || queueItemsLength
-                    : queueItemsLength,
-                items: result.queueDatas
-                  .map((it) =>
-                    typeof it === 'object' && it && 'content' in it
-                      ? it.content
-                      : null,
-                  )
-                  .filter(Boolean),
-                shuffleEnabled: false,
-                shouldAssignIds: true,
-              },
-            });
-          }
-        });
+      addVideosToQueue([videoId], queueInsertPosition);
     },
   );
   window.ipcRenderer.on(
     'peard:add-many-to-queue',
     (_, videoIds: string[], queueInsertPosition: string) => {
-      const queue = document.querySelector<QueueElement>('#queue');
-      const app = document.querySelector<MusicPlayerAppElement>('ytmusic-app');
-      if (!app || !Array.isArray(videoIds) || videoIds.length === 0) return;
-
-      const store = queue?.queue.store.store;
-      if (!store) return;
-
-      app.networkManager
-        .fetch('/music/get_queue', {
-          queueContextParams: store.getState().queue.queueContextParams,
-          queueInsertPosition,
-          videoIds,
-        })
-        .then((result) => {
-          if (
-            result &&
-            typeof result === 'object' &&
-            'queueDatas' in result &&
-            Array.isArray(result.queueDatas)
-          ) {
-            const queueItems = store.getState().queue.items;
-            const queueItemsLength = queueItems.length ?? 0;
-            queue?.dispatch({
-              type: 'ADD_ITEMS',
-              payload: {
-                nextQueueItemId: store.getState().queue.nextQueueItemId,
-                index:
-                  queueInsertPosition === 'INSERT_AFTER_CURRENT_VIDEO'
-                    ? queueItems.findIndex(
-                        (it) =>
-                          (
-                            it.playlistPanelVideoRenderer ||
-                            it.playlistPanelVideoWrapperRenderer
-                              ?.primaryRenderer.playlistPanelVideoRenderer
-                          )?.selected,
-                      ) + 1 || queueItemsLength
-                    : queueItemsLength,
-                items: result.queueDatas
-                  .map((it) =>
-                    typeof it === 'object' && it && 'content' in it
-                      ? it.content
-                      : null,
-                  )
-                  .filter(Boolean),
-                shuffleEnabled: false,
-                shouldAssignIds: true,
-              },
-            });
-          }
-        });
+      addVideosToQueue(videoIds, queueInsertPosition);
     },
   );
   window.ipcRenderer.on(
@@ -531,6 +545,70 @@ async function onApiLoaded() {
       }
     },
   );
+  const navigateToWatch = (videoId: string, playlistId?: string) => {
+    const list = playlistId ? `&list=${playlistId}` : '';
+    window.location.href = `https://music.youtube.com/watch?v=${videoId}${list}`;
+  };
+
+  const playPlaylistById = async (playlistId: string, videoId?: string) => {
+    const listId = playlistId.startsWith('VL')
+      ? playlistId.slice(2)
+      : playlistId;
+
+    if (videoId) {
+      navigateToWatch(videoId, listId);
+      return;
+    }
+
+    const app = document.querySelector<MusicPlayerAppElement>('ytmusic-app');
+    if (!app) return;
+
+    try {
+      const browseId = playlistId.startsWith('VL')
+        ? playlistId
+        : `VL${playlistId}`;
+      const data = await app.networkManager.fetch<
+        unknown,
+        { browseId: string }
+      >('/browse', { browseId });
+
+      const endpoint = findPlayableEndpoint(data);
+      if (endpoint?.videoId) {
+        navigateToWatch(
+          endpoint.videoId,
+          endpoint.playlistId?.startsWith('VL')
+            ? endpoint.playlistId.slice(2)
+            : (endpoint.playlistId ?? listId),
+        );
+        return;
+      }
+
+      if (endpoint?.playlistId) {
+        const pid = endpoint.playlistId.startsWith('VL')
+          ? endpoint.playlistId.slice(2)
+          : endpoint.playlistId;
+        if (pid !== listId) {
+          await playPlaylistById(pid);
+          return;
+        }
+      }
+
+      const info = parsePlaylistInfo(playlistId, data);
+      const firstVideoId = info.tracks.find((track) => track.videoId)?.videoId;
+      if (firstVideoId) {
+        navigateToWatch(firstVideoId, listId);
+      }
+    } catch {
+      // ignore browse failures
+    }
+  };
+
+  window.ipcRenderer.on(
+    'peard:play-playlist',
+    async (_, playlistId: string, videoId?: string) => {
+      await playPlaylistById(playlistId, videoId);
+    },
+  );
   window.ipcRenderer.on('peard:play-artist', async (_, channelId: string) => {
     const app = document.querySelector<MusicPlayerAppElement>('ytmusic-app');
     if (!app) return;
@@ -543,16 +621,13 @@ async function onApiLoaded() {
       const endpoint = findPlayableEndpoint(data);
       if (!endpoint) return;
 
-      if ('videoId' in endpoint && endpoint.videoId) {
-        const list = endpoint.playlistId
-          ? `&list=${endpoint.playlistId}`
-          : '';
-        window.location.href = `https://music.youtube.com/watch?v=${endpoint.videoId}${list}`;
+      if (endpoint.videoId) {
+        navigateToWatch(endpoint.videoId, endpoint.playlistId);
         return;
       }
 
       if (endpoint.playlistId) {
-        window.location.href = `https://music.youtube.com/playlist?list=${endpoint.playlistId}`;
+        await playPlaylistById(endpoint.playlistId);
       }
     } catch {
       // ignore browse failures
@@ -567,18 +642,29 @@ async function onApiLoaded() {
         '/browse',
         { browseId: albumId },
       );
-      const endpoint = findPlayableEndpoint(data);
-      if (!endpoint?.playlistId && !endpoint?.videoId) return;
+      const endpoint = findPlayableEndpoint(data, true);
 
-      if (endpoint.videoId) {
-        const list = endpoint.playlistId
-          ? `&list=${endpoint.playlistId}`
-          : '';
-        window.location.href = `https://music.youtube.com/watch?v=${endpoint.videoId}${list}`;
+      if (endpoint?.playlistId?.includes('OLAK') || endpoint?.playlistId?.startsWith('PL')) {
+        await playPlaylistById(endpoint.playlistId);
         return;
       }
 
-      window.location.href = `https://music.youtube.com/playlist?list=${endpoint.playlistId}`;
+      if (endpoint?.videoId) {
+        navigateToWatch(endpoint.videoId, endpoint.playlistId);
+        return;
+      }
+
+      if (endpoint?.playlistId) {
+        await playPlaylistById(endpoint.playlistId);
+        return;
+      }
+
+      // Album browse pages often expose tracks without a direct watch endpoint.
+      const info = parsePlaylistInfo(albumId, data);
+      const firstVideoId = info.tracks.find((track) => track.videoId)?.videoId;
+      if (firstVideoId) {
+        navigateToWatch(firstVideoId);
+      }
     } catch {
       // ignore browse failures
     }


### PR DESCRIPTION
## Summary
- Adds API endpoints to play playlists, artists and albums, plus add songs to playlists (building on #4505 / #4602).
- Adds queue helpers: `POST /queue/clear`, `/queue/add-many`, `/queue/reorder`.
- Adds `GET /player-state` and `GET /playlist/{id}` for unified player and playlist info.
- Fixes real autoplay for playlists/albums via watch URLs and stabilizes batch queue adds.

## Test plan
- [ ] Enable api-server plugin and confirm Swagger at `http://localhost:26538/swagger`
- [ ] `POST /api/v1/playPlaylist` with a real `playlistId` changes the current song
- [ ] `POST /api/v1/playArtist` / `playAlbum` start playback for valid IDs
- [ ] `POST /api/v1/queue/clear`, `add-many`, `reorder` update `GET /api/v1/queue`
- [ ] `GET /api/v1/player-state` returns playing/paused, volume, repeat, shuffle, song, time
- [ ] `GET /api/v1/playlist/{id}` returns name, trackCount and tracks
- [ ] `POST /api/v1/playlists/{id}/songs` adds valid videoIds (expect 500 on invalid IDs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added new playback controls for playlists, artists, and albums.
  - Added playlist browsing and details, including the ability to add multiple songs to a playlist and fetch user library playlists.
  - Added bulk queue actions: add multiple tracks, reorder the queue, and a POST alias to clear the queue.
  - Added a player-state endpoint with playback status, volume/mute, repeat/shuffle, current track, and elapsed/duration timing.
  - Improved playlist/album playback discovery across different content formats and renderer types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->