### PR TITLE
feat(do-not-track): Add Bypass Age Restriction under do-not-track plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "pinyin-pro": "3.28.1",
     "semver": "7.8.5",
     "serve": "14.2.6",
+    "simple-youtube-age-restriction-bypass": "github:zerodytrash/Simple-YouTube-Age-Restriction-Bypass",
     "socks": "2.8.9",
     "solid-element": "1.9.1",
     "solid-floating-ui": "0.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,6 +201,9 @@ importers:
       serve:
         specifier: 14.2.6
         version: 14.2.6
+      simple-youtube-age-restriction-bypass:
+        specifier: github:zerodytrash/Simple-YouTube-Age-Restriction-Bypass
+        version: https://codeload.github.com/zerodytrash/Simple-YouTube-Age-Restriction-Bypass/tar.gz/ec15480219fea8ad76ec2a8d2dfe0f458c9d3944
       socks:
         specifier: 2.8.9
         version: 2.8.9
@@ -3621,6 +3624,11 @@ packages:
   simple-update-notifier@2.0.0:
     resolution: {integrity: sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==}
     engines: {node: '>=10'}
+
+  simple-youtube-age-restriction-bypass@https://codeload.github.com/zerodytrash/Simple-YouTube-Age-Restriction-Bypass/tar.gz/ec15480219fea8ad76ec2a8d2dfe0f458c9d3944:
+    resolution: {gitHosted: true, integrity: sha512-NmZ/CWFyzA53oI9dkVd85QhMS/+OLpz0bEGERIplI5QymLoeBYBok9xEUFmsfyxxBVuTnjVCzZU5qIRNkV09Cg==, tarball: https://codeload.github.com/zerodytrash/Simple-YouTube-Age-Restriction-Bypass/tar.gz/ec15480219fea8ad76ec2a8d2dfe0f458c9d3944}
+    version: 2.5.11
+    engines: {node: '>=18.0.0', npm: '>=7.0.0'}
 
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
@@ -7336,6 +7344,8 @@ snapshots:
   simple-update-notifier@2.0.0:
     dependencies:
       semver: 7.8.5
+
+  simple-youtube-age-restriction-bypass@https://codeload.github.com/zerodytrash/Simple-YouTube-Age-Restriction-Bypass/tar.gz/ec15480219fea8ad76ec2a8d2dfe0f458c9d3944: {}
 
   sirv@3.0.2:
     dependencies:

--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -500,7 +500,8 @@
     "do-not-track": {
       "description": "Block all tracking out of the box",
       "menu": {
-        "blocker": "Blocker"
+        "blocker": "Blocker",
+        "bypass-age-restriction": "Bypass Age Restriction"
       },
       "name": "Do Not Track"
     },

--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -501,7 +501,7 @@
       "description": "Block all tracking out of the box",
       "menu": {
         "blocker": "Blocker",
-        "bypass-age-restriction": "Bypass Age Restriction"
+        "bypass-age-restriction": "Bypass Age Restriction (manual restart required)"
       },
       "name": "Do Not Track"
     },

--- a/src/plugins/do-not-track/index.ts
+++ b/src/plugins/do-not-track/index.ts
@@ -39,6 +39,11 @@ export interface TrackerBlockerConfig {
    * @default false
    */
   disableDefaultLists: boolean;
+  /**
+   * Whether to enable the Bypass Age Restriction.
+   * @default false
+   */
+  bypassAgeRestriction: boolean;
 }
 
 export default createPlugin({
@@ -51,6 +56,7 @@ export default createPlugin({
     blocker: blockers.InPlayer,
     additionalBlockLists: [],
     disableDefaultLists: false,
+    bypassAgeRestriction: false,
   } as TrackerBlockerConfig,
   menu: async ({ getConfig, setConfig }) => {
     const config = await getConfig();
@@ -67,6 +73,16 @@ export default createPlugin({
           },
         })),
       },
+      {
+        label: t('plugins.bypassAgeRestriction.name'),
+        type: "checkbox",
+        checked: config.bypassAgeRestriction,
+        click() {
+          setConfig({
+            bypassAgeRestriction: !config.bypassAgeRestriction
+          })
+        }
+      }
     ];
   },
   backend: {
@@ -136,4 +152,13 @@ export default createPlugin({
       }
     },
   },
+  renderer: {
+    async start({ getConfig }) {
+      const config = await getConfig();
+      if (config.bypassAgeRestriction) {
+        const { inject } = await import('simple-youtube-age-restriction-bypass');
+        inject();
+      }
+    }
+  }
 });

--- a/src/plugins/do-not-track/index.ts
+++ b/src/plugins/do-not-track/index.ts
@@ -77,15 +77,14 @@ export default createPlugin({
       },
       {
         label: t('plugins.do-not-track.menu.bypass-age-restriction'),
-        sublabel: t('required manual restart'),
-        type: "checkbox",
+        type: 'checkbox',
         checked: config.bypassAgeRestriction,
         click() {
           setConfig({
-            bypassAgeRestriction: !config.bypassAgeRestriction
-          })
-        }
-      }
+            bypassAgeRestriction: !config.bypassAgeRestriction,
+          });
+        },
+      },
     ];
   },
   backend: {

--- a/src/plugins/do-not-track/index.ts
+++ b/src/plugins/do-not-track/index.ts
@@ -1,5 +1,7 @@
 import { contextBridge, webFrame, type BrowserWindow } from 'electron';
 
+import bypassScript from 'simple-youtube-age-restriction-bypass/dist/Simple-YouTube-Age-Restriction-Bypass.user.js?raw';
+
 import { t } from '@/i18n';
 import { createPlugin } from '@/utils';
 
@@ -74,7 +76,8 @@ export default createPlugin({
         })),
       },
       {
-        label: t('plugins.bypassAgeRestriction.name'),
+        label: t('plugins.do-not-track.menu.bypass-age-restriction'),
+        sublabel: t('required manual restart'),
         type: "checkbox",
         checked: config.bypassAgeRestriction,
         click() {
@@ -144,6 +147,16 @@ export default createPlugin({
       } else if (config.blocker === blockers.WithBlocklists) {
         await injectCliqzPreload();
       }
+
+      if (config.bypassAgeRestriction) {
+        // Simple workaround to prevent userscript from creating 'default' TrustedType policy,
+        // causing TypeError "Policy with name 'default' already exist" at src/utils/trusted-types.ts.
+        const sanitizedScript = bypassScript.replace(
+          "trustedTypes.createPolicy('default'",
+          "trustedTypes.createPolicy('syarb-default'",
+        );
+        await webFrame.executeJavaScript(sanitizedScript);
+      }
     },
     async onConfigChange(newConfig) {
       if (newConfig.blocker === blockers.InPlayer && !isInjected()) {
@@ -152,13 +165,5 @@ export default createPlugin({
       }
     },
   },
-  renderer: {
-    async start({ getConfig }) {
-      const config = await getConfig();
-      if (config.bypassAgeRestriction) {
-        const { inject } = await import('simple-youtube-age-restriction-bypass');
-        inject();
-      }
-    }
-  }
 });
+

--- a/src/plugins/do-not-track/types/simple-youtube-age-restriction-bypass.d.ts
+++ b/src/plugins/do-not-track/types/simple-youtube-age-restriction-bypass.d.ts
@@ -1,0 +1,3 @@
+declare module 'simple-youtube-age-restriction-bypass' {
+  export const inject: () => void;
+}

--- a/src/plugins/do-not-track/types/simple-youtube-age-restriction-bypass.d.ts
+++ b/src/plugins/do-not-track/types/simple-youtube-age-restriction-bypass.d.ts
@@ -1,3 +1,4 @@
-declare module 'simple-youtube-age-restriction-bypass' {
-  export const inject: () => void;
+declare module 'simple-youtube-age-restriction-bypass/dist/Simple-YouTube-Age-Restriction-Bypass.user.js?raw' {
+  const script: string;
+  export default script;
 }


### PR DESCRIPTION
Close #4623


Adding back Bypass Age Restriction under "Do Not Track" plugins. It's quite self-explanatory. I assumed that the bypass age restriction should be inside the Do Not Track plugins because the adblock is inside that plugin. 

I put a sub-label for the Bypass Age Restriction menu because it needs app restart to apply. And because adblock doesn't need restart, I  have two options:
1. Set the entire Do Not Track `restartNeeded` to true, even though the adblock toggle doesn't need it
2. Set the sub label to inform users to manually restart

I need a feedback for this whether I put sub-label or change the `restartNeeded` to true




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional setting to bypass YouTube age restrictions.
  * Added a Do Not Track menu checkbox for enabling the bypass.
  * The feature is disabled by default and requires an app restart after changing the setting.
  * Added English localization for the new setting.
  * When enabled, the bypass is applied automatically during startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->