### PR TITLE
feat(plugins): add Status Bar Lyrics plugin for macOS

### DIFF
--- a/src/plugins/statusbar-lyrics/backend.ts
+++ b/src/plugins/statusbar-lyrics/backend.ts
@@ -1,0 +1,41 @@
+import { nativeImage, Tray } from 'electron';
+import is from 'electron-is';
+
+import { createBackend } from '@/utils';
+
+let tray: Tray | undefined;
+
+const getTray = () => {
+  if (!tray) {
+    tray = new Tray(nativeImage.createEmpty());
+  }
+  return tray;
+};
+
+const normalizeText = (text: string, maxLength: number) => {
+  const cleaned = text.replace(/\s+/g, ' ').trim();
+  if (cleaned.length <= maxLength) return cleaned;
+  return `${cleaned.slice(0, maxLength - 1).trimEnd()}…`;
+};
+
+export const backend = createBackend({
+  start(ctx) {
+    ctx.ipc.handle('statusbar-lyrics:set-text', (text: string, maxLength: number) => {
+      if (!is.macOS()) return;
+
+      const trayInstance = getTray();
+      // trayInstance.setTitle(normalizeText(text, maxLength));
+      trayInstance.setTitle(text);
+    });
+
+    ctx.ipc.handle('statusbar-lyrics:clear', () => {
+      if (!is.macOS()) return;
+      getTray().setTitle('');
+    });
+  },
+  stop(ctx) {
+    ctx.ipc.removeHandler('statusbar-lyrics:set-text');
+    ctx.ipc.removeHandler('statusbar-lyrics:clear');
+    tray?.setTitle('');
+  },
+});

--- a/src/plugins/statusbar-lyrics/backend.ts
+++ b/src/plugins/statusbar-lyrics/backend.ts
@@ -18,9 +18,10 @@ const getTray = () => {
 // compact and readable even when the source line contains extra whitespace.
 const normalizeText = (text: string, maxLength: number) => {
   const cleaned = text.replace(/\s+/g, ' ').trim();
-  if (maxLength <= 0) return '';
-  if (cleaned.length <= maxLength) return cleaned;
-  return `${cleaned.slice(0, maxLength - 1).trimEnd()}…`;
+  const limit = Number.isFinite(maxLength) ? Math.floor(maxLength) : 0;
+  if (limit <= 0) return '';
+  if (cleaned.length <= limit) return cleaned;
+  return `${cleaned.slice(0, limit - 1).trimEnd()}…`;
 };
 
 export const backend = createBackend({
@@ -30,8 +31,8 @@ export const backend = createBackend({
       if (!is.macOS()) return;
 
       const trayInstance = getTray();
-      // trayInstance.setTitle(normalizeText(text, maxLength));
-      trayInstance.setTitle(text);
+      trayInstance.setTitle(normalizeText(text, maxLength));
+      // trayInstance.setTitle(text);
     });
 
     ctx.ipc.handle('statusbar-lyrics:clear', () => {

--- a/src/plugins/statusbar-lyrics/backend.ts
+++ b/src/plugins/statusbar-lyrics/backend.ts
@@ -5,6 +5,8 @@ import { createBackend } from '@/utils';
 
 let tray: Tray | undefined;
 
+// Lazily create a tray instance so the plugin can reuse a single macOS title
+// target without allocating a visible icon.
 const getTray = () => {
   if (!tray) {
     tray = new Tray(nativeImage.createEmpty());
@@ -12,6 +14,8 @@ const getTray = () => {
   return tray;
 };
 
+// Normalize lyric text before sending it to the tray title so the result stays
+// compact and readable even when the source line contains extra whitespace.
 const normalizeText = (text: string, maxLength: number) => {
   const cleaned = text.replace(/\s+/g, ' ').trim();
   if (maxLength <= 0) return '';
@@ -20,13 +24,13 @@ const normalizeText = (text: string, maxLength: number) => {
 };
 
 export const backend = createBackend({
+  // Handle renderer requests that update or clear the macOS menu bar title.
   start(ctx) {
     ctx.ipc.handle('statusbar-lyrics:set-text', (text: string, maxLength: number) => {
       if (!is.macOS()) return;
 
       const trayInstance = getTray();
-      // trayInstance.setTitle(normalizeText(text, maxLength));
-      trayInstance.setTitle(text);
+      trayInstance.setTitle(normalizeText(text, maxLength));
     });
 
     ctx.ipc.handle('statusbar-lyrics:clear', () => {
@@ -34,6 +38,7 @@ export const backend = createBackend({
       getTray().setTitle('');
     });
   },
+  // Tear down handlers and clear any remaining tray text when the plugin stops.
   stop(ctx) {
     ctx.ipc.removeHandler('statusbar-lyrics:set-text');
     ctx.ipc.removeHandler('statusbar-lyrics:clear');

--- a/src/plugins/statusbar-lyrics/backend.ts
+++ b/src/plugins/statusbar-lyrics/backend.ts
@@ -30,7 +30,8 @@ export const backend = createBackend({
       if (!is.macOS()) return;
 
       const trayInstance = getTray();
-      trayInstance.setTitle(normalizeText(text, maxLength));
+      // trayInstance.setTitle(normalizeText(text, maxLength));
+      trayInstance.setTitle(text);
     });
 
     ctx.ipc.handle('statusbar-lyrics:clear', () => {

--- a/src/plugins/statusbar-lyrics/backend.ts
+++ b/src/plugins/statusbar-lyrics/backend.ts
@@ -14,6 +14,7 @@ const getTray = () => {
 
 const normalizeText = (text: string, maxLength: number) => {
   const cleaned = text.replace(/\s+/g, ' ').trim();
+  if (maxLength <= 0) return '';
   if (cleaned.length <= maxLength) return cleaned;
   return `${cleaned.slice(0, maxLength - 1).trimEnd()}…`;
 };

--- a/src/plugins/statusbar-lyrics/backend.ts
+++ b/src/plugins/statusbar-lyrics/backend.ts
@@ -44,6 +44,10 @@ export const backend = createBackend({
   stop(ctx) {
     ctx.ipc.removeHandler('statusbar-lyrics:set-text');
     ctx.ipc.removeHandler('statusbar-lyrics:clear');
-    tray?.setTitle('');
+    if (tray && !tray.isDestroyed()) {
+      tray.setTitle('');
+      tray.destroy();
+    }
+    tray = undefined;
   },
 });

--- a/src/plugins/statusbar-lyrics/index.ts
+++ b/src/plugins/statusbar-lyrics/index.ts
@@ -2,16 +2,19 @@ import { createPlugin } from '@/utils';
 import { Platform } from '@/types/plugins';
 
 import { backend } from './backend';
+import { menu } from './menu';
 import { renderer } from './renderer';
 
 export interface StatusbarLyricsPluginConfig {
   enabled: boolean;
   maxLength: number;
+  includePronunciation: boolean;
 }
 
 export const defaultConfig: StatusbarLyricsPluginConfig = {
   enabled: false,
   maxLength: 32,
+  includePronunciation: false,
 };
 
 export default createPlugin({
@@ -20,6 +23,7 @@ export default createPlugin({
   restartNeeded: false,
   platform: Platform.macOS,
   config: defaultConfig,
+  menu,
   backend,
   renderer,
 });

--- a/src/plugins/statusbar-lyrics/index.ts
+++ b/src/plugins/statusbar-lyrics/index.ts
@@ -17,6 +17,8 @@ export const defaultConfig: StatusbarLyricsPluginConfig = {
   includePronunciation: false,
 };
 
+// Plugin entry point: wires the renderer, backend, and menu together and
+// exposes the configuration that controls how lyrics appear in the status bar.
 export default createPlugin({
   name: () => 'Status Bar Lyrics',
   description: () => 'Show the current lyric line in the macOS menu bar title.',

--- a/src/plugins/statusbar-lyrics/index.ts
+++ b/src/plugins/statusbar-lyrics/index.ts
@@ -21,7 +21,7 @@ export const defaultConfig: StatusbarLyricsPluginConfig = {
 // exposes the configuration that controls how lyrics appear in the status bar.
 export default createPlugin({
   name: () => 'Status Bar Lyrics',
-  description: () => 'Show the current lyric line in the macOS menu bar title.',
+  description: () => 'Show the current lyric line in the macOS menu bar title. Requires Synced Lyrics to be enabled.',
   restartNeeded: false,
   platform: Platform.macOS,
   config: defaultConfig,

--- a/src/plugins/statusbar-lyrics/index.ts
+++ b/src/plugins/statusbar-lyrics/index.ts
@@ -1,0 +1,25 @@
+import { createPlugin } from '@/utils';
+import { Platform } from '@/types/plugins';
+
+import { backend } from './backend';
+import { renderer } from './renderer';
+
+export interface StatusbarLyricsPluginConfig {
+  enabled: boolean;
+  maxLength: number;
+}
+
+export const defaultConfig: StatusbarLyricsPluginConfig = {
+  enabled: false,
+  maxLength: 32,
+};
+
+export default createPlugin({
+  name: () => 'Status Bar Lyrics',
+  description: () => 'Show the current lyric line in the macOS menu bar title.',
+  restartNeeded: false,
+  platform: Platform.macOS,
+  config: defaultConfig,
+  backend,
+  renderer,
+});

--- a/src/plugins/statusbar-lyrics/index.ts
+++ b/src/plugins/statusbar-lyrics/index.ts
@@ -13,7 +13,7 @@ export interface StatusbarLyricsPluginConfig {
 
 export const defaultConfig: StatusbarLyricsPluginConfig = {
   enabled: false,
-  maxLength: 32,
+  maxLength: 55,
   includePronunciation: false,
 };
 

--- a/src/plugins/statusbar-lyrics/menu.ts
+++ b/src/plugins/statusbar-lyrics/menu.ts
@@ -3,20 +3,22 @@ import type { MenuItemConstructorOptions } from 'electron';
 
 import type { StatusbarLyricsPluginConfig } from './index';
 
+// Expose the user-facing setting that controls whether pronunciation text is
+// included in the status bar output.
 export const menu = async (
-  ctx: MenuContext<StatusbarLyricsPluginConfig>,
+    ctx: MenuContext<StatusbarLyricsPluginConfig>,
 ): Promise<MenuItemConstructorOptions[]> => {
-  const config = await ctx.getConfig();
+    const config = await ctx.getConfig();
 
-  return [
-    {
-      label: 'Include pronunciation',
-      toolTip: 'Include pronunciation or romanization lines in the status bar text when available.',
-      type: 'checkbox',
-      checked: config.includePronunciation,
-      click(item) {
-        ctx.setConfig({ includePronunciation: item.checked });
-      },
-    },
-  ];
+    return [
+        {
+            label: 'Include pronunciation',
+            toolTip: 'Include pronunciation or romanization lines in the status bar text when available.',
+            type: 'checkbox',
+            checked: config.includePronunciation,
+            click(item) {
+                ctx.setConfig({ includePronunciation: item.checked });
+            },
+        },
+    ];
 };

--- a/src/plugins/statusbar-lyrics/menu.ts
+++ b/src/plugins/statusbar-lyrics/menu.ts
@@ -1,0 +1,22 @@
+import type { MenuContext } from '@/types/contexts';
+import type { MenuItemConstructorOptions } from 'electron';
+
+import type { StatusbarLyricsPluginConfig } from './index';
+
+export const menu = async (
+  ctx: MenuContext<StatusbarLyricsPluginConfig>,
+): Promise<MenuItemConstructorOptions[]> => {
+  const config = await ctx.getConfig();
+
+  return [
+    {
+      label: 'Include pronunciation',
+      toolTip: 'Include pronunciation or romanization lines in the status bar text when available.',
+      type: 'checkbox',
+      checked: config.includePronunciation,
+      click(item) {
+        ctx.setConfig({ includePronunciation: item.checked });
+      },
+    },
+  ];
+};

--- a/src/plugins/statusbar-lyrics/renderer.ts
+++ b/src/plugins/statusbar-lyrics/renderer.ts
@@ -8,6 +8,9 @@ let activeLineElement: HTMLElement | null = null;
 let timer: number | undefined;
 let observer: MutationObserver | undefined;
 let sendLyrics: (() => void) | undefined;
+let sendInFlight = false;
+let sendRequested = false;
+let lastPayload: string | undefined;
 
 const onPlayOrPaused = () => {
   void sendLyrics?.();
@@ -21,6 +24,12 @@ const resetLineState = () => {
   activeLineText = '';
   activeLineStartedAt = 0;
   activeLineElement = null;
+};
+
+const resetSendState = () => {
+  sendInFlight = false;
+  sendRequested = false;
+  lastPayload = undefined;
 };
 
 // Collapse whitespace so lyric fragments remain stable when DOM nodes split a
@@ -153,8 +162,15 @@ export const renderer = createRenderer({
     const send = async () => {
       const config = (await ctx.getConfig()) as StatusbarLyricsPluginConfig;
       const text = pollLyrics(config.includePronunciation);
+      const payload = config.enabled && text ? `${config.maxLength}\u0000${text}` : '';
 
-      if (!config.enabled || !text) {
+      if (payload === lastPayload) {
+        return;
+      }
+
+      lastPayload = payload;
+
+      if (!payload) {
         await ctx.ipc.invoke('statusbar-lyrics:clear');
         return;
       }
@@ -162,8 +178,27 @@ export const renderer = createRenderer({
       await ctx.ipc.invoke('statusbar-lyrics:set-text', text, config.maxLength);
     };
 
+    const flushSend = async () => {
+      if (sendInFlight) {
+        sendRequested = true;
+        return;
+      }
+
+      sendInFlight = true;
+
+      try {
+        do {
+          sendRequested = false;
+          await send();
+        } while (sendRequested);
+      } finally {
+        sendInFlight = false;
+      }
+    };
+
     sendLyrics = () => {
-      void send();
+      sendRequested = true;
+      void flushSend();
     };
 
     if (timer) {
@@ -175,7 +210,7 @@ export const renderer = createRenderer({
     resetLineState();
 
     observer = new MutationObserver(() => {
-      void send();
+      sendLyrics?.();
     });
 
     const target = document.querySelector('ytmusic-player-page');
@@ -190,7 +225,7 @@ export const renderer = createRenderer({
     }
 
     timer = window.setInterval(() => {
-      void send();
+      sendLyrics?.();
     }, 250);
 
     window.ipcRenderer.removeListener('peard:play-or-paused', onPlayOrPaused);
@@ -214,6 +249,7 @@ export const renderer = createRenderer({
 
     sendLyrics = undefined;
     resetLineState();
+    resetSendState();
 
     void window.ipcRenderer.invoke('statusbar-lyrics:clear');
   },

--- a/src/plugins/statusbar-lyrics/renderer.ts
+++ b/src/plugins/statusbar-lyrics/renderer.ts
@@ -6,8 +6,12 @@ let activeLineText = '';
 let activeLineStartedAt = 0;
 let activeLineElement: HTMLElement | null = null;
 
+// Collapse whitespace so lyric fragments remain stable when DOM nodes split a
+// line into multiple pieces.
 const normalizeText = (text: string) => text.replace(/\s+/g, ' ').trim();
 
+// Detect translation or pronunciation nodes so the plugin can prefer the main
+// lyric line when both primary and auxiliary text are present.
 const isLikelyPronunciation = (element: HTMLElement | null) => {
   if (!element) return false;
 
@@ -19,6 +23,8 @@ const isLikelyPronunciation = (element: HTMLElement | null) => {
   );
 };
 
+// Detect romanization-only nodes as auxiliary text so the plugin can prefer
+// the main lyric line when both are rendered.
 const isLikelyRomaji = (element: HTMLElement | null) => {
   if (!element) return false;
 
@@ -44,6 +50,8 @@ const getPrimaryText = (element: HTMLElement | null) => {
   return normalizeText(element.textContent ?? '');
 };
 
+// Find the text container inside a lyric row that actually holds the primary
+// line content.
 const getPrimaryTextElement = (lineElement: HTMLElement | null) => {
   if (!lineElement) return null;
 
@@ -53,6 +61,8 @@ const getPrimaryTextElement = (lineElement: HTMLElement | null) => {
   return visibleCandidate ?? candidates[0] ?? null;
 };
 
+// Read the CSS duration that synced lyrics expose so the plugin can predict
+// when the current line is about to switch.
 const parseDurationMs = (element: HTMLElement) => {
   const rawDuration = getComputedStyle(element).getPropertyValue(
     '--lyrics-duration',
@@ -64,6 +74,8 @@ const parseDurationMs = (element: HTMLElement) => {
   return parsedDuration * 1000;
 };
 
+// Choose the best text for a line, optionally keeping pronunciation text when
+// the user has enabled it in the plugin settings.
 const getLineText = (element: HTMLElement | null, includePronunciation: boolean) => {
   if (!element) return '';
 
@@ -84,6 +96,8 @@ const getLineText = (element: HTMLElement | null, includePronunciation: boolean)
   return lines[0] ?? text;
 };
 
+// Poll the current synced lyrics row and switch to the next line slightly
+// before the animation ends so the tray title stays in sync with playback.
 const pollLyrics = (includePronunciation: boolean) => {
   const currentLine = document.querySelector<HTMLElement>('.synced-line.current');
   if (!currentLine) return '';
@@ -116,6 +130,8 @@ const pollLyrics = (includePronunciation: boolean) => {
 };
 
 export const renderer = createRenderer({
+  // Observe lyric DOM changes and push the current line to the backend whenever
+  // playback state or lyric content changes.
   async start(ctx) {
     const stop = () => {
       if (timer) {
@@ -159,7 +175,7 @@ export const renderer = createRenderer({
 
     timer = window.setInterval(() => {
       void send();
-      }, 250);
+    }, 250);
 
     ctx.ipc.on('peard:play-or-paused', () => {
       void send();
@@ -170,6 +186,7 @@ export const renderer = createRenderer({
 
     (this as { stop?: () => void }).stop = stop;
   },
+  // Delegate to the stop handler registered during startup.
   stop() {
     (this as { stop?: () => void }).stop?.();
   },

--- a/src/plugins/statusbar-lyrics/renderer.ts
+++ b/src/plugins/statusbar-lyrics/renderer.ts
@@ -1,0 +1,117 @@
+import { createRenderer } from '@/utils';
+
+import type { StatusbarLyricsPluginConfig } from './index';
+
+let activeLineText = '';
+let activeLineStartedAt = 0;
+let activeLineElement: HTMLElement | null = null;
+
+const normalizeText = (text: string) => text.replace(/\s+/g, ' ').trim();
+
+const parseDurationMs = (element: HTMLElement) => {
+  const rawDuration = getComputedStyle(element).getPropertyValue(
+    '--lyrics-duration',
+  );
+  const parsedDuration = Number.parseFloat(rawDuration);
+
+  if (!Number.isFinite(parsedDuration) || parsedDuration <= 0) return null;
+
+  return parsedDuration * 1000;
+};
+
+const getLineText = (element: HTMLElement | null) => {
+  if (!element) return '';
+
+  const textElement = element.querySelector<HTMLElement>('.text-lyrics');
+  if (!textElement) return '';
+
+  return normalizeText(textElement.textContent ?? '');
+};
+
+const pollLyrics = () => {
+  const currentTextElement = document.querySelector<HTMLElement>(
+    '.synced-line.current .text-lyrics',
+  );
+  if (!currentTextElement) return '';
+
+  const currentLine = currentTextElement.closest<HTMLElement>('.synced-line');
+  const currentText = normalizeText(currentTextElement.textContent ?? '');
+  const now = performance.now();
+
+  if (activeLineElement !== currentLine || currentText !== activeLineText) {
+    activeLineElement = currentLine;
+    activeLineText = currentText;
+    activeLineStartedAt = now;
+  }
+
+  const durationMs = parseDurationMs(currentTextElement) ?? 0;
+  const leadMs = Math.max(180, Math.min(400, durationMs * 0.18));
+  const switchAtMs = Math.max(0, durationMs - leadMs);
+
+  if (now - activeLineStartedAt >= switchAtMs) {
+    const nextLineText = getLineText(currentLine?.nextElementSibling as HTMLElement | null);
+    if (nextLineText) return nextLineText;
+  }
+
+  return currentText;
+};
+
+export const renderer = createRenderer({
+  async start(ctx) {
+    const stop = () => {
+      if (timer) {
+        window.clearInterval(timer);
+      }
+      observer?.disconnect();
+      ctx.ipc.removeAllListeners('peard:play-or-paused');
+      ctx.ipc.removeAllListeners('peard:time-changed');
+      void ctx.ipc.invoke('statusbar-lyrics:clear');
+    };
+
+    const send = async () => {
+      const text = pollLyrics();
+      const config = (await ctx.getConfig()) as StatusbarLyricsPluginConfig;
+
+      if (!config.enabled || !text) {
+        await ctx.ipc.invoke('statusbar-lyrics:clear');
+        return;
+      }
+
+      await ctx.ipc.invoke('statusbar-lyrics:set-text', text, config.maxLength);
+    };
+
+    let timer: number | undefined;
+    let observer: MutationObserver | undefined;
+
+    observer = new MutationObserver(() => {
+      void send();
+    });
+
+    const target = document.querySelector('ytmusic-player-page');
+    if (target) {
+      observer.observe(target, {
+        childList: true,
+        subtree: true,
+        characterData: true,
+        attributes: true,
+        attributeFilter: ['class'],
+      });
+    }
+
+    timer = window.setInterval(() => {
+      void send();
+      }, 250);
+
+    ctx.ipc.on('peard:play-or-paused', () => {
+      void send();
+    });
+    ctx.ipc.on('peard:time-changed', () => {
+      void send();
+    });
+
+    (this as { stop?: () => void }).stop = stop;
+  },
+  stop() {
+    (this as { stop?: () => void }).stop?.();
+  },
+});

--- a/src/plugins/statusbar-lyrics/renderer.ts
+++ b/src/plugins/statusbar-lyrics/renderer.ts
@@ -133,13 +133,21 @@ export const renderer = createRenderer({
   // Observe lyric DOM changes and push the current line to the backend whenever
   // playback state or lyric content changes.
   async start(ctx) {
+    const onPlayOrPaused = () => {
+      void send();
+    };
+
+    const onTimeChanged = () => {
+      void send();
+    };
+
     const stop = () => {
       if (timer) {
         window.clearInterval(timer);
       }
       observer?.disconnect();
-      ctx.ipc.removeAllListeners('peard:play-or-paused');
-      ctx.ipc.removeAllListeners('peard:time-changed');
+      window.ipcRenderer.removeListener('peard:play-or-paused', onPlayOrPaused);
+      window.ipcRenderer.removeListener('peard:time-changed', onTimeChanged);
       void ctx.ipc.invoke('statusbar-lyrics:clear');
     };
 
@@ -177,12 +185,8 @@ export const renderer = createRenderer({
       void send();
     }, 250);
 
-    ctx.ipc.on('peard:play-or-paused', () => {
-      void send();
-    });
-    ctx.ipc.on('peard:time-changed', () => {
-      void send();
-    });
+    window.ipcRenderer.on('peard:play-or-paused', onPlayOrPaused);
+    window.ipcRenderer.on('peard:time-changed', onTimeChanged);
 
     (this as { stop?: () => void }).stop = stop;
   },

--- a/src/plugins/statusbar-lyrics/renderer.ts
+++ b/src/plugins/statusbar-lyrics/renderer.ts
@@ -8,6 +8,51 @@ let activeLineElement: HTMLElement | null = null;
 
 const normalizeText = (text: string) => text.replace(/\s+/g, ' ').trim();
 
+const isLikelyPronunciation = (element: HTMLElement | null) => {
+  if (!element) return false;
+
+  const className = element.className?.toString() ?? '';
+  if (/(translation|translated|subtitle|pronunciation|romaji|romanization)/i.test(className)) return true;
+
+  return Boolean(
+    element.closest('.translation, .translated, .lyrics-translation, .pronunciation, .romaji, [data-translation], [data-romanization], [aria-label*="translation" i], [aria-label*="pronunciation" i], [aria-label*="romaji" i]'),
+  );
+};
+
+const isLikelyRomaji = (element: HTMLElement | null) => {
+  if (!element) return false;
+
+  const className = element.className?.toString() ?? '';
+  if (/(romaji|romanization|pronunciation)/i.test(className)) return true;
+
+  return Boolean(element.closest('.romaji, [data-romanization], [aria-label*="romaji" i]'));
+};
+
+const getPrimaryText = (element: HTMLElement | null) => {
+  if (!element) return '';
+
+  const primaryChildren = Array.from(element.children).filter(
+    (child): child is HTMLElement => child instanceof HTMLElement && !isLikelyPronunciation(child) && !isLikelyRomaji(child),
+  );
+
+  const directText = primaryChildren
+    .map((child) => normalizeText(child.textContent ?? ''))
+    .find(Boolean);
+
+  if (directText) return directText;
+
+  return normalizeText(element.textContent ?? '');
+};
+
+const getPrimaryTextElement = (lineElement: HTMLElement | null) => {
+  if (!lineElement) return null;
+
+  const candidates = Array.from(lineElement.querySelectorAll<HTMLElement>('.text-lyrics'));
+  const visibleCandidate = candidates.find((candidate) => !isLikelyPronunciation(candidate));
+
+  return visibleCandidate ?? candidates[0] ?? null;
+};
+
 const parseDurationMs = (element: HTMLElement) => {
   const rawDuration = getComputedStyle(element).getPropertyValue(
     '--lyrics-duration',
@@ -19,23 +64,34 @@ const parseDurationMs = (element: HTMLElement) => {
   return parsedDuration * 1000;
 };
 
-const getLineText = (element: HTMLElement | null) => {
+const getLineText = (element: HTMLElement | null, includePronunciation: boolean) => {
   if (!element) return '';
 
-  const textElement = element.querySelector<HTMLElement>('.text-lyrics');
+  const textElement = getPrimaryTextElement(element);
   if (!textElement) return '';
 
-  return normalizeText(textElement.textContent ?? '');
+  const text = includePronunciation
+    ? normalizeText(textElement.textContent ?? '')
+    : getPrimaryText(textElement);
+
+  if (!text) return '';
+
+  const lines = text
+    .split(/\r?\n/)
+    .map((line) => normalizeText(line))
+    .filter(Boolean);
+
+  return lines[0] ?? text;
 };
 
-const pollLyrics = () => {
-  const currentTextElement = document.querySelector<HTMLElement>(
-    '.synced-line.current .text-lyrics',
-  );
+const pollLyrics = (includePronunciation: boolean) => {
+  const currentLine = document.querySelector<HTMLElement>('.synced-line.current');
+  if (!currentLine) return '';
+
+  const currentTextElement = getPrimaryTextElement(currentLine);
   if (!currentTextElement) return '';
 
-  const currentLine = currentTextElement.closest<HTMLElement>('.synced-line');
-  const currentText = normalizeText(currentTextElement.textContent ?? '');
+  const currentText = getLineText(currentLine, includePronunciation);
   const now = performance.now();
 
   if (activeLineElement !== currentLine || currentText !== activeLineText) {
@@ -49,7 +105,10 @@ const pollLyrics = () => {
   const switchAtMs = Math.max(0, durationMs - leadMs);
 
   if (now - activeLineStartedAt >= switchAtMs) {
-    const nextLineText = getLineText(currentLine?.nextElementSibling as HTMLElement | null);
+    const nextLineText = getLineText(
+      currentLine?.nextElementSibling as HTMLElement | null,
+      includePronunciation,
+    );
     if (nextLineText) return nextLineText;
   }
 
@@ -69,8 +128,8 @@ export const renderer = createRenderer({
     };
 
     const send = async () => {
-      const text = pollLyrics();
       const config = (await ctx.getConfig()) as StatusbarLyricsPluginConfig;
+      const text = pollLyrics(config.includePronunciation);
 
       if (!config.enabled || !text) {
         await ctx.ipc.invoke('statusbar-lyrics:clear');

--- a/src/plugins/statusbar-lyrics/renderer.ts
+++ b/src/plugins/statusbar-lyrics/renderer.ts
@@ -5,6 +5,23 @@ import type { StatusbarLyricsPluginConfig } from './index';
 let activeLineText = '';
 let activeLineStartedAt = 0;
 let activeLineElement: HTMLElement | null = null;
+let timer: number | undefined;
+let observer: MutationObserver | undefined;
+let sendLyrics: (() => void) | undefined;
+
+const onPlayOrPaused = () => {
+  void sendLyrics?.();
+};
+
+const onTimeChanged = () => {
+  void sendLyrics?.();
+};
+
+const resetLineState = () => {
+  activeLineText = '';
+  activeLineStartedAt = 0;
+  activeLineElement = null;
+};
 
 // Collapse whitespace so lyric fragments remain stable when DOM nodes split a
 // line into multiple pieces.
@@ -133,24 +150,6 @@ export const renderer = createRenderer({
   // Observe lyric DOM changes and push the current line to the backend whenever
   // playback state or lyric content changes.
   async start(ctx) {
-    const onPlayOrPaused = () => {
-      void send();
-    };
-
-    const onTimeChanged = () => {
-      void send();
-    };
-
-    const stop = () => {
-      if (timer) {
-        window.clearInterval(timer);
-      }
-      observer?.disconnect();
-      window.ipcRenderer.removeListener('peard:play-or-paused', onPlayOrPaused);
-      window.ipcRenderer.removeListener('peard:time-changed', onTimeChanged);
-      void ctx.ipc.invoke('statusbar-lyrics:clear');
-    };
-
     const send = async () => {
       const config = (await ctx.getConfig()) as StatusbarLyricsPluginConfig;
       const text = pollLyrics(config.includePronunciation);
@@ -163,8 +162,17 @@ export const renderer = createRenderer({
       await ctx.ipc.invoke('statusbar-lyrics:set-text', text, config.maxLength);
     };
 
-    let timer: number | undefined;
-    let observer: MutationObserver | undefined;
+    sendLyrics = () => {
+      void send();
+    };
+
+    if (timer) {
+      window.clearInterval(timer);
+      timer = undefined;
+    }
+    observer?.disconnect();
+    observer = undefined;
+    resetLineState();
 
     observer = new MutationObserver(() => {
       void send();
@@ -185,13 +193,28 @@ export const renderer = createRenderer({
       void send();
     }, 250);
 
+    window.ipcRenderer.removeListener('peard:play-or-paused', onPlayOrPaused);
+    window.ipcRenderer.removeListener('peard:time-changed', onTimeChanged);
+
     window.ipcRenderer.on('peard:play-or-paused', onPlayOrPaused);
     window.ipcRenderer.on('peard:time-changed', onTimeChanged);
 
-    (this as { stop?: () => void }).stop = stop;
   },
-  // Delegate to the stop handler registered during startup.
   stop() {
-    (this as { stop?: () => void }).stop?.();
+    if (timer) {
+      window.clearInterval(timer);
+      timer = undefined;
+    }
+
+    observer?.disconnect();
+    observer = undefined;
+
+    window.ipcRenderer.removeListener('peard:play-or-paused', onPlayOrPaused);
+    window.ipcRenderer.removeListener('peard:time-changed', onTimeChanged);
+
+    sendLyrics = undefined;
+    resetLineState();
+
+    void window.ipcRenderer.invoke('statusbar-lyrics:clear');
   },
 });

--- a/src/plugins/statusbar-lyrics/renderer.ts
+++ b/src/plugins/statusbar-lyrics/renderer.ts
@@ -11,8 +11,15 @@ let sendLyrics: (() => void) | undefined;
 let sendInFlight = false;
 let sendRequested = false;
 let lastPayload: string | undefined;
+let isPlaying = false;
+let resetLineBaseline = true;
 
-const onPlayOrPaused = () => {
+const onPlayOrPaused = (
+  _event: unknown,
+  payload: { isPaused: boolean; elapsedSeconds: number },
+) => {
+  isPlaying = !payload.isPaused;
+  resetLineBaseline = true;
   void sendLyrics?.();
 };
 
@@ -24,6 +31,11 @@ const resetLineState = () => {
   activeLineText = '';
   activeLineStartedAt = 0;
   activeLineElement = null;
+};
+
+const resetPlaybackState = () => {
+  isPlaying = false;
+  resetLineBaseline = true;
 };
 
 const resetSendState = () => {
@@ -87,6 +99,16 @@ const getPrimaryTextElement = (lineElement: HTMLElement | null) => {
   return visibleCandidate ?? candidates[0] ?? null;
 };
 
+const getNextLyricRow = (lineElement: HTMLElement | null) => {
+  let nextElement = lineElement?.nextElementSibling as HTMLElement | null;
+
+  while (nextElement && !nextElement.querySelector('.text-lyrics')) {
+    nextElement = nextElement.nextElementSibling as HTMLElement | null;
+  }
+
+  return nextElement;
+};
+
 // Read the CSS duration that synced lyrics expose so the plugin can predict
 // when the current line is about to switch.
 const parseDurationMs = (element: HTMLElement) => {
@@ -134,10 +156,21 @@ const pollLyrics = (includePronunciation: boolean) => {
   const currentText = getLineText(currentLine, includePronunciation);
   const now = performance.now();
 
+  if (resetLineBaseline) {
+    activeLineElement = currentLine;
+    activeLineText = currentText;
+    activeLineStartedAt = now;
+    resetLineBaseline = false;
+  }
+
   if (activeLineElement !== currentLine || currentText !== activeLineText) {
     activeLineElement = currentLine;
     activeLineText = currentText;
     activeLineStartedAt = now;
+  }
+
+  if (!isPlaying) {
+    return currentText;
   }
 
   const durationMs = parseDurationMs(currentTextElement) ?? 0;
@@ -145,10 +178,7 @@ const pollLyrics = (includePronunciation: boolean) => {
   const switchAtMs = Math.max(0, durationMs - leadMs);
 
   if (now - activeLineStartedAt >= switchAtMs) {
-    const nextLineText = getLineText(
-      currentLine?.nextElementSibling as HTMLElement | null,
-      includePronunciation,
-    );
+    const nextLineText = getLineText(getNextLyricRow(currentLine), includePronunciation);
     if (nextLineText) return nextLineText;
   }
 
@@ -208,6 +238,7 @@ export const renderer = createRenderer({
     observer?.disconnect();
     observer = undefined;
     resetLineState();
+    resetPlaybackState();
 
     observer = new MutationObserver(() => {
       sendLyrics?.();
@@ -249,6 +280,7 @@ export const renderer = createRenderer({
 
     sendLyrics = undefined;
     resetLineState();
+    resetPlaybackState();
     resetSendState();
 
     void window.ipcRenderer.invoke('statusbar-lyrics:clear');


### PR DESCRIPTION
This PR adds the Status Bar Lyrics plugin, which shows the current synced lyric line in the macOS menu bar title.

It includes:
- config support for enabling the plugin
- renderer logic to detect and poll synced lyric lines
- backend IPC handling to update and clear the tray title
- menu option to include pronunciation text when the lyrics is in Chinese.

How to use / Prerequisites:
1. Ensure the built-in **Synced Lyrics** plugin is enabled.
2. Make sure the plugin can access and poll the lyrics DOM to capture the text (e.g., by switching to **Song** mode instead of Video, and navigating to the **Lyrics** tab).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a macOS Status Bar Lyrics plugin that displays synchronized lyrics in the menu bar.
  * Supports configurable lyric length limits and optional pronunciation.
  * Added a menu option to toggle pronunciation display.
  * Automatically updates, truncates, and clears lyrics as playback changes.
  * Excludes translations and alternate lyric formats unless pronunciation is enabled.
  * Lyrics are cleared when playback is unavailable or the plugin is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->