### PR TITLE
feat(resume-shuffle): Add plugin to resume the last queue shuffled

### DIFF
--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -769,6 +769,10 @@
         }
       }
     },
+    "resume-shuffle": {
+      "description": "Bring the queue back shuffled when \"Resume last song when app starts\" is enabled",
+      "name": "Resume Shuffle"
+    },
     "scrobbler": {
       "description": "Add scrobbling support (etc. last.fm, Listenbrainz)",
       "dialog": {

--- a/src/plugins/resume-shuffle/index.ts
+++ b/src/plugins/resume-shuffle/index.ts
@@ -29,7 +29,8 @@ const isShuffled = () =>
     .querySelector<HTMLElement>('ytmusic-player-bar')
     ?.attributes.getNamedItem('shuffle-on') ?? null) !== null;
 
-// The queue is filled asynchronously, so wait for it before shuffling
+// The queue is filled asynchronously, so wait for it before shuffling.
+// Returns a canceller, so a pending shuffle can't outlive the plugin.
 const shuffleWhenReady = (queue: ShuffleQueue) => {
   const store = queue.store.store;
   let unsubscribe: (() => void) | undefined;
@@ -44,7 +45,12 @@ const shuffleWhenReady = (queue: ShuffleQueue) => {
   unsubscribe = store.subscribe(shuffle);
   shuffle();
   // Give up if it never arrives, so a queue started later isn't shuffled by surprise
-  setTimeout(() => unsubscribe?.(), RESTORE_TIMEOUT_MS);
+  const timeout = setTimeout(() => unsubscribe?.(), RESTORE_TIMEOUT_MS);
+
+  return () => {
+    clearTimeout(timeout);
+    unsubscribe?.();
+  };
 };
 
 export default createPlugin<
@@ -52,6 +58,7 @@ export default createPlugin<
   unknown,
   {
     observer: MutationObserver | null;
+    cancelShuffle: (() => void) | null;
   },
   ResumeShufflePluginConfig
 >({
@@ -65,6 +72,7 @@ export default createPlugin<
   },
   renderer: {
     observer: null,
+    cancelShuffle: null,
     async onPlayerApiReady(_api, { getConfig, setConfig }) {
       const saveShuffleState = () => setConfig({ shuffled: isShuffled() });
 
@@ -75,23 +83,26 @@ export default createPlugin<
       }
 
       const { shuffled } = await getConfig();
-      const queue =
+      const shouldRestore =
         location.pathname === '/watch' &&
         shuffled &&
-        window.mainConfig.get('options.resumeOnStart')
-          ? getQueue()
-          : undefined;
+        window.mainConfig.get('options.resumeOnStart');
+      const queue = shouldRestore ? getQueue() : undefined;
 
       if (queue?.store.store) {
-        shuffleWhenReady(queue);
-      } else {
-        // The observer above only reacts to changes, so record the initial state too
+        this.cancelShuffle = shuffleWhenReady(queue);
+      } else if (!shouldRestore) {
+        // The observer above only reacts to changes, so record the initial state too.
+        // Skipped when a restore was wanted but the queue was missing, so that a
+        // saved `shuffled: true` survives instead of being overwritten with false.
         saveShuffleState();
       }
     },
     stop() {
       this.observer?.disconnect();
       this.observer = null;
+      this.cancelShuffle?.();
+      this.cancelShuffle = null;
     },
   },
 });

--- a/src/plugins/resume-shuffle/index.ts
+++ b/src/plugins/resume-shuffle/index.ts
@@ -103,8 +103,7 @@ export default createPlugin<
         this.cancelShuffle = shuffleWhenReady(queue);
       } else if (!shouldRestore) {
         // The observer above only reacts to changes, so record the initial state too.
-        // Skipped when a restore was wanted but the queue was missing,
-        // so that a saved `shuffled: true` survives instead of being overwritten with false.
+        // Skipped when a restore was wanted but the queue was missing, so that a saved `shuffled: true` survives instead of being overwritten with false.
         saveShuffleState();
       }
     },

--- a/src/plugins/resume-shuffle/index.ts
+++ b/src/plugins/resume-shuffle/index.ts
@@ -103,8 +103,8 @@ export default createPlugin<
         this.cancelShuffle = shuffleWhenReady(queue);
       } else if (!shouldRestore) {
         // The observer above only reacts to changes, so record the initial state too.
-        // Skipped when a restore was wanted but the queue was missing, so that a
-        // saved `shuffled: true` survives instead of being overwritten with false.
+        // Skipped when a restore was wanted but the queue was missing,
+        // so that a saved `shuffled: true` survives instead of being overwritten with false.
         saveShuffleState();
       }
     },

--- a/src/plugins/resume-shuffle/index.ts
+++ b/src/plugins/resume-shuffle/index.ts
@@ -5,7 +5,7 @@ const RESTORE_TIMEOUT_MS = 10_000;
 
 export type ResumeShufflePluginConfig = {
   enabled: boolean;
-  /** Whether the queue was shuffled when the app was last closed. */
+  /** Whether the queue was shuffled when the app was last closed */
   shuffled: boolean;
 };
 
@@ -29,8 +29,8 @@ const isShuffled = () =>
     .querySelector<HTMLElement>('ytmusic-player-bar')
     ?.attributes.getNamedItem('shuffle-on') ?? null) !== null;
 
-// The queue is filled asynchronously, so wait for it before shuffling.
-// Returns a canceller, so a pending shuffle can't outlive the plugin.
+// The queue is filled asynchronously, so wait for it before shuffling
+// Returns a canceller, so a pending shuffle can't outlive the plugin
 const shuffleWhenReady = (queue: ShuffleQueue) => {
   const store = queue.store.store;
   let unsubscribe: (() => void) | undefined;
@@ -102,8 +102,8 @@ export default createPlugin<
       if (queue?.store.store) {
         this.cancelShuffle = shuffleWhenReady(queue);
       } else if (!shouldRestore) {
-        // The observer above only reacts to changes, so record the initial state too.
-        // Skipped when a restore was wanted but the queue was missing, so that a saved `shuffled: true` survives instead of being overwritten with false.
+        // The observer above only reacts to changes, so record the initial state too
+        // Skipped when a restore was wanted but the queue was missing, so that a saved `shuffled: true` survives instead of being overwritten with false
         saveShuffleState();
       }
     },

--- a/src/plugins/resume-shuffle/index.ts
+++ b/src/plugins/resume-shuffle/index.ts
@@ -1,0 +1,97 @@
+import { t } from '@/i18n';
+import { createPlugin } from '@/utils';
+
+const RESTORE_TIMEOUT_MS = 10_000;
+
+export type ResumeShufflePluginConfig = {
+  enabled: boolean;
+  /** Whether the queue was shuffled when the app was last closed. */
+  shuffled: boolean;
+};
+
+// Kept local so the plugin doesn't need to touch the shared queue types
+type ShuffleQueue = {
+  shuffle(): void;
+  store: {
+    store: {
+      getState(): { queue: { items: unknown[] } };
+      subscribe(callback: () => void): () => void;
+    };
+  };
+};
+
+const getQueue = () =>
+  document.querySelector<HTMLElement & { queue?: ShuffleQueue }>('#queue')
+    ?.queue;
+
+const isShuffled = () =>
+  (document
+    .querySelector<HTMLElement>('ytmusic-player-bar')
+    ?.attributes.getNamedItem('shuffle-on') ?? null) !== null;
+
+// The queue is filled asynchronously, so wait for it before shuffling
+const shuffleWhenReady = (queue: ShuffleQueue) => {
+  const store = queue.store.store;
+  let unsubscribe: (() => void) | undefined;
+
+  const shuffle = () => {
+    if (!store.getState().queue.items.length) return;
+
+    unsubscribe?.();
+    if (!isShuffled()) queue.shuffle();
+  };
+
+  unsubscribe = store.subscribe(shuffle);
+  shuffle();
+  // Give up if it never arrives, so a queue started later isn't shuffled by surprise
+  setTimeout(() => unsubscribe?.(), RESTORE_TIMEOUT_MS);
+};
+
+export default createPlugin<
+  unknown,
+  unknown,
+  {
+    observer: MutationObserver | null;
+  },
+  ResumeShufflePluginConfig
+>({
+  name: () => t('plugins.resume-shuffle.name'),
+  description: () => t('plugins.resume-shuffle.description'),
+  addedVersion: '3.12.X',
+  restartNeeded: false,
+  config: {
+    enabled: false,
+    shuffled: false,
+  },
+  renderer: {
+    observer: null,
+    async onPlayerApiReady(_api, { getConfig, setConfig }) {
+      const saveShuffleState = () => setConfig({ shuffled: isShuffled() });
+
+      const playerBar = document.querySelector('ytmusic-player-bar');
+      if (playerBar) {
+        this.observer = new MutationObserver(saveShuffleState);
+        this.observer.observe(playerBar, { attributeFilter: ['shuffle-on'] });
+      }
+
+      const { shuffled } = await getConfig();
+      const queue =
+        location.pathname === '/watch' &&
+        shuffled &&
+        window.mainConfig.get('options.resumeOnStart')
+          ? getQueue()
+          : undefined;
+
+      if (queue?.store.store) {
+        shuffleWhenReady(queue);
+      } else {
+        // The observer above only reacts to changes, so record the initial state too
+        saveShuffleState();
+      }
+    },
+    stop() {
+      this.observer?.disconnect();
+      this.observer = null;
+    },
+  },
+});

--- a/src/plugins/resume-shuffle/index.ts
+++ b/src/plugins/resume-shuffle/index.ts
@@ -59,12 +59,13 @@ export default createPlugin<
   {
     observer: MutationObserver | null;
     cancelShuffle: (() => void) | null;
+    stopped: boolean;
   },
   ResumeShufflePluginConfig
 >({
   name: () => t('plugins.resume-shuffle.name'),
   description: () => t('plugins.resume-shuffle.description'),
-  addedVersion: '3.12.X',
+  addedVersion: '3.13.X',
   restartNeeded: false,
   config: {
     enabled: false,
@@ -73,7 +74,13 @@ export default createPlugin<
   renderer: {
     observer: null,
     cancelShuffle: null,
+    stopped: false,
     async onPlayerApiReady(_api, { getConfig, setConfig }) {
+      // Defensive: this can run again on plugin re-enable
+      this.observer?.disconnect();
+      this.cancelShuffle?.();
+      this.stopped = false;
+
       const saveShuffleState = () => setConfig({ shuffled: isShuffled() });
 
       const playerBar = document.querySelector('ytmusic-player-bar');
@@ -83,6 +90,9 @@ export default createPlugin<
       }
 
       const { shuffled } = await getConfig();
+      // The plugin may have been disabled while awaiting the config
+      if (this.stopped) return;
+
       const shouldRestore =
         location.pathname === '/watch' &&
         shuffled &&
@@ -99,6 +109,7 @@ export default createPlugin<
       }
     },
     stop() {
+      this.stopped = true;
       this.observer?.disconnect();
       this.observer = null;
       this.cancelShuffle?.();


### PR DESCRIPTION
Closes #994

"Resume last song when app starts" restores the last played song, but the queue always comes back in its original order. This plugin saves the player bar's shuffle state and re-applies it once the resumed queue has loaded:

- The player bar's `shuffle-on` attribute is mirrored into the plugin's own config, so nothing is added to the core config schema.
- On startup, if resume is enabled and the saved state was shuffled, the queue is shuffled once it has loaded. The web player's own shuffle keeps the playing song at the top, so the resumed song keeps playing.
- Runs on watch-page loads while resume is enabled: the resumed page at startup, and after an in-page reload (such as Memory Saver #4617, where the player would otherwise drop the shuffle). Gives up after 10s so a queue the user starts later can't be shuffled by surprise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added localized i18n text for **Resume Shuffle** (display name and description).
- **Bug Fixes**
  - Improved reliability when enabling/disabling **Resume Shuffle**: shuffle restoration stops if the plugin is turned off mid-resume, and re-enabling resumes cleanly without leftover observers/subscriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


