### PR TITLE
feat(memory-saver): Add plugin that reloads the page to reclaim leaked memory

### DIFF
--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -614,6 +614,10 @@
         "fetched-lyrics": "Fetched lyrics for Genius"
       }
     },
+    "memory-saver": {
+      "description": "Reloads the page while you're away once memory use grows too high, keeping the current song, position and shuffle. Works around a memory leak in the web player itself that slows the app down over long sessions",
+      "name": "Memory Saver"
+    },
     "music-together": {
       "description": "Share a playlist with others. When the host plays a song, everyone else will hear the same song",
       "dialog": {

--- a/src/plugins/memory-saver/index.ts
+++ b/src/plugins/memory-saver/index.ts
@@ -37,7 +37,6 @@ export default createPlugin<
   {
     api: MusicPlayer | null;
     pending: boolean;
-    resumeShuffleEnabled: boolean;
     keepPausedUntil: number;
     canReloadNow: () => boolean;
     tryReload: () => void;
@@ -88,22 +87,14 @@ export default createPlugin<
   renderer: {
     api: null,
     pending: false,
-    resumeShuffleEnabled: false,
     keepPausedUntil: 0,
     canReloadNow() {
       // The reload rebuilds the queue from the URL, which only works for playlist and radio queues; hold off on hand-built ones
       const { video_id: videoId, list } = this.api?.getVideoData() ?? {};
       if (!videoId || !list) return false;
 
-      // The rebuilt queue always comes back unshuffled, so only reload when the resume-shuffle plugin is set up to re-apply the shuffle
-      if (isShuffled()) {
-        return (
-          this.resumeShuffleEnabled &&
-          window.mainConfig.get('options.resumeOnStart')
-        );
-      }
-
-      return true;
+      // The rebuilt queue always comes back unshuffled, so never reload while shuffle is on
+      return !isShuffled();
     },
     tryReload() {
       if (this.pending && this.canReloadNow()) this.reload();
@@ -162,14 +153,10 @@ export default createPlugin<
         this.keepPaused();
       }
 
-      ipc.on(RELOAD_CHANNEL, async () => {
+      ipc.on(RELOAD_CHANNEL, () => {
         // Anchor the cooldown to the previous actual reload, not the request; a reload deferred for a long time still counts from when it happened
         const lastReloadAt = Number(sessionStorage.getItem(LAST_RELOAD_KEY));
         if (Date.now() - lastReloadAt < COOLDOWN_MS) return;
-
-        // Resolved here rather than per attempt, so the reload gate stays synchronous
-        this.resumeShuffleEnabled =
-          await window.mainConfig.plugins.isEnabled('resume-shuffle');
 
         this.pending = true;
         // Paused is already a safe moment; otherwise wait for the next pause or track change
@@ -183,7 +170,6 @@ export default createPlugin<
     },
     stop({ ipc }) {
       this.pending = false;
-      this.resumeShuffleEnabled = false;
       this.api = null;
       // A disabled plugin should never leave a pending restore behind
       sessionStorage.removeItem(WAS_PAUSED_KEY);

--- a/src/plugins/memory-saver/index.ts
+++ b/src/plugins/memory-saver/index.ts
@@ -64,8 +64,7 @@ export default createPlugin<
       if (this.interval) clearInterval(this.interval);
       this.interval = setInterval(async () => {
         if (window.isDestroyed()) return;
-        // A reload navigates to the song page, so never ask for one while the user is at the keyboard;
-        // the renderer then picks a gap in playback
+        // A reload navigates to the song page, so never ask for one while the user is at the keyboard; the renderer then picks a gap in playback
         if (powerMonitor.getSystemIdleTime() < SYSTEM_IDLE_S) return;
         if (Date.now() - this.lastRequestAt < COOLDOWN_MS) return;
 
@@ -90,13 +89,11 @@ export default createPlugin<
     pending: false,
     keepPausedUntil: 0,
     canReloadNow() {
-      // The reload rebuilds the queue from the URL, which only works for playlist and radio queues;
-      // hold off on hand-built ones
+      // The reload rebuilds the queue from the URL, which only works for playlist and radio queues; hold off on hand-built ones
       const { video_id: videoId, list } = this.api?.getVideoData() ?? {};
       if (!videoId || !list) return false;
 
-      // The rebuilt queue always comes back unshuffled,
-      // so only reload when the resume-shuffle plugin is set up to re-apply the shuffle
+      // The rebuilt queue always comes back unshuffled, so only reload when the resume-shuffle plugin is set up to re-apply the shuffle
       if (isShuffled()) {
         return (
           !!window.mainConfig.plugins.getPlugins()['resume-shuffle']?.enabled &&
@@ -110,8 +107,7 @@ export default createPlugin<
       if (this.pending && this.canReloadNow()) this.reload();
     },
     reload() {
-      // Built from the player rather than `options.resumeOnStart`'s saved url,
-      // which still points at the previous song during a track change
+      // Built from the player rather than `options.resumeOnStart`'s saved url, which still points at the previous song during a track change
       const { video_id: videoId, list } = this.api?.getVideoData() ?? {};
       if (!videoId) return;
 
@@ -121,14 +117,12 @@ export default createPlugin<
       target.searchParams.set('v', videoId);
       if (list) target.searchParams.set('list', list);
 
-      // Carry the playback position over; the player honours `t` and then drops it from the address bar,
-      // so it cannot pile up across reloads.
+      // Carry the playback position over; the player honours `t` and then drops it from the address bar, so it cannot pile up across reloads.
       const video = document.querySelector('video');
       const elapsed = Math.floor(video?.currentTime ?? 0);
       if (elapsed > 0) target.searchParams.set('t', `${elapsed}s`);
 
-      // The page always autoplays after loading, so remember a paused player and put it back afterwards;
-      // pausing must not restart the music.
+      // The page always autoplays after loading, so remember a paused player and put it back afterwards; pausing must not restart the music.
       if (video?.paused) sessionStorage.setItem(WAS_PAUSED_KEY, '1');
       sessionStorage.setItem(LAST_RELOAD_KEY, `${Date.now()}`);
 
@@ -137,8 +131,7 @@ export default createPlugin<
     keepPaused() {
       const video = document.querySelector('video');
       this.api?.pauseVideo();
-      // Autoplay can win the race, so pause again on the first frame it plays,
-      // but only briefly, so a deliberate play later isn't cancelled
+      // Autoplay can win the race, so pause again on the first frame it plays, but only briefly, so a deliberate play later isn't cancelled
       this.keepPausedUntil = Date.now() + 5_000;
       video?.addEventListener('timeupdate', this.onTimeUpdate, { once: true });
     },
@@ -147,8 +140,7 @@ export default createPlugin<
       if (event.target instanceof HTMLVideoElement) event.target.pause();
     },
     onPause(event) {
-      // A track ending naturally also fires 'pause' (with `ended` set) just before the next one loads;
-      // let the track change do the reload instead
+      // A track ending naturally also fires 'pause' (with `ended` set) just before the next one loads; let the track change do the reload instead
       if (event.target instanceof HTMLVideoElement && event.target.ended) {
         return;
       }
@@ -169,8 +161,7 @@ export default createPlugin<
       }
 
       ipc.on(RELOAD_CHANNEL, () => {
-        // Anchor the cooldown to the previous actual reload, not the request;
-        // a reload deferred for a long time still counts from when it happened
+        // Anchor the cooldown to the previous actual reload, not the request; a reload deferred for a long time still counts from when it happened
         const lastReloadAt = Number(sessionStorage.getItem(LAST_RELOAD_KEY));
         if (Date.now() - lastReloadAt < COOLDOWN_MS) return;
 
@@ -190,8 +181,7 @@ export default createPlugin<
       // A disabled plugin should never leave a pending restore behind
       sessionStorage.removeItem(WAS_PAUSED_KEY);
 
-      // The channel is exclusively this plugin's,
-      // so removing all listeners is safe and is the only cleanup the wrapped `ipc.on` allows
+      // The channel is exclusively this plugin's, so removing all listeners is safe and is the only cleanup the wrapped `ipc.on` allows
       ipc.removeAllListeners(RELOAD_CHANNEL);
       const video = document.querySelector('video');
       video?.removeEventListener('pause', this.onPause);

--- a/src/plugins/memory-saver/index.ts
+++ b/src/plugins/memory-saver/index.ts
@@ -7,19 +7,19 @@ import type { MusicPlayer } from '@/types/music-player';
 import type { VideoDataChanged } from '@/types/video-data-changed';
 
 const CHECK_INTERVAL_MS = 60_000;
-/** Minimum spacing between reloads, anchored to the previous actual reload. */
+/** Minimum spacing between reloads, anchored to the previous actual reload */
 const COOLDOWN_MS = 60 * 60_000;
-/** Only ask for a reload while the user has been away from the keyboard this long. */
+/** Only ask for a reload while the user has been away from the keyboard this long */
 const SYSTEM_IDLE_S = 120;
 
 const RELOAD_CHANNEL = 'memory-saver:reload-when-idle';
-/** These survive the reload but not an app restart, which is exactly the lifetime needed. */
+/** These survive the reload but not an app restart, which is exactly the lifetime needed */
 const WAS_PAUSED_KEY = 'peard:memory-saver-was-paused';
 const LAST_RELOAD_KEY = 'peard:memory-saver-last-reload';
 
 export type MemorySaverPluginConfig = {
   enabled: boolean;
-  /** Reload once the renderer process is above this many MB. */
+  /** Reload once the renderer process is above this many MB */
   thresholdMB: number;
 };
 
@@ -37,6 +37,7 @@ export default createPlugin<
   {
     api: MusicPlayer | null;
     pending: boolean;
+    resumeShuffleEnabled: boolean;
     keepPausedUntil: number;
     canReloadNow: () => boolean;
     tryReload: () => void;
@@ -87,6 +88,7 @@ export default createPlugin<
   renderer: {
     api: null,
     pending: false,
+    resumeShuffleEnabled: false,
     keepPausedUntil: 0,
     canReloadNow() {
       // The reload rebuilds the queue from the URL, which only works for playlist and radio queues; hold off on hand-built ones
@@ -96,7 +98,7 @@ export default createPlugin<
       // The rebuilt queue always comes back unshuffled, so only reload when the resume-shuffle plugin is set up to re-apply the shuffle
       if (isShuffled()) {
         return (
-          !!window.mainConfig.plugins.getPlugins()['resume-shuffle']?.enabled &&
+          this.resumeShuffleEnabled &&
           window.mainConfig.get('options.resumeOnStart')
         );
       }
@@ -117,12 +119,12 @@ export default createPlugin<
       target.searchParams.set('v', videoId);
       if (list) target.searchParams.set('list', list);
 
-      // Carry the playback position over; the player honours `t` and then drops it from the address bar, so it cannot pile up across reloads.
+      // Carry the playback position over; the player honours `t` and then drops it from the address bar, so it cannot pile up across reloads
       const video = document.querySelector('video');
       const elapsed = Math.floor(video?.currentTime ?? 0);
       if (elapsed > 0) target.searchParams.set('t', `${elapsed}s`);
 
-      // The page always autoplays after loading, so remember a paused player and put it back afterwards; pausing must not restart the music.
+      // The page always autoplays after loading, so remember a paused player and put it back afterwards; pausing must not restart the music
       if (video?.paused) sessionStorage.setItem(WAS_PAUSED_KEY, '1');
       sessionStorage.setItem(LAST_RELOAD_KEY, `${Date.now()}`);
 
@@ -160,10 +162,14 @@ export default createPlugin<
         this.keepPaused();
       }
 
-      ipc.on(RELOAD_CHANNEL, () => {
+      ipc.on(RELOAD_CHANNEL, async () => {
         // Anchor the cooldown to the previous actual reload, not the request; a reload deferred for a long time still counts from when it happened
         const lastReloadAt = Number(sessionStorage.getItem(LAST_RELOAD_KEY));
         if (Date.now() - lastReloadAt < COOLDOWN_MS) return;
+
+        // Resolved here rather than per attempt, so the reload gate stays synchronous
+        this.resumeShuffleEnabled =
+          await window.mainConfig.plugins.isEnabled('resume-shuffle');
 
         this.pending = true;
         // Paused is already a safe moment; otherwise wait for the next pause or track change
@@ -177,6 +183,7 @@ export default createPlugin<
     },
     stop({ ipc }) {
       this.pending = false;
+      this.resumeShuffleEnabled = false;
       this.api = null;
       // A disabled plugin should never leave a pending restore behind
       sessionStorage.removeItem(WAS_PAUSED_KEY);

--- a/src/plugins/memory-saver/index.ts
+++ b/src/plugins/memory-saver/index.ts
@@ -1,0 +1,202 @@
+import { app, powerMonitor } from 'electron';
+
+import { t } from '@/i18n';
+import { createPlugin } from '@/utils';
+
+import type { MusicPlayer } from '@/types/music-player';
+import type { VideoDataChanged } from '@/types/video-data-changed';
+
+const CHECK_INTERVAL_MS = 60_000;
+/** Minimum spacing between reloads, anchored to the previous actual reload. */
+const COOLDOWN_MS = 60 * 60_000;
+/** Only ask for a reload while the user has been away from the keyboard this long. */
+const SYSTEM_IDLE_S = 120;
+
+const RELOAD_CHANNEL = 'memory-saver:reload-when-idle';
+/** These survive the reload but not an app restart, which is exactly the lifetime needed. */
+const WAS_PAUSED_KEY = 'peard:memory-saver-was-paused';
+const LAST_RELOAD_KEY = 'peard:memory-saver-last-reload';
+
+export type MemorySaverPluginConfig = {
+  enabled: boolean;
+  /** Reload once the renderer process is above this many MB. */
+  thresholdMB: number;
+};
+
+const isShuffled = () =>
+  (document
+    .querySelector<HTMLElement>('ytmusic-player-bar')
+    ?.attributes.getNamedItem('shuffle-on') ?? null) !== null;
+
+export default createPlugin<
+  {
+    interval: NodeJS.Timeout | null;
+    lastRequestAt: number;
+  },
+  unknown,
+  {
+    api: MusicPlayer | null;
+    pending: boolean;
+    keepPausedUntil: number;
+    canReloadNow: () => boolean;
+    tryReload: () => void;
+    reload: () => void;
+    keepPaused: () => void;
+    onPause: (event: Event) => void;
+    onVideoDataChange: (event: CustomEvent<VideoDataChanged>) => void;
+    onTimeUpdate: (event: Event) => void;
+  },
+  MemorySaverPluginConfig
+>({
+  name: () => t('plugins.memory-saver.name'),
+  description: () => t('plugins.memory-saver.description'),
+  addedVersion: '3.13.X',
+  restartNeeded: false,
+  config: {
+    enabled: false,
+    thresholdMB: 1200,
+  },
+  backend: {
+    interval: null,
+    lastRequestAt: 0,
+    start({ window, ipc, getConfig }) {
+      // macOS keeps the app alive with the window closed; don't stack intervals
+      if (this.interval) clearInterval(this.interval);
+      this.interval = setInterval(async () => {
+        if (window.isDestroyed()) return;
+        // A reload navigates to the song page, so never ask for one while the user is at the keyboard;
+        // the renderer then picks a gap in playback
+        if (powerMonitor.getSystemIdleTime() < SYSTEM_IDLE_S) return;
+        if (Date.now() - this.lastRequestAt < COOLDOWN_MS) return;
+
+        const { thresholdMB } = await getConfig();
+        const pid = window.webContents.getOSProcessId();
+        const usedKB = app.getAppMetrics().find((metric) => metric.pid === pid)
+          ?.memory.workingSetSize;
+
+        if (usedKB && usedKB / 1024 >= thresholdMB) {
+          this.lastRequestAt = Date.now();
+          ipc.send(RELOAD_CHANNEL);
+        }
+      }, CHECK_INTERVAL_MS);
+    },
+    stop() {
+      if (this.interval) clearInterval(this.interval);
+      this.interval = null;
+    },
+  },
+  renderer: {
+    api: null,
+    pending: false,
+    keepPausedUntil: 0,
+    canReloadNow() {
+      // The reload rebuilds the queue from the URL, which only works for playlist and radio queues;
+      // hold off on hand-built ones
+      const { video_id: videoId, list } = this.api?.getVideoData() ?? {};
+      if (!videoId || !list) return false;
+
+      // The rebuilt queue always comes back unshuffled,
+      // so only reload when the resume-shuffle plugin is set up to re-apply the shuffle
+      if (isShuffled()) {
+        return (
+          !!window.mainConfig.plugins.getPlugins()['resume-shuffle']?.enabled &&
+          window.mainConfig.get('options.resumeOnStart')
+        );
+      }
+
+      return true;
+    },
+    tryReload() {
+      if (this.pending && this.canReloadNow()) this.reload();
+    },
+    reload() {
+      // Built from the player rather than `options.resumeOnStart`'s saved url,
+      // which still points at the previous song during a track change
+      const { video_id: videoId, list } = this.api?.getVideoData() ?? {};
+      if (!videoId) return;
+
+      this.pending = false;
+
+      const target = new URL('/watch', location.origin);
+      target.searchParams.set('v', videoId);
+      if (list) target.searchParams.set('list', list);
+
+      // Carry the playback position over; the player honours `t` and then drops it from the address bar,
+      // so it cannot pile up across reloads.
+      const video = document.querySelector('video');
+      const elapsed = Math.floor(video?.currentTime ?? 0);
+      if (elapsed > 0) target.searchParams.set('t', `${elapsed}s`);
+
+      // The page always autoplays after loading, so remember a paused player and put it back afterwards;
+      // pausing must not restart the music.
+      if (video?.paused) sessionStorage.setItem(WAS_PAUSED_KEY, '1');
+      sessionStorage.setItem(LAST_RELOAD_KEY, `${Date.now()}`);
+
+      location.replace(target.toString());
+    },
+    keepPaused() {
+      const video = document.querySelector('video');
+      this.api?.pauseVideo();
+      // Autoplay can win the race, so pause again on the first frame it plays,
+      // but only briefly, so a deliberate play later isn't cancelled
+      this.keepPausedUntil = Date.now() + 5_000;
+      video?.addEventListener('timeupdate', this.onTimeUpdate, { once: true });
+    },
+    onTimeUpdate(event) {
+      if (Date.now() > this.keepPausedUntil) return;
+      if (event.target instanceof HTMLVideoElement) event.target.pause();
+    },
+    onPause(event) {
+      // A track ending naturally also fires 'pause' (with `ended` set) just before the next one loads;
+      // let the track change do the reload instead
+      if (event.target instanceof HTMLVideoElement && event.target.ended) {
+        return;
+      }
+      this.tryReload();
+    },
+    onVideoDataChange(event) {
+      // A track change is the least disruptive moment to lose a few seconds
+      if (event.detail.name === 'dataloaded') this.tryReload();
+    },
+    onPlayerApiReady(api, { ipc }) {
+      this.api = api;
+      // Defensive: this can run again on plugin re-enable
+      ipc.removeAllListeners(RELOAD_CHANNEL);
+
+      if (sessionStorage.getItem(WAS_PAUSED_KEY)) {
+        sessionStorage.removeItem(WAS_PAUSED_KEY);
+        this.keepPaused();
+      }
+
+      ipc.on(RELOAD_CHANNEL, () => {
+        // Anchor the cooldown to the previous actual reload, not the request;
+        // a reload deferred for a long time still counts from when it happened
+        const lastReloadAt = Number(sessionStorage.getItem(LAST_RELOAD_KEY));
+        if (Date.now() - lastReloadAt < COOLDOWN_MS) return;
+
+        this.pending = true;
+        // Paused is already a safe moment; otherwise wait for the next pause or track change
+        if (document.querySelector('video')?.paused) this.tryReload();
+      });
+
+      document
+        .querySelector('video')
+        ?.addEventListener('pause', this.onPause, { passive: true });
+      document.addEventListener('videodatachange', this.onVideoDataChange);
+    },
+    stop({ ipc }) {
+      this.pending = false;
+      this.api = null;
+      // A disabled plugin should never leave a pending restore behind
+      sessionStorage.removeItem(WAS_PAUSED_KEY);
+
+      // The channel is exclusively this plugin's,
+      // so removing all listeners is safe and is the only cleanup the wrapped `ipc.on` allows
+      ipc.removeAllListeners(RELOAD_CHANNEL);
+      const video = document.querySelector('video');
+      video?.removeEventListener('pause', this.onPause);
+      video?.removeEventListener('timeupdate', this.onTimeUpdate);
+      document.removeEventListener('videodatachange', this.onVideoDataChange);
+    },
+  },
+});


### PR DESCRIPTION
Adds an opt-in plugin that reloads the page when the renderer's memory crosses a threshold, working around the web player's memory leak behind the long-session slowdown and crash reports (#4450, #1722, #1158, #797, #322, #295).

🤖 Claude measured over the DevTools protocol against the real app: `Performance.getMetrics` sampled after every track change on a 50-track playlist, with GC forced before each sample so growth reflects actual retention.

| configuration | nodes/track | listeners/track | heap/track |
|---|---|---|---|
| default plugins | 128 | 33 | 0.47 MB |
| all 40 plugins disabled | 132 | 33 | 0.43 MB |
| this app's renderer script not injected | 125 | 32 | 0.32 MB |

The rate is unchanged with our code completely absent, so the leak is upstream and can't be fixed here. The retained nodes are detached (the attached DOM grew by 6 elements while total nodes grew ~1,500), which is why the UI degrades rather than just growing. Over a week of continuous playback that's roughly 370k nodes and over 1 GB. A reload reclaims all of it: in one test, 83 to 73 MB of heap and 43.8k to 41.6k nodes.

Behavior

- The backend checks the renderer's working set once a minute, and only acts while the user is away from the keyboard (`powerMonitor.getSystemIdleTime()`), since a reload lands on the song page. The threshold is `thresholdMB` in config.json (default 1200).
- The renderer reloads at the next gap in playback: immediately if paused (staying paused afterwards), otherwise at the next pause or track change.
- The song and position survive. The queue is rebuilt from the watch URL, so only playlist and radio queues reload; hand-built queues are left alone.
- While shuffle is on, the plugin holds off entirely, since the rebuilt queue would come back unshuffled. A follow-up can lift this once there is a way to [restore the shuffle after a reload](https://github.com/pear-devs/pear-desktop/pull/4616).
- Reloads are spaced at least an hour apart.
- Play next / Add to queue are lost on reload, and radio queues may regenerate different upcoming tracks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the Memory Saver plugin.
  * Automatically reloads the page during idle periods when renderer memory usage exceeds a configured threshold.
  * Preserves the current song, playback position, queue, shuffle state, and pause state across the reload.
  * Smarter reload timing: reloads respect resume-shuffle behavior and only trigger when safe to restore playback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
