### PR TITLE
plugin fix(skip-disliked-songs): stop skipping 2 songs

### DIFF
--- a/src/plugins/skip-disliked-songs/index.ts
+++ b/src/plugins/skip-disliked-songs/index.ts
@@ -2,39 +2,95 @@ import { t } from '@/i18n';
 import { createPlugin } from '@/utils';
 import { waitForElement } from '@/utils/wait-for-element';
 
+import type { MusicPlayer } from '@/types/music-player';
+
+const CONFIRM_DELAY_MS = 1000;
+const REARM_MS = 1500;
+
+let lastSkipVideoId = '';
+let lastSkipTime = 0;
+let observer: MutationObserver | undefined;
+let confirmTimer: ReturnType<typeof setTimeout> | undefined;
+
+const isRecentlySkipped = (videoId: string) =>
+  videoId === lastSkipVideoId && Date.now() - lastSkipTime < REARM_MS;
+
 export default createPlugin<
   unknown,
   unknown,
   {
-    observer?: MutationObserver;
+    dislikeBtn?: HTMLElement;
+    playerApi?: MusicPlayer;
     start(): void;
     stop(): void;
+    onPlayerApiReady(api: MusicPlayer): void;
+    proposeSkip(): void;
   }
 >({
   name: () => t('plugins.skip-disliked-songs.name'),
   description: () => t('plugins.skip-disliked-songs.description'),
   restartNeeded: false,
   renderer: {
+    proposeSkip() {
+      const { playerApi, dislikeBtn } = this;
+      if (!playerApi || !dislikeBtn) return;
+
+      const videoId = playerApi.getVideoData?.()?.video_id;
+      if (!videoId || isRecentlySkipped(videoId)) return;
+      if (dislikeBtn.getAttribute('like-status') !== 'DISLIKE') return;
+
+      clearTimeout(confirmTimer);
+      confirmTimer = setTimeout(() => {
+        const stillDisliked =
+          playerApi.getVideoData?.()?.video_id === videoId &&
+          dislikeBtn.getAttribute('like-status') === 'DISLIKE';
+
+        if (stillDisliked && !isRecentlySkipped(videoId)) {
+          lastSkipVideoId = videoId;
+          lastSkipTime = Date.now();
+          playerApi.nextVideo();
+        }
+      }, CONFIRM_DELAY_MS);
+    },
+
+    onPlayerApiReady(api: MusicPlayer) {
+      this.playerApi = api;
+      api.addEventListener('videodatachange', () => this.proposeSkip());
+      this.proposeSkip();
+    },
+
     start() {
+      observer?.disconnect();
+
       waitForElement<HTMLElement>('#like-button-renderer').then(
         (dislikeBtn) => {
-          this.observer = new MutationObserver(() => {
-            if (dislikeBtn?.getAttribute('like-status') == 'DISLIKE') {
-              document
-                .querySelector<HTMLButtonElement>('yt-icon-button.next-button')
-                ?.click();
+          this.dislikeBtn = dislikeBtn;
+
+          observer = new MutationObserver((mutations) => {
+            if (mutations.some((m) => m.attributeName === 'like-status')) {
+              this.proposeSkip();
             }
           });
-          this.observer.observe(dislikeBtn, {
+
+          observer.observe(dislikeBtn, {
             attributes: true,
             childList: false,
             subtree: false,
+            attributeFilter: ['like-status'],
           });
+
+          this.proposeSkip();
         },
       );
     },
+
     stop() {
-      this.observer?.disconnect();
+      observer?.disconnect();
+      observer = undefined;
+      clearTimeout(confirmTimer);
+      this.playerApi = undefined;
+      lastSkipVideoId = '';
+      lastSkipTime = 0;
     },
   },
 });


### PR DESCRIPTION
fixes: https://github.com/pear-devs/pear-desktop/issues/4223#issuecomment-5126673468

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved skipping of disliked songs by adding a confirmation delay to verify the dislike state before advancing.
  * Reduced accidental/duplicate skips during rapid player updates and repeated like-status changes.
  * Enhanced responsiveness to player availability and video changes for more reliable behavior.
  * Improved stop behavior by clearing pending timers and resetting internal skip tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

RECORDING (40s), showcases skips of multiple disliked songs and singular skips: https://github.com/user-attachments/assets/09c572aa-f758-46f7-bdb3-6f47bb496913