### PR TITLE
feat(plugins): add mini player

### DIFF
--- a/assets/mini-player/index.html
+++ b/assets/mini-player/index.html
@@ -194,12 +194,20 @@
         height: 26px;
       }
 
+      #shuffle,
+      #repeat {
+        width: 24px !important;
+        height: 24px !important;
+      }
+
       #play {
         width: 30px !important;
         height: 30px !important;
       }
 
-      #like.liked {
+      #like.liked,
+      #shuffle.active,
+      #repeat.active {
         color: var(--accent);
         opacity: 1;
       }
@@ -289,6 +297,29 @@
       </div>
 
       <div id="controls">
+        <button id="like" data-action="like" title="Like">
+          <svg width="17" height="17" viewBox="0 0 24 24">
+            <path
+              id="like-path"
+              d="M12 20.4 3.9 12.6a5 5 0 0 1 7.1-7l1 1 1-1a5 5 0 0 1 7.1 7L12 20.4Zm0-2.8 6.7-6.4a3 3 0 1 0-4.3-4.2L12 9.4 9.6 7A3 3 0 1 0 5.3 11.2L12 17.6Z"
+            />
+          </svg>
+        </button>
+        <button id="volume" data-action="mute" title="Mute">
+          <svg width="17" height="17" viewBox="0 0 24 24">
+            <path
+              id="volume-path"
+              d="M4 9h3l4-4v14l-4-4H4V9Zm11.5 3a3.5 3.5 0 0 0-2-3.2v6.4a3.5 3.5 0 0 0 2-3.2Zm0-7.3v2.1a5.5 5.5 0 0 1 0 10.4v2.1a7.5 7.5 0 0 0 0-14.6Z"
+            />
+          </svg>
+        </button>
+        <button id="shuffle" data-action="shuffle" title="Shuffle">
+          <svg width="16" height="16" viewBox="0 0 24 24">
+            <path
+              d="M10.59 9.17 5.41 4 4 5.41l5.17 5.17 1.42-1.41zM14.5 4l2.04 2.04L4 18.59 5.41 20 17.96 7.46 20 9.5V4h-5.5zm.33 9.41-1.41 1.41 3.13 3.13L14.5 20H20v-5.5l-2.04 2.04-3.13-3.13z"
+            />
+          </svg>
+        </button>
         <button data-action="previous" title="Previous">
           <svg width="18" height="18" viewBox="0 0 24 24">
             <path d="M6 6h2v12H6V6Zm3.5 6L18 6v12L9.5 12Z" />
@@ -304,19 +335,11 @@
             <path d="M16 6h2v12h-2V6Zm-1.5 6L6 18V6l8.5 6Z" />
           </svg>
         </button>
-        <button id="like" data-action="like" title="Like">
-          <svg width="17" height="17" viewBox="0 0 24 24">
+        <button id="repeat" data-action="repeat" title="Repeat">
+          <svg width="16" height="16" viewBox="0 0 24 24">
             <path
-              id="like-path"
-              d="M12 20.4 3.9 12.6a5 5 0 0 1 7.1-7l1 1 1-1a5 5 0 0 1 7.1 7L12 20.4Zm0-2.8 6.7-6.4a3 3 0 1 0-4.3-4.2L12 9.4 9.6 7A3 3 0 1 0 5.3 11.2L12 17.6Z"
-            />
-          </svg>
-        </button>
-        <button id="volume" data-action="mute" title="Mute">
-          <svg width="17" height="17" viewBox="0 0 24 24">
-            <path
-              id="volume-path"
-              d="M4 9h3l4-4v14l-4-4H4V9Zm11.5 3a3.5 3.5 0 0 0-2-3.2v6.4a3.5 3.5 0 0 0 2-3.2Zm0-7.3v2.1a5.5 5.5 0 0 1 0 10.4v2.1a7.5 7.5 0 0 0 0-14.6Z"
+              id="repeat-path"
+              d="M7 7h10v3l4-4-4-4v3H5v6h2V7zm10 10H7v-3l-4 4 4 4v-3h12v-6h-2v4z"
             />
           </svg>
         </button>
@@ -349,6 +372,9 @@
         likePath: document.getElementById('like-path'),
         volume: document.getElementById('volume'),
         volumePath: document.getElementById('volume-path'),
+        shuffle: document.getElementById('shuffle'),
+        repeat: document.getElementById('repeat'),
+        repeatPath: document.getElementById('repeat-path'),
         track: document.getElementById('track'),
         fill: document.getElementById('fill'),
       };
@@ -363,6 +389,10 @@
         'M4 9h3l4-4v14l-4-4H4V9Zm16.3 1.1-1.4-1.4L17 10.6 15.1 8.7l-1.4 1.4 1.9 1.9-1.9 1.9 1.4 1.4 1.9-1.9 1.9 1.9 1.4-1.4-1.9-1.9 1.9-1.9Z';
       const PLAY = 'M8 5v14l11-7L8 5Z';
       const PAUSE = 'M6 5h4v14H6V5Zm8 0h4v14h-4V5Z';
+      const REPEAT =
+        'M7 7h10v3l4-4-4-4v3H5v6h2V7zm10 10H7v-3l-4 4 4 4v-3h12v-6h-2v4z';
+      const REPEAT_ONE =
+        'M7 7h10v3l4-4-4-4v3H5v6h2V7zm10 10H7v-3l-4 4 4 4v-3h12v-6h-2v4zm-4-2V9h-1l-2 1v1h1.5v4H13z';
 
       let state = {
         title: '',
@@ -374,6 +404,8 @@
         likeStatus: 'INDIFFERENT',
         volume: 100,
         isMuted: false,
+        isShuffled: false,
+        repeatMode: 'NONE',
       };
 
       /** Locally interpolated position, resynced on every state push. */
@@ -436,6 +468,17 @@
           'd',
           state.isMuted ? SPEAKER_OFF : SPEAKER_ON,
         );
+
+        el.shuffle.classList.toggle('active', state.isShuffled);
+
+        const repeatsOne = state.repeatMode === 'ONE';
+        el.repeat.classList.toggle('active', state.repeatMode !== 'NONE');
+        el.repeatPath.setAttribute('d', repeatsOne ? REPEAT_ONE : REPEAT);
+        el.repeat.title = repeatsOne
+          ? 'Repeat one'
+          : state.repeatMode === 'ALL'
+            ? 'Repeat all'
+            : 'Repeat';
 
         renderTrack();
       };

--- a/assets/mini-player/index.html
+++ b/assets/mini-player/index.html
@@ -453,8 +453,14 @@
           updateMarquee(el.artistWrap, el.artist);
         }
 
-        if (state.imageSrc && el.art.src !== state.imageSrc) {
-          el.art.src = state.imageSrc;
+        // Also runs for an empty src, so artwork from the previous song goes
+        // away when the new one has none.
+        if (el.art.getAttribute('src') !== state.imageSrc) {
+          if (state.imageSrc) {
+            el.art.src = state.imageSrc;
+          } else {
+            el.art.removeAttribute('src');
+          }
         }
 
         el.play.setAttribute('d', state.isPaused ? PLAY : PAUSE);
@@ -588,34 +594,54 @@
         }
       });
 
-      el.track.addEventListener('pointerup', (event) => {
+      const endDrag = (event, commit) => {
         if (!dragging) {
           return;
         }
 
-        if (dragging === 'seek') {
+        if (commit && dragging === 'seek') {
           api.control('seek', Math.round(elapsed));
         }
 
         dragging = null;
         el.track.classList.remove('dragging', 'volume');
-        el.track.releasePointerCapture(event.pointerId);
+
+        if (el.track.hasPointerCapture(event.pointerId)) {
+          el.track.releasePointerCapture(event.pointerId);
+        }
+
         lastTick = Date.now();
         renderTrack();
-      });
+      };
+
+      el.track.addEventListener('pointerup', (event) => endDrag(event, true));
+
+      // Without this a cancelled pointer stream would leave `dragging` set,
+      // freezing the progress bar until the next drag.
+      el.track.addEventListener('pointercancel', (event) =>
+        endDrag(event, false),
+      );
 
       // Scroll anywhere on the bar to change the volume.
+      let volumeModeTimer = null;
+      let volumeSendTimer = null;
+
       el.bar.addEventListener('wheel', (event) => {
         const step = event.deltaY > 0 ? -5 : 5;
         state.volume = clamp(state.volume + step, 0, 100);
         state.isMuted = false;
-        api.control('volume', state.volume);
 
         el.track.classList.add('volume');
         renderTrack();
 
-        clearTimeout(el.bar.dataset.volumeTimer);
-        el.bar.dataset.volumeTimer = setTimeout(() => {
+        // One gesture fires many wheel events; only the last value matters.
+        clearTimeout(volumeSendTimer);
+        volumeSendTimer = setTimeout(() => {
+          api.control('volume', state.volume);
+        }, 60);
+
+        clearTimeout(volumeModeTimer);
+        volumeModeTimer = setTimeout(() => {
           if (!dragging) {
             el.track.classList.remove('volume');
             renderTrack();

--- a/assets/mini-player/index.html
+++ b/assets/mini-player/index.html
@@ -1,0 +1,592 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Mini Player</title>
+    <style>
+      :root {
+        --bg: rgba(17, 17, 19, 0.86);
+        --fg: #f5f5f7;
+        --muted: rgba(245, 245, 247, 0.62);
+        --accent: #ff2d55;
+        --line: rgba(255, 255, 255, 0.16);
+      }
+
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+        user-select: none;
+        -webkit-user-drag: none;
+      }
+
+      html,
+      body {
+        width: 100%;
+        height: 100%;
+        overflow: hidden;
+        background: transparent;
+        font-family:
+          -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Ubuntu,
+          sans-serif;
+        color: var(--fg);
+        cursor: default;
+      }
+
+      #bar {
+        position: relative;
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        width: 100%;
+        height: 100%;
+        padding: 10px 12px 12px;
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        border-radius: 14px;
+        background: var(--bg);
+        backdrop-filter: blur(24px) saturate(160%);
+        overflow: hidden;
+        -webkit-app-region: drag;
+      }
+
+      button {
+        -webkit-app-region: no-drag;
+        display: grid;
+        place-items: center;
+        border: none;
+        background: none;
+        color: var(--fg);
+        cursor: pointer;
+        opacity: 0.82;
+        transition: opacity 0.15s ease, transform 0.15s ease;
+      }
+
+      button:hover {
+        opacity: 1;
+        transform: scale(1.12);
+      }
+
+      button:active {
+        transform: scale(0.94);
+      }
+
+      button svg {
+        display: block;
+        fill: currentcolor;
+        pointer-events: none;
+      }
+
+      /* --- album art ------------------------------------------------ */
+
+      #art {
+        position: relative;
+        flex: 0 0 auto;
+        width: 64px;
+        height: 64px;
+        border-radius: 9px;
+        overflow: hidden;
+        background: rgba(255, 255, 255, 0.07);
+      }
+
+      #art-img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        display: block;
+      }
+
+      #restore {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+        border-radius: 9px;
+        background: rgba(0, 0, 0, 0.55);
+        opacity: 0;
+        transform: none;
+      }
+
+      #art:hover #restore {
+        opacity: 1;
+      }
+
+      #restore:active {
+        transform: none;
+      }
+
+      /* --- track info ----------------------------------------------- */
+
+      #info {
+        flex: 1 1 auto;
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 3px;
+      }
+
+      .marquee {
+        position: relative;
+        width: 100%;
+        overflow: hidden;
+        white-space: nowrap;
+        mask-image: linear-gradient(
+          90deg,
+          #000 0,
+          #000 calc(100% - 16px),
+          transparent 100%
+        );
+      }
+
+      .marquee > span {
+        display: inline-block;
+        will-change: transform;
+      }
+
+      .marquee.overflowing > span {
+        animation: slide 12s linear infinite alternate;
+      }
+
+      @keyframes slide {
+        0%,
+        14% {
+          transform: translateX(0);
+        }
+        86%,
+        100% {
+          transform: translateX(calc(-1 * var(--dist, 0px)));
+        }
+      }
+
+      #title {
+        font-size: 13px;
+        font-weight: 600;
+        letter-spacing: 0.1px;
+      }
+
+      #artist {
+        font-size: 11.5px;
+        color: var(--muted);
+      }
+
+      #time {
+        font-size: 10px;
+        font-variant-numeric: tabular-nums;
+        color: var(--muted);
+        opacity: 0;
+        transition: opacity 0.15s ease;
+      }
+
+      #bar:hover #time {
+        opacity: 1;
+      }
+
+      /* --- controls -------------------------------------------------- */
+
+      #controls {
+        flex: 0 0 auto;
+        display: flex;
+        align-items: center;
+        gap: 1px;
+      }
+
+      #controls button {
+        width: 26px;
+        height: 26px;
+      }
+
+      #play {
+        width: 30px !important;
+        height: 30px !important;
+      }
+
+      #like.liked {
+        color: var(--accent);
+        opacity: 1;
+      }
+
+      #volume.muted {
+        opacity: 0.45;
+      }
+
+      /* --- close ----------------------------------------------------- */
+
+      #close {
+        position: absolute;
+        top: 3px;
+        right: 4px;
+        width: 16px;
+        height: 16px;
+        border-radius: 50%;
+        opacity: 0;
+        color: var(--muted);
+      }
+
+      #bar:hover #close {
+        opacity: 0.7;
+      }
+
+      #close:hover {
+        opacity: 1 !important;
+        color: var(--fg);
+      }
+
+      /* --- bottom slider (seek / volume) ----------------------------- */
+
+      #track {
+        -webkit-app-region: no-drag;
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        height: 10px;
+        display: flex;
+        align-items: flex-end;
+        cursor: pointer;
+      }
+
+      #rail {
+        position: relative;
+        width: 100%;
+        height: 3px;
+        background: var(--line);
+        transition: height 0.12s ease;
+      }
+
+      #track:hover #rail,
+      #track.dragging #rail {
+        height: 6px;
+      }
+
+      #fill {
+        position: absolute;
+        inset: 0 auto 0 0;
+        width: 0;
+        background: var(--fg);
+      }
+
+      #track.volume #fill {
+        background: var(--accent);
+      }
+    </style>
+  </head>
+  <body>
+    <div id="bar">
+      <div id="art">
+        <img id="art-img" alt="" />
+        <button id="restore" title="Open main window">
+          <svg width="18" height="18" viewBox="0 0 24 24">
+            <path
+              d="M4 14h2v2.6l4-4L11.4 14l-4 4H10v2H4v-6Zm16-4h-2V7.4l-4 4L12.6 10l4-4H14V4h6v6Z"
+            />
+          </svg>
+        </button>
+      </div>
+
+      <div id="info">
+        <div class="marquee" id="title-wrap"><span id="title"></span></div>
+        <div class="marquee" id="artist-wrap"><span id="artist"></span></div>
+        <div id="time">0:00 / 0:00</div>
+      </div>
+
+      <div id="controls">
+        <button data-action="previous" title="Previous">
+          <svg width="18" height="18" viewBox="0 0 24 24">
+            <path d="M6 6h2v12H6V6Zm3.5 6L18 6v12L9.5 12Z" />
+          </svg>
+        </button>
+        <button id="play" data-action="playPause" title="Play/Pause">
+          <svg width="22" height="22" viewBox="0 0 24 24">
+            <path id="play-path" d="M8 5v14l11-7L8 5Z" />
+          </svg>
+        </button>
+        <button data-action="next" title="Next">
+          <svg width="18" height="18" viewBox="0 0 24 24">
+            <path d="M16 6h2v12h-2V6Zm-1.5 6L6 18V6l8.5 6Z" />
+          </svg>
+        </button>
+        <button id="like" data-action="like" title="Like">
+          <svg width="17" height="17" viewBox="0 0 24 24">
+            <path
+              id="like-path"
+              d="M12 20.4 3.9 12.6a5 5 0 0 1 7.1-7l1 1 1-1a5 5 0 0 1 7.1 7L12 20.4Zm0-2.8 6.7-6.4a3 3 0 1 0-4.3-4.2L12 9.4 9.6 7A3 3 0 1 0 5.3 11.2L12 17.6Z"
+            />
+          </svg>
+        </button>
+        <button id="volume" data-action="mute" title="Mute">
+          <svg width="17" height="17" viewBox="0 0 24 24">
+            <path
+              id="volume-path"
+              d="M4 9h3l4-4v14l-4-4H4V9Zm11.5 3a3.5 3.5 0 0 0-2-3.2v6.4a3.5 3.5 0 0 0 2-3.2Zm0-7.3v2.1a5.5 5.5 0 0 1 0 10.4v2.1a7.5 7.5 0 0 0 0-14.6Z"
+            />
+          </svg>
+        </button>
+      </div>
+
+      <button id="close" title="Close mini player">
+        <svg width="11" height="11" viewBox="0 0 24 24">
+          <path
+            d="M18.3 5.7 12 12l6.3 6.3-1.4 1.4L10.6 13.4 4.3 19.7 2.9 18.3 9.2 12 2.9 5.7l1.4-1.4L10.6 10.6l6.3-6.3 1.4 1.4Z"
+          />
+        </svg>
+      </button>
+
+      <div id="track"><div id="rail"><div id="fill"></div></div></div>
+    </div>
+
+    <script>
+      const api = window.miniPlayer;
+
+      const el = {
+        bar: document.getElementById('bar'),
+        art: document.getElementById('art-img'),
+        title: document.getElementById('title'),
+        titleWrap: document.getElementById('title-wrap'),
+        artist: document.getElementById('artist'),
+        artistWrap: document.getElementById('artist-wrap'),
+        time: document.getElementById('time'),
+        play: document.getElementById('play-path'),
+        like: document.getElementById('like'),
+        likePath: document.getElementById('like-path'),
+        volume: document.getElementById('volume'),
+        volumePath: document.getElementById('volume-path'),
+        track: document.getElementById('track'),
+        fill: document.getElementById('fill'),
+      };
+
+      const HEART_OUTLINE =
+        'M12 20.4 3.9 12.6a5 5 0 0 1 7.1-7l1 1 1-1a5 5 0 0 1 7.1 7L12 20.4Zm0-2.8 6.7-6.4a3 3 0 1 0-4.3-4.2L12 9.4 9.6 7A3 3 0 1 0 5.3 11.2L12 17.6Z';
+      const HEART_FILLED =
+        'M12 20.4 3.9 12.6a5 5 0 0 1 7.1-7l1 1 1-1a5 5 0 0 1 7.1 7L12 20.4Z';
+      const SPEAKER_ON =
+        'M4 9h3l4-4v14l-4-4H4V9Zm11.5 3a3.5 3.5 0 0 0-2-3.2v6.4a3.5 3.5 0 0 0 2-3.2Zm0-7.3v2.1a5.5 5.5 0 0 1 0 10.4v2.1a7.5 7.5 0 0 0 0-14.6Z';
+      const SPEAKER_OFF =
+        'M4 9h3l4-4v14l-4-4H4V9Zm16.3 1.1-1.4-1.4L17 10.6 15.1 8.7l-1.4 1.4 1.9 1.9-1.9 1.9 1.4 1.4 1.9-1.9 1.9 1.9 1.4-1.4-1.9-1.9 1.9-1.9Z';
+      const PLAY = 'M8 5v14l11-7L8 5Z';
+      const PAUSE = 'M6 5h4v14H6V5Zm8 0h4v14h-4V5Z';
+
+      let state = {
+        title: '',
+        artist: '',
+        imageSrc: '',
+        isPaused: true,
+        songDuration: 0,
+        elapsedSeconds: 0,
+        likeStatus: 'INDIFFERENT',
+        volume: 100,
+        isMuted: false,
+      };
+
+      /** Locally interpolated position, resynced on every state push. */
+      let elapsed = 0;
+      let lastTick = 0;
+      let dragging = null; // 'seek' | 'volume' | null
+
+      const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
+
+      const formatTime = (seconds) => {
+        const total = Math.max(0, Math.floor(seconds || 0));
+        const mins = Math.floor(total / 60);
+        return `${mins}:${String(total % 60).padStart(2, '0')}`;
+      };
+
+      const updateMarquee = (wrap, span) => {
+        const distance = span.scrollWidth - wrap.clientWidth;
+        wrap.classList.toggle('overflowing', distance > 2);
+        wrap.style.setProperty('--dist', `${Math.max(0, distance)}px`);
+      };
+
+      const isVolumeMode = () => el.track.classList.contains('volume');
+
+      const renderTrack = () => {
+        if (dragging === 'volume' || (isVolumeMode() && !dragging)) {
+          el.fill.style.width = `${state.isMuted ? 0 : state.volume}%`;
+          return;
+        }
+
+        const ratio = state.songDuration
+          ? clamp(elapsed / state.songDuration, 0, 1)
+          : 0;
+        el.fill.style.width = `${ratio * 100}%`;
+        el.time.textContent = `${formatTime(elapsed)} / ${formatTime(state.songDuration)}`;
+      };
+
+      const render = () => {
+        if (el.title.textContent !== state.title) {
+          el.title.textContent = state.title;
+          updateMarquee(el.titleWrap, el.title);
+        }
+
+        if (el.artist.textContent !== state.artist) {
+          el.artist.textContent = state.artist;
+          updateMarquee(el.artistWrap, el.artist);
+        }
+
+        if (state.imageSrc && el.art.src !== state.imageSrc) {
+          el.art.src = state.imageSrc;
+        }
+
+        el.play.setAttribute('d', state.isPaused ? PLAY : PAUSE);
+
+        const liked = state.likeStatus === 'LIKE';
+        el.like.classList.toggle('liked', liked);
+        el.likePath.setAttribute('d', liked ? HEART_FILLED : HEART_OUTLINE);
+
+        el.volume.classList.toggle('muted', state.isMuted);
+        el.volumePath.setAttribute(
+          'd',
+          state.isMuted ? SPEAKER_OFF : SPEAKER_ON,
+        );
+
+        renderTrack();
+      };
+
+      // Tick the progress bar between backend updates so it moves smoothly.
+      setInterval(() => {
+        const now = Date.now();
+        const delta = (now - lastTick) / 1000;
+        lastTick = now;
+
+        if (!state.isPaused && !dragging && state.songDuration) {
+          elapsed = clamp(elapsed + delta, 0, state.songDuration);
+          renderTrack();
+        }
+      }, 500);
+
+      api.on('mini-player:state', (next) => {
+        const songChanged = next.title !== state.title;
+        state = { ...state, ...next };
+
+        if (
+          songChanged ||
+          Math.abs((next.elapsedSeconds ?? elapsed) - elapsed) > 1.5
+        ) {
+          elapsed = next.elapsedSeconds ?? 0;
+        }
+
+        lastTick = Date.now();
+        render();
+      });
+
+      // Only sent on platforms where BrowserWindow.setOpacity does nothing.
+      api.on('mini-player:config', ({ opacity }) => {
+        el.bar.style.opacity = String(opacity);
+      });
+
+      // --- interactions ------------------------------------------------
+
+      document.querySelectorAll('[data-action]').forEach((button) => {
+        button.addEventListener('click', () => {
+          api.control(button.dataset.action);
+        });
+      });
+
+      document
+        .getElementById('restore')
+        .addEventListener('click', () => api.control('restore'));
+      document
+        .getElementById('close')
+        .addEventListener('click', () => api.control('close'));
+
+      el.bar.addEventListener('dblclick', (event) => {
+        if (event.target.closest('button') || event.target.closest('#track')) {
+          return;
+        }
+
+        api.control('restore');
+      });
+
+      el.bar.addEventListener('mouseenter', () => api.hover(true));
+      el.bar.addEventListener('mouseleave', () => api.hover(false));
+
+      // Hovering the volume button turns the bottom line into a volume slider.
+      el.volume.addEventListener('mouseenter', () => {
+        if (!dragging) {
+          el.track.classList.add('volume');
+          renderTrack();
+        }
+      });
+
+      el.volume.addEventListener('mouseleave', () => {
+        if (dragging !== 'volume') {
+          el.track.classList.remove('volume');
+          renderTrack();
+        }
+      });
+
+      const ratioFromEvent = (event) => {
+        const rect = el.track.getBoundingClientRect();
+        return clamp((event.clientX - rect.left) / rect.width, 0, 1);
+      };
+
+      const applyDrag = (event) => {
+        const ratio = ratioFromEvent(event);
+
+        if (dragging === 'volume') {
+          state.volume = Math.round(ratio * 100);
+          state.isMuted = false;
+          api.control('volume', state.volume);
+        } else {
+          elapsed = ratio * state.songDuration;
+        }
+
+        renderTrack();
+      };
+
+      el.track.addEventListener('pointerdown', (event) => {
+        dragging = isVolumeMode() ? 'volume' : 'seek';
+        el.track.classList.add('dragging');
+        el.track.setPointerCapture(event.pointerId);
+        applyDrag(event);
+      });
+
+      el.track.addEventListener('pointermove', (event) => {
+        if (dragging) {
+          applyDrag(event);
+        }
+      });
+
+      el.track.addEventListener('pointerup', (event) => {
+        if (!dragging) {
+          return;
+        }
+
+        if (dragging === 'seek') {
+          api.control('seek', Math.round(elapsed));
+        }
+
+        dragging = null;
+        el.track.classList.remove('dragging', 'volume');
+        el.track.releasePointerCapture(event.pointerId);
+        lastTick = Date.now();
+        renderTrack();
+      });
+
+      // Scroll anywhere on the bar to change the volume.
+      el.bar.addEventListener('wheel', (event) => {
+        const step = event.deltaY > 0 ? -5 : 5;
+        state.volume = clamp(state.volume + step, 0, 100);
+        state.isMuted = false;
+        api.control('volume', state.volume);
+
+        el.track.classList.add('volume');
+        renderTrack();
+
+        clearTimeout(el.bar.dataset.volumeTimer);
+        el.bar.dataset.volumeTimer = setTimeout(() => {
+          if (!dragging) {
+            el.track.classList.remove('volume');
+            renderTrack();
+          }
+        }, 1200);
+      });
+
+      window.addEventListener('resize', () => {
+        updateMarquee(el.titleWrap, el.title);
+        updateMarquee(el.artistWrap, el.artist);
+      });
+
+      render();
+      api.ready();
+    </script>
+  </body>
+</html>

--- a/assets/mini-player/preload.cjs
+++ b/assets/mini-player/preload.cjs
@@ -1,0 +1,20 @@
+// Preload for the mini player window.
+// Kept as a plain CommonJS asset so it can be loaded straight from `assets`
+// without being part of the main preload bundle.
+const { contextBridge, ipcRenderer } = require('electron');
+
+const INCOMING = ['mini-player:state', 'mini-player:config'];
+
+contextBridge.exposeInMainWorld('miniPlayer', {
+  on: (channel, listener) => {
+    if (!INCOMING.includes(channel)) {
+      return;
+    }
+
+    ipcRenderer.on(channel, (_event, ...args) => listener(...args));
+  },
+  ready: () => ipcRenderer.send('mini-player:ready'),
+  hover: (isHovered) => ipcRenderer.send('mini-player:hover', isHovered),
+  control: (action, value) =>
+    ipcRenderer.send('mini-player:control', action, value),
+});

--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -614,6 +614,35 @@
         "fetched-lyrics": "Fetched lyrics for Genius"
       }
     },
+    "mini-player": {
+      "description": "Adds a small always-on-top player with album art, track info and controls",
+      "menu": {
+        "always-on-top": "Always on top",
+        "close": "Close mini player",
+        "hide-main-window": "Hide main window while open",
+        "hotkey": {
+          "label": "Hotkey",
+          "prompt": {
+            "keybind-options": {
+              "hotkey": "Hotkey"
+            },
+            "label": "Choose a hotkey to toggle the mini player",
+            "title": "Mini Player Hotkey"
+          }
+        },
+        "opacity": {
+          "label": "Opacity",
+          "submenu": {
+            "percent": "{{opacity}}%"
+          }
+        },
+        "opaque-on-hover": "Fully opaque on hover",
+        "open": "Open mini player",
+        "open-on-start": "Open on startup",
+        "reset-position": "Reset position and size"
+      },
+      "name": "Mini Player"
+    },
     "music-together": {
       "description": "Share a playlist with others. When the host plays a song, everyone else will hear the same song",
       "dialog": {

--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -641,7 +641,10 @@
         "open-on-start": "Open on startup",
         "reset-position": "Reset position and size"
       },
-      "name": "Mini Player"
+      "name": "Mini Player",
+      "templates": {
+        "button": "Mini player"
+      }
     },
     "music-together": {
       "description": "Share a playlist with others. When the host plays a song, everyone else will hear the same song",

--- a/src/plugins/mini-player/index.ts
+++ b/src/plugins/mini-player/index.ts
@@ -29,7 +29,7 @@ export const defaultConfig: MiniPlayerPluginConfig = {
   openOnStart: false,
   hotkey: 'CmdOrCtrl+Shift+M',
   position: null,
-  size: [400, 100],
+  size: [480, 100],
 };
 
 export default createPlugin({

--- a/src/plugins/mini-player/index.ts
+++ b/src/plugins/mini-player/index.ts
@@ -1,0 +1,47 @@
+import { t } from '@/i18n';
+import { createPlugin } from '@/utils';
+
+import { onConfigChange, onMainLoad, onUnload } from './main';
+import { onMenu } from './menu';
+
+export type MiniPlayerPluginConfig = {
+  enabled: boolean;
+  /** Window opacity while the pointer is elsewhere (0.2 - 1). */
+  opacity: number;
+  /** Become fully opaque while the pointer is over the mini player. */
+  opaqueOnHover: boolean;
+  alwaysOnTop: boolean;
+  /** Hide the main window while the mini player is open. */
+  hideMainWindow: boolean;
+  /** Open the mini player as soon as the app starts. */
+  openOnStart: boolean;
+  hotkey: string;
+  position: [number, number] | null;
+  size: [number, number];
+};
+
+export const defaultConfig: MiniPlayerPluginConfig = {
+  enabled: false,
+  opacity: 0.95,
+  opaqueOnHover: true,
+  alwaysOnTop: true,
+  hideMainWindow: true,
+  openOnStart: false,
+  hotkey: 'CmdOrCtrl+Shift+M',
+  position: null,
+  size: [400, 100],
+};
+
+export default createPlugin({
+  name: () => t('plugins.mini-player.name'),
+  description: () => t('plugins.mini-player.description'),
+  restartNeeded: false,
+  config: defaultConfig,
+  menu: onMenu,
+
+  backend: {
+    start: onMainLoad,
+    stop: onUnload,
+    onConfigChange,
+  },
+});

--- a/src/plugins/mini-player/index.ts
+++ b/src/plugins/mini-player/index.ts
@@ -3,6 +3,7 @@ import { createPlugin } from '@/utils';
 
 import { onConfigChange, onMainLoad, onUnload } from './main';
 import { onMenu } from './menu';
+import { onPlayerApiReady, onRendererUnload } from './renderer';
 
 export type MiniPlayerPluginConfig = {
   enabled: boolean;
@@ -43,5 +44,9 @@ export default createPlugin({
     start: onMainLoad,
     stop: onUnload,
     onConfigChange,
+  },
+  renderer: {
+    onPlayerApiReady,
+    stop: onRendererUnload,
   },
 });

--- a/src/plugins/mini-player/main.ts
+++ b/src/plugins/mini-player/main.ts
@@ -40,6 +40,10 @@ let saveConfig: BackendContext<MiniPlayerPluginConfig>['setConfig'] | null =
   null;
 let saveBoundsTimer: NodeJS.Timeout | null = null;
 let callbackRegistered = false;
+/** Whether this plugin is the one that hid the main window. */
+let didHideMainWindow = false;
+/** Set once the main window starts closing, so nothing tries to show it again. */
+let isQuitting = false;
 
 /** Cached so the artwork is only re-encoded when the song actually changes. */
 let artworkVideoId = '';
@@ -240,7 +244,7 @@ const openMiniPlayer = () => {
 
   miniWindow.on('closed', () => {
     miniWindow = null;
-    restoreMainWindow(false);
+    unhideMainWindow();
   });
 
   registerHotkey(miniWindow);
@@ -249,16 +253,10 @@ const openMiniPlayer = () => {
     // Media keeps playing in the hidden window; make sure it is not throttled.
     mainWindow.webContents.setBackgroundThrottling(false);
     mainWindow.hide();
+    didHideMainWindow = true;
   }
 
-  // Ask the renderer to start reporting player state changes.
-  mainWindow?.webContents.send('peard:setup-volume-changed-listener');
-  mainWindow?.webContents.send('peard:setup-like-changed-listener');
-  mainWindow?.webContents.send('peard:setup-repeat-changed-listener');
-  mainWindow?.webContents.send('peard:setup-shuffle-changed-listener');
-
-  // The shuffle observer only fires on change, so ask for the current value.
-  mainWindow?.webContents.send('peard:get-shuffle');
+  requestPlayerState();
 };
 
 const closeMiniPlayer = () => {
@@ -267,17 +265,62 @@ const closeMiniPlayer = () => {
   }
 };
 
-const restoreMainWindow = (focus: boolean) => {
+/**
+ * Ask the renderer to start reporting player state. The listeners on the other
+ * end are singletons, so this is safe to call again after every page load.
+ */
+const requestPlayerState = () => {
   if (!mainWindow || mainWindow.isDestroyed()) {
+    return;
+  }
+
+  mainWindow.webContents.send('peard:setup-volume-changed-listener');
+  mainWindow.webContents.send('peard:setup-like-changed-listener');
+  mainWindow.webContents.send('peard:setup-repeat-changed-listener');
+  mainWindow.webContents.send('peard:setup-shuffle-changed-listener');
+
+  // The shuffle observer only fires on change, so ask for the current value.
+  mainWindow.webContents.send('peard:get-shuffle');
+};
+
+/**
+ * Plugins load before the main window navigates, so a mini player opened via
+ * `openOnStart` sends its setup messages into a page that does not exist yet.
+ * Ask again once the renderer is actually up.
+ */
+const onPlayerApiLoaded = () => {
+  if (isOpen()) {
+    requestPlayerState();
+  }
+};
+
+/** Undo the hide that opening the mini player performed — and only that. */
+const unhideMainWindow = () => {
+  if (!didHideMainWindow) {
+    return;
+  }
+
+  didHideMainWindow = false;
+
+  // Nothing to restore while the app itself is going away.
+  if (isQuitting || !mainWindow || mainWindow.isDestroyed()) {
     return;
   }
 
   mainWindow.webContents.setBackgroundThrottling(true);
   mainWindow.show();
+};
 
-  if (focus) {
-    mainWindow.focus();
+/** Explicit request to go back to the full app. */
+const showMainWindow = () => {
+  if (!mainWindow || mainWindow.isDestroyed()) {
+    return;
   }
+
+  didHideMainWindow = false;
+  mainWindow.webContents.setBackgroundThrottling(true);
+  mainWindow.show();
+  mainWindow.focus();
 };
 
 const toggleMiniPlayer = () => {
@@ -286,6 +329,12 @@ const toggleMiniPlayer = () => {
   } else {
     openMiniPlayer();
   }
+};
+
+/** The app is shutting down: take the mini player with it, restore nothing. */
+const onMainWindowClose = () => {
+  isQuitting = true;
+  closeMiniPlayer();
 };
 
 const registerHotkey = (window: BrowserWindow) => {
@@ -300,9 +349,22 @@ const registerHotkey = (window: BrowserWindow) => {
   }
 };
 
-const unregisterHotkey = (window: BrowserWindow | null) => {
-  if (window && !window.isDestroyed()) {
-    localShortcut.unregisterAll(window);
+/**
+ * Only remove our own accelerator: the main window is shared with other
+ * plugins (in-app-menu, shortcuts) that register their own local shortcuts.
+ */
+const unregisterHotkey = (
+  window: BrowserWindow | null,
+  accelerator: string,
+) => {
+  if (!accelerator || !window || window.isDestroyed()) {
+    return;
+  }
+
+  try {
+    localShortcut.unregister(window, accelerator);
+  } catch (error: unknown) {
+    console.error(LoggerPrefix, '[mini-player] failed to unregister', error);
   }
 };
 
@@ -365,7 +427,7 @@ const onControl = (
       break;
     }
     case 'restore': {
-      restoreMainWindow(true);
+      showMainWindow();
       if (config.hideMainWindow) {
         closeMiniPlayer();
       }
@@ -406,6 +468,7 @@ export const onMainLoad = async ({
   ipcMain.on('peard:shuffle-changed', onShuffleChanged);
   ipcMain.on('peard:get-shuffle-response', onShuffleChanged);
   ipcMain.on('peard:repeat-changed', onRepeatChanged);
+  ipcMain.on('peard:player-api-loaded', onPlayerApiLoaded);
   ipcMain.on('plugin:toggle-mini-player', toggleMiniPlayer);
 
   if (!callbackRegistered) {
@@ -416,7 +479,7 @@ export const onMainLoad = async ({
 
   registerHotkey(window);
 
-  window.on('close', closeMiniPlayer);
+  window.on('close', onMainWindowClose);
 
   if (config.openOnStart) {
     openMiniPlayer();
@@ -424,12 +487,12 @@ export const onMainLoad = async ({
 };
 
 export const onConfigChange = (newConfig: MiniPlayerPluginConfig) => {
-  const hotkeyChanged = config?.hotkey !== newConfig.hotkey;
+  const previousHotkey = config?.hotkey;
   config = newConfig;
 
-  if (hotkeyChanged) {
-    unregisterHotkey(mainWindow);
-    unregisterHotkey(miniWindow);
+  if (previousHotkey !== newConfig.hotkey) {
+    unregisterHotkey(mainWindow, previousHotkey);
+    unregisterHotkey(miniWindow, previousHotkey);
 
     if (mainWindow) registerHotkey(mainWindow);
     if (miniWindow) registerHotkey(miniWindow);
@@ -448,14 +511,21 @@ export const onUnload = () => {
   ipcMain.removeListener('peard:shuffle-changed', onShuffleChanged);
   ipcMain.removeListener('peard:get-shuffle-response', onShuffleChanged);
   ipcMain.removeListener('peard:repeat-changed', onRepeatChanged);
+  ipcMain.removeListener('peard:player-api-loaded', onPlayerApiLoaded);
   ipcMain.removeAllListeners('plugin:toggle-mini-player');
 
-  unregisterHotkey(mainWindow);
-  closeMiniPlayer();
-  restoreMainWindow(false);
+  if (saveBoundsTimer) {
+    clearTimeout(saveBoundsTimer);
+    saveBoundsTimer = null;
+  }
 
-  mainWindow?.removeListener('close', closeMiniPlayer);
+  unregisterHotkey(mainWindow, config?.hotkey);
+  closeMiniPlayer();
+  unhideMainWindow();
+
+  mainWindow?.removeListener('close', onMainWindowClose);
   mainWindow = null;
+  saveConfig = null;
 };
 
 export const openMiniPlayerWindow = openMiniPlayer;

--- a/src/plugins/mini-player/main.ts
+++ b/src/plugins/mini-player/main.ts
@@ -1,0 +1,424 @@
+import MiniPlayerHtml from '@assets/mini-player/index.html?asset';
+import MiniPlayerPreload from '@assets/mini-player/preload.cjs?asset';
+import { BrowserWindow, ipcMain, screen } from 'electron';
+import is from 'electron-is';
+import localShortcut from 'electron-localshortcut';
+
+import { getSongControls } from '@/providers/song-controls';
+import { registerCallback, type SongInfo } from '@/providers/song-info';
+import { LikeType, type VolumeState } from '@/types/datahost-get-state';
+import { LoggerPrefix } from '@/utils';
+
+import type { MiniPlayerPluginConfig } from './index';
+import type { BackendContext } from '@/types/contexts';
+
+/** What the mini player window renders. */
+interface MiniPlayerState {
+  title: string;
+  artist: string;
+  imageSrc: string;
+  isPaused: boolean;
+  songDuration: number;
+  elapsedSeconds: number;
+  likeStatus: LikeType;
+  volume: number;
+  isMuted: boolean;
+}
+
+const MARGIN = 24;
+
+let config: MiniPlayerPluginConfig;
+let mainWindow: BrowserWindow | null = null;
+let miniWindow: BrowserWindow | null = null;
+let saveConfig: BackendContext<MiniPlayerPluginConfig>['setConfig'] | null =
+  null;
+let saveBoundsTimer: NodeJS.Timeout | null = null;
+let callbackRegistered = false;
+
+/** Cached so the artwork is only re-encoded when the song actually changes. */
+let artworkVideoId = '';
+
+const state: MiniPlayerState = {
+  title: '',
+  artist: '',
+  imageSrc: '',
+  isPaused: true,
+  songDuration: 0,
+  elapsedSeconds: 0,
+  likeStatus: LikeType.Indifferent,
+  volume: 100,
+  isMuted: false,
+};
+
+const isOpen = () => !!miniWindow && !miniWindow.isDestroyed();
+
+const pushState = () => {
+  if (isOpen()) {
+    miniWindow!.webContents.send('mini-player:state', state);
+  }
+};
+
+const applyArtwork = (songInfo: SongInfo) => {
+  if (songInfo.videoId === artworkVideoId) {
+    return;
+  }
+
+  artworkVideoId = songInfo.videoId;
+
+  // Inline the artwork so the window never needs network access of its own.
+  const image = songInfo.image;
+  state.imageSrc =
+    image && !image.isEmpty()
+      ? image.resize({ width: 160, height: 160 }).toDataURL()
+      : (songInfo.imageSrc ?? '');
+};
+
+const onSongInfo = (songInfo: SongInfo) => {
+  // Tracked even while closed, so opening the window shows the current song
+  // right away instead of waiting for the next player event.
+  applyArtwork(songInfo);
+
+  state.title = songInfo.alternativeTitle || songInfo.title;
+  state.artist = songInfo.artist;
+  state.isPaused = songInfo.isPaused ?? state.isPaused;
+  state.songDuration = songInfo.songDuration;
+  state.elapsedSeconds = songInfo.elapsedSeconds ?? 0;
+
+  pushState();
+};
+
+const onVolumeChanged = (_: Electron.IpcMainEvent, volume: VolumeState) => {
+  state.volume = volume.state;
+  state.isMuted = volume.isMuted;
+  pushState();
+};
+
+const onLikeChanged = (_: Electron.IpcMainEvent, likeStatus: LikeType) => {
+  state.likeStatus = likeStatus;
+  pushState();
+};
+
+const defaultPosition = (width: number, height: number): [number, number] => {
+  const { workArea } = screen.getPrimaryDisplay();
+
+  return [
+    workArea.x + workArea.width - width - MARGIN,
+    workArea.y + workArea.height - height - MARGIN,
+  ];
+};
+
+/** Keep the saved position usable if the display setup changed since last run. */
+const isOnScreen = ([x, y]: [number, number]) =>
+  screen
+    .getAllDisplays()
+    .some(
+      ({ workArea }) =>
+        x >= workArea.x - 8 &&
+        y >= workArea.y - 8 &&
+        x < workArea.x + workArea.width &&
+        y < workArea.y + workArea.height,
+    );
+
+const applyOpacity = (isHovered = false) => {
+  if (!isOpen()) {
+    return;
+  }
+
+  const opacity = isHovered && config.opaqueOnHover ? 1 : config.opacity;
+
+  if (is.linux()) {
+    // `setOpacity` is a no-op on Linux, so fade the card in CSS instead.
+    miniWindow!.webContents.send('mini-player:config', { opacity });
+  } else {
+    miniWindow!.setOpacity(opacity);
+  }
+};
+
+const applyAlwaysOnTop = () => {
+  if (!isOpen()) {
+    return;
+  }
+
+  miniWindow!.setAlwaysOnTop(config.alwaysOnTop, 'screen-saver', 1);
+  miniWindow!.setVisibleOnAllWorkspaces(config.alwaysOnTop, {
+    visibleOnFullScreen: true,
+  });
+};
+
+/** Persist window bounds, debounced so dragging does not hammer the store. */
+const rememberBounds = () => {
+  if (!isOpen() || miniWindow!.isMinimized()) {
+    return;
+  }
+
+  const [x, y] = miniWindow!.getPosition();
+  const [width, height] = miniWindow!.getSize();
+
+  config.position = [x, y];
+  config.size = [width, height];
+
+  if (saveBoundsTimer) {
+    clearTimeout(saveBoundsTimer);
+  }
+
+  saveBoundsTimer = setTimeout(async () => {
+    saveBoundsTimer = null;
+    await saveConfig?.({ position: config.position, size: config.size });
+  }, 500);
+};
+
+const openMiniPlayer = () => {
+  if (isOpen()) {
+    miniWindow!.show();
+    return;
+  }
+
+  const [width, height] = config.size;
+  const position =
+    config.position && isOnScreen(config.position)
+      ? config.position
+      : defaultPosition(width, height);
+
+  miniWindow = new BrowserWindow({
+    width,
+    height,
+    x: position[0],
+    y: position[1],
+    minWidth: 320,
+    minHeight: 92,
+    maxHeight: 140,
+    title: 'Mini Player',
+    frame: false,
+    transparent: true,
+    resizable: true,
+    maximizable: false,
+    minimizable: false,
+    fullscreenable: false,
+    skipTaskbar: true,
+    hasShadow: true,
+    backgroundColor: '#00000000',
+    show: false,
+    webPreferences: {
+      preload: MiniPlayerPreload,
+      contextIsolation: true,
+      sandbox: false,
+      backgroundThrottling: false,
+    },
+  });
+
+  miniWindow.loadFile(MiniPlayerHtml).catch((error: unknown) => {
+    console.error(LoggerPrefix, '[mini-player] failed to load window', error);
+  });
+
+  miniWindow.once('ready-to-show', () => {
+    applyAlwaysOnTop();
+    applyOpacity();
+    miniWindow?.showInactive();
+  });
+
+  miniWindow.on('move', () => rememberBounds());
+
+  miniWindow.on('resize', () => rememberBounds());
+
+  miniWindow.on('closed', () => {
+    miniWindow = null;
+    restoreMainWindow(false);
+  });
+
+  registerHotkey(miniWindow);
+
+  if (mainWindow && config.hideMainWindow) {
+    // Media keeps playing in the hidden window; make sure it is not throttled.
+    mainWindow.webContents.setBackgroundThrottling(false);
+    mainWindow.hide();
+  }
+
+  // Ask the renderer to start reporting volume and like changes.
+  mainWindow?.webContents.send('peard:setup-volume-changed-listener');
+  mainWindow?.webContents.send('peard:setup-like-changed-listener');
+};
+
+const closeMiniPlayer = () => {
+  if (isOpen()) {
+    miniWindow!.close();
+  }
+};
+
+const restoreMainWindow = (focus: boolean) => {
+  if (!mainWindow || mainWindow.isDestroyed()) {
+    return;
+  }
+
+  mainWindow.webContents.setBackgroundThrottling(true);
+  mainWindow.show();
+
+  if (focus) {
+    mainWindow.focus();
+  }
+};
+
+const toggleMiniPlayer = () => {
+  if (isOpen()) {
+    closeMiniPlayer();
+  } else {
+    openMiniPlayer();
+  }
+};
+
+const registerHotkey = (window: BrowserWindow) => {
+  if (!config.hotkey) {
+    return;
+  }
+
+  try {
+    localShortcut.register(window, config.hotkey, toggleMiniPlayer);
+  } catch (error: unknown) {
+    console.error(LoggerPrefix, '[mini-player] invalid hotkey', error);
+  }
+};
+
+const unregisterHotkey = (window: BrowserWindow | null) => {
+  if (window && !window.isDestroyed()) {
+    localShortcut.unregisterAll(window);
+  }
+};
+
+const onControl = (
+  _: Electron.IpcMainEvent,
+  action: string,
+  value?: number,
+) => {
+  if (!mainWindow || mainWindow.isDestroyed()) {
+    return;
+  }
+
+  const controls = getSongControls(mainWindow);
+
+  switch (action) {
+    case 'playPause': {
+      controls.playPause();
+      // Optimistic update: the renderer echoes the real value right after.
+      state.isPaused = !state.isPaused;
+      pushState();
+      break;
+    }
+    case 'next': {
+      controls.next();
+      break;
+    }
+    case 'previous': {
+      controls.previous();
+      break;
+    }
+    case 'like': {
+      controls.like();
+      break;
+    }
+    case 'mute': {
+      controls.muteUnmute();
+      break;
+    }
+    case 'volume': {
+      if (typeof value === 'number') {
+        controls.setVolume(value);
+      }
+      break;
+    }
+    case 'seek': {
+      if (typeof value === 'number') {
+        controls.seekTo(value);
+        state.elapsedSeconds = value;
+      }
+      break;
+    }
+    case 'restore': {
+      restoreMainWindow(true);
+      if (config.hideMainWindow) {
+        closeMiniPlayer();
+      }
+      break;
+    }
+    case 'close': {
+      closeMiniPlayer();
+      break;
+    }
+    default: {
+      break;
+    }
+  }
+};
+
+const onHover = (_: Electron.IpcMainEvent, isHovered: boolean) =>
+  applyOpacity(isHovered);
+
+const onReady = () => {
+  pushState();
+  applyOpacity();
+};
+
+export const onMainLoad = async ({
+  window,
+  getConfig,
+  setConfig,
+}: BackendContext<MiniPlayerPluginConfig>) => {
+  config = await getConfig();
+  mainWindow = window;
+  saveConfig = setConfig;
+
+  ipcMain.on('mini-player:control', onControl);
+  ipcMain.on('mini-player:hover', onHover);
+  ipcMain.on('mini-player:ready', onReady);
+  ipcMain.on('peard:volume-changed', onVolumeChanged);
+  ipcMain.on('peard:like-changed', onLikeChanged);
+  ipcMain.on('plugin:toggle-mini-player', toggleMiniPlayer);
+
+  if (!callbackRegistered) {
+    // `registerCallback` has no counterpart; the handler no-ops when closed.
+    registerCallback(onSongInfo);
+    callbackRegistered = true;
+  }
+
+  registerHotkey(window);
+
+  window.on('close', closeMiniPlayer);
+
+  if (config.openOnStart) {
+    openMiniPlayer();
+  }
+};
+
+export const onConfigChange = (newConfig: MiniPlayerPluginConfig) => {
+  const hotkeyChanged = config?.hotkey !== newConfig.hotkey;
+  config = newConfig;
+
+  if (hotkeyChanged) {
+    unregisterHotkey(mainWindow);
+    unregisterHotkey(miniWindow);
+
+    if (mainWindow) registerHotkey(mainWindow);
+    if (miniWindow) registerHotkey(miniWindow);
+  }
+
+  applyAlwaysOnTop();
+  applyOpacity();
+};
+
+export const onUnload = () => {
+  ipcMain.removeListener('mini-player:control', onControl);
+  ipcMain.removeListener('mini-player:hover', onHover);
+  ipcMain.removeListener('mini-player:ready', onReady);
+  ipcMain.removeListener('peard:volume-changed', onVolumeChanged);
+  ipcMain.removeListener('peard:like-changed', onLikeChanged);
+  ipcMain.removeAllListeners('plugin:toggle-mini-player');
+
+  unregisterHotkey(mainWindow);
+  closeMiniPlayer();
+  restoreMainWindow(false);
+
+  mainWindow?.removeListener('close', closeMiniPlayer);
+  mainWindow = null;
+};
+
+export const openMiniPlayerWindow = openMiniPlayer;
+export const isMiniPlayerOpen = isOpen;
+export const toggle = toggleMiniPlayer;

--- a/src/plugins/mini-player/main.ts
+++ b/src/plugins/mini-player/main.ts
@@ -6,7 +6,11 @@ import localShortcut from 'electron-localshortcut';
 
 import { getSongControls } from '@/providers/song-controls';
 import { registerCallback, type SongInfo } from '@/providers/song-info';
-import { LikeType, type VolumeState } from '@/types/datahost-get-state';
+import {
+  LikeType,
+  type RepeatMode,
+  type VolumeState,
+} from '@/types/datahost-get-state';
 import { LoggerPrefix } from '@/utils';
 
 import type { MiniPlayerPluginConfig } from './index';
@@ -23,6 +27,8 @@ interface MiniPlayerState {
   likeStatus: LikeType;
   volume: number;
   isMuted: boolean;
+  isShuffled: boolean;
+  repeatMode: RepeatMode;
 }
 
 const MARGIN = 24;
@@ -48,6 +54,8 @@ const state: MiniPlayerState = {
   likeStatus: LikeType.Indifferent,
   volume: 100,
   isMuted: false,
+  isShuffled: false,
+  repeatMode: 'NONE',
 };
 
 const isOpen = () => !!miniWindow && !miniWindow.isDestroyed();
@@ -95,6 +103,16 @@ const onVolumeChanged = (_: Electron.IpcMainEvent, volume: VolumeState) => {
 
 const onLikeChanged = (_: Electron.IpcMainEvent, likeStatus: LikeType) => {
   state.likeStatus = likeStatus;
+  pushState();
+};
+
+const onShuffleChanged = (_: Electron.IpcMainEvent, isShuffled: boolean) => {
+  state.isShuffled = isShuffled;
+  pushState();
+};
+
+const onRepeatChanged = (_: Electron.IpcMainEvent, repeatMode: RepeatMode) => {
+  state.repeatMode = repeatMode ?? 'NONE';
   pushState();
 };
 
@@ -184,7 +202,7 @@ const openMiniPlayer = () => {
     height,
     x: position[0],
     y: position[1],
-    minWidth: 320,
+    minWidth: 400,
     minHeight: 92,
     maxHeight: 140,
     title: 'Mini Player',
@@ -233,9 +251,14 @@ const openMiniPlayer = () => {
     mainWindow.hide();
   }
 
-  // Ask the renderer to start reporting volume and like changes.
+  // Ask the renderer to start reporting player state changes.
   mainWindow?.webContents.send('peard:setup-volume-changed-listener');
   mainWindow?.webContents.send('peard:setup-like-changed-listener');
+  mainWindow?.webContents.send('peard:setup-repeat-changed-listener');
+  mainWindow?.webContents.send('peard:setup-shuffle-changed-listener');
+
+  // The shuffle observer only fires on change, so ask for the current value.
+  mainWindow?.webContents.send('peard:get-shuffle');
 };
 
 const closeMiniPlayer = () => {
@@ -314,6 +337,16 @@ const onControl = (
       controls.like();
       break;
     }
+    case 'shuffle': {
+      controls.shuffle();
+      // The player bar does not always report back, so ask for the new value.
+      controls.requestShuffleInformation();
+      break;
+    }
+    case 'repeat': {
+      controls.switchRepeat(1);
+      break;
+    }
     case 'mute': {
       controls.muteUnmute();
       break;
@@ -370,6 +403,9 @@ export const onMainLoad = async ({
   ipcMain.on('mini-player:ready', onReady);
   ipcMain.on('peard:volume-changed', onVolumeChanged);
   ipcMain.on('peard:like-changed', onLikeChanged);
+  ipcMain.on('peard:shuffle-changed', onShuffleChanged);
+  ipcMain.on('peard:get-shuffle-response', onShuffleChanged);
+  ipcMain.on('peard:repeat-changed', onRepeatChanged);
   ipcMain.on('plugin:toggle-mini-player', toggleMiniPlayer);
 
   if (!callbackRegistered) {
@@ -409,6 +445,9 @@ export const onUnload = () => {
   ipcMain.removeListener('mini-player:ready', onReady);
   ipcMain.removeListener('peard:volume-changed', onVolumeChanged);
   ipcMain.removeListener('peard:like-changed', onLikeChanged);
+  ipcMain.removeListener('peard:shuffle-changed', onShuffleChanged);
+  ipcMain.removeListener('peard:get-shuffle-response', onShuffleChanged);
+  ipcMain.removeListener('peard:repeat-changed', onRepeatChanged);
   ipcMain.removeAllListeners('plugin:toggle-mini-player');
 
   unregisterHotkey(mainWindow);

--- a/src/plugins/mini-player/menu.ts
+++ b/src/plugins/mini-player/menu.ts
@@ -1,0 +1,115 @@
+import prompt from 'custom-electron-prompt';
+
+import { t } from '@/i18n';
+import promptOptions from '@/providers/prompt-options';
+
+import { isMiniPlayerOpen, toggle } from './main';
+
+import type { MiniPlayerPluginConfig } from './index';
+import type { MenuTemplate } from '@/menu';
+import type { MenuContext } from '@/types/contexts';
+
+const opacityList = [0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 1];
+
+export const onMenu = async ({
+  window,
+  getConfig,
+  setConfig,
+}: MenuContext<MiniPlayerPluginConfig>): Promise<MenuTemplate> => {
+  const config = await getConfig();
+
+  return [
+    {
+      label: isMiniPlayerOpen()
+        ? t('plugins.mini-player.menu.close')
+        : t('plugins.mini-player.menu.open'),
+      click: () => toggle(),
+    },
+    { type: 'separator' },
+    {
+      label: t('plugins.mini-player.menu.opacity.label'),
+      submenu: opacityList.map((opacity) => ({
+        label: t('plugins.mini-player.menu.opacity.submenu.percent', {
+          opacity: Math.round(opacity * 100),
+        }),
+        type: 'radio',
+        checked: config.opacity === opacity,
+        click() {
+          setConfig({ opacity });
+        },
+      })),
+    },
+    {
+      label: t('plugins.mini-player.menu.opaque-on-hover'),
+      type: 'checkbox',
+      checked: config.opaqueOnHover,
+      click(item) {
+        setConfig({ opaqueOnHover: item.checked });
+      },
+    },
+    {
+      label: t('plugins.mini-player.menu.always-on-top'),
+      type: 'checkbox',
+      checked: config.alwaysOnTop,
+      click(item) {
+        setConfig({ alwaysOnTop: item.checked });
+      },
+    },
+    {
+      label: t('plugins.mini-player.menu.hide-main-window'),
+      type: 'checkbox',
+      checked: config.hideMainWindow,
+      click(item) {
+        setConfig({ hideMainWindow: item.checked });
+      },
+    },
+    {
+      label: t('plugins.mini-player.menu.open-on-start'),
+      type: 'checkbox',
+      checked: config.openOnStart,
+      click(item) {
+        setConfig({ openOnStart: item.checked });
+      },
+    },
+    {
+      label: t('plugins.mini-player.menu.hotkey.label'),
+      type: 'checkbox',
+      checked: !!config.hotkey,
+      async click(item) {
+        const output = await prompt(
+          {
+            title: t('plugins.mini-player.menu.hotkey.prompt.title'),
+            label: t('plugins.mini-player.menu.hotkey.prompt.label'),
+            type: 'keybind',
+            keybindOptions: [
+              {
+                value: 'hotkey',
+                label: t(
+                  'plugins.mini-player.menu.hotkey.prompt.keybind-options.hotkey',
+                ),
+                default: config.hotkey,
+              },
+            ],
+            ...promptOptions(),
+          },
+          window,
+        );
+
+        if (output) {
+          const { accelerator } = output[0];
+          setConfig({ hotkey: accelerator });
+          item.checked = !!accelerator;
+        } else {
+          // Reset checkbox if prompt was canceled
+          item.checked = !item.checked;
+        }
+      },
+    },
+    {
+      label: t('plugins.mini-player.menu.reset-position'),
+      click() {
+        setConfig({ position: null, size: [400, 100] });
+      },
+    },
+  ];
+};

--- a/src/plugins/mini-player/menu.ts
+++ b/src/plugins/mini-player/menu.ts
@@ -108,7 +108,7 @@ export const onMenu = async ({
     {
       label: t('plugins.mini-player.menu.reset-position'),
       click() {
-        setConfig({ position: null, size: [400, 100] });
+        setConfig({ position: null, size: [480, 100] });
       },
     },
   ];

--- a/src/plugins/mini-player/menu.ts
+++ b/src/plugins/mini-player/menu.ts
@@ -3,9 +3,9 @@ import prompt from 'custom-electron-prompt';
 import { t } from '@/i18n';
 import promptOptions from '@/providers/prompt-options';
 
+import { defaultConfig, type MiniPlayerPluginConfig } from './index';
 import { isMiniPlayerOpen, toggle } from './main';
 
-import type { MiniPlayerPluginConfig } from './index';
 import type { MenuTemplate } from '@/menu';
 import type { MenuContext } from '@/types/contexts';
 
@@ -108,7 +108,10 @@ export const onMenu = async ({
     {
       label: t('plugins.mini-player.menu.reset-position'),
       click() {
-        setConfig({ position: null, size: [480, 100] });
+        setConfig({
+          position: defaultConfig.position,
+          size: [...defaultConfig.size],
+        });
       },
     },
   ];

--- a/src/plugins/mini-player/renderer.tsx
+++ b/src/plugins/mini-player/renderer.tsx
@@ -18,6 +18,35 @@ let container: HTMLElement | null = null;
 let disposeButton: (() => void) | null = null;
 
 /**
+ * Close the popup this entry lives in, scoped to the element that was clicked.
+ * A document-wide `#icon` lookup would hit the first icon on the page, which
+ * belongs to an unrelated button — that id is not unique here.
+ */
+const closeSongMenu = (target: EventTarget | null) => {
+  if (!(target instanceof Element)) {
+    return;
+  }
+
+  const popup = target.closest<HTMLElement & { close?: () => void }>(
+    'tp-yt-iron-dropdown',
+  );
+
+  if (popup?.close) {
+    popup.close();
+    return;
+  }
+
+  // Fall back to the key the dropdown closes on anyway.
+  target.dispatchEvent(
+    new KeyboardEvent('keydown', {
+      key: 'Escape',
+      bubbles: true,
+      composed: true,
+    }),
+  );
+};
+
+/**
  * Adds an entry to the player's song menu, mirroring what picture-in-picture
  * does. If YouTube Music ever renames these nodes the entry simply stops
  * appearing — the hotkey and the plugin menu keep working.
@@ -45,9 +74,9 @@ export const onPlayerApiReady = (
   disposeButton = render(
     () => (
       <MiniPlayerButton
-        onClick={() => {
+        onClick={(event) => {
           ipc.send('plugin:toggle-mini-player');
-          document.querySelector<HTMLButtonElement>('#icon')?.click(); // Close the menu
+          closeSongMenu(event.currentTarget);
         }}
         text={t('plugins.mini-player.templates.button')}
       />

--- a/src/plugins/mini-player/renderer.tsx
+++ b/src/plugins/mini-player/renderer.tsx
@@ -1,0 +1,85 @@
+import { render } from 'solid-js/web';
+
+import { t } from '@/i18n';
+import {
+  isMusicOrVideoTrack,
+  isPlayerMenu,
+} from '@/plugins/utils/renderer/check';
+import { getSongMenu } from '@/providers/dom-elements';
+
+import { MiniPlayerButton } from './templates/mini-player-button';
+
+import type { MiniPlayerPluginConfig } from './index';
+import type { RendererContext } from '@/types/contexts';
+import type { MusicPlayer } from '@/types/music-player';
+
+let observer: MutationObserver | null = null;
+let container: HTMLElement | null = null;
+let disposeButton: (() => void) | null = null;
+
+/**
+ * Adds an entry to the player's song menu, mirroring what picture-in-picture
+ * does. If YouTube Music ever renames these nodes the entry simply stops
+ * appearing — the hotkey and the plugin menu keep working.
+ */
+export const onPlayerApiReady = (
+  _: MusicPlayer,
+  { ipc }: RendererContext<MiniPlayerPluginConfig>,
+) => {
+  const popupContainer = document.querySelector('ytmusic-popup-container');
+  if (!popupContainer || container) {
+    return;
+  }
+
+  container = document.createElement('div');
+  container.classList.add(
+    'style-scope',
+    'menu-item',
+    'ytmusic-menu-popup-renderer',
+  );
+  container.setAttribute('aria-disabled', 'false');
+  container.setAttribute('aria-selected', 'false');
+  container.setAttribute('role', 'option');
+  container.setAttribute('tabindex', '-1');
+
+  disposeButton = render(
+    () => (
+      <MiniPlayerButton
+        onClick={() => {
+          ipc.send('plugin:toggle-mini-player');
+          document.querySelector<HTMLButtonElement>('#icon')?.click(); // Close the menu
+        }}
+        text={t('plugins.mini-player.templates.button')}
+      />
+    ),
+    container,
+  );
+
+  observer = new MutationObserver(() => {
+    const menu = getSongMenu();
+
+    if (
+      !container ||
+      menu?.contains(container) ||
+      !isMusicOrVideoTrack() ||
+      !isPlayerMenu(menu)
+    ) {
+      return;
+    }
+
+    menu?.prepend(container);
+  });
+
+  observer.observe(popupContainer, { childList: true, subtree: true });
+};
+
+export const onRendererUnload = () => {
+  observer?.disconnect();
+  observer = null;
+
+  disposeButton?.();
+  disposeButton = null;
+
+  container?.remove();
+  container = null;
+};

--- a/src/plugins/mini-player/templates/mini-player-button.tsx
+++ b/src/plugins/mini-player/templates/mini-player-button.tsx
@@ -1,0 +1,44 @@
+export interface MiniPlayerButtonProps {
+  onClick?: (e: MouseEvent) => void;
+  text: string;
+}
+
+export const MiniPlayerButton = (props: MiniPlayerButtonProps) => (
+  <a
+    class="yt-simple-endpoint style-scope ytmusic-menu-navigation-item-renderer"
+    id="navigation-endpoint"
+    onClick={(e) => props.onClick?.(e)}
+    tabindex={-1}
+  >
+    <div class="icon ytmd-menu-item style-scope ytmusic-menu-navigation-item-renderer">
+      <svg
+        class="style-scope yt-icon"
+        style={{
+          'pointer-events': 'none',
+          'display': 'block',
+          'width': '100%',
+          'height': '100%',
+        }}
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          class="style-scope yt-icon"
+          d="M3 4h18a1 1 0 0 1 1 1v14a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1Zm1 2v12h16V6H4Z"
+          fill="#aaaaaa"
+        />
+        <path
+          class="style-scope yt-icon"
+          d="M11.5 11.5H19V17.5H11.5Z"
+          fill="#aaaaaa"
+        />
+      </svg>
+    </div>
+    <div
+      class="text style-scope ytmusic-menu-navigation-item-renderer"
+      id="ytmcustom-mini-player"
+    >
+      {props.text}
+    </div>
+  </a>
+);

--- a/tests/mini-player.test.js
+++ b/tests/mini-player.test.js
@@ -9,8 +9,8 @@ process.env.NODE_ENV = 'test';
 
 const appPath = path.resolve(import.meta.dirname, '..');
 
-/** Boot the app with the mini player enabled in a throwaway user data dir. */
-const launchWithMiniPlayer = async () => {
+/** A throwaway profile with the mini player enabled. */
+const createUserDataDir = () => {
   const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ytm-mini-'));
 
   fs.writeFileSync(
@@ -28,7 +28,11 @@ const launchWithMiniPlayer = async () => {
     }),
   );
 
-  const app = await electron.launch({
+  return userDataDir;
+};
+
+const launchWithMiniPlayer = (userDataDir) =>
+  electron.launch({
     cwd: appPath,
     args: [
       appPath,
@@ -39,9 +43,6 @@ const launchWithMiniPlayer = async () => {
       '--disable-dev-shm-usage',
     ],
   });
-
-  return { app, userDataDir };
-};
 
 const getMiniPlayerWindow = async (app) => {
   for (let attempt = 0; attempt < 60; attempt++) {
@@ -62,17 +63,32 @@ const getMiniPlayerWindow = async (app) => {
 test('Mini player - opens, renders pushed state and forwards controls', async () => {
   test.setTimeout(120_000);
 
-  const { app, userDataDir } = await launchWithMiniPlayer();
+  await withMiniPlayerApp(runAssertions);
+});
+
+/**
+ * Owns the temporary profile from before the launch until after the shutdown,
+ * so neither a failed startup nor a failed assertion leaves anything behind.
+ */
+const withMiniPlayerApp = async (run) => {
+  const userDataDir = createUserDataDir();
+  let app;
 
   try {
-    await runAssertions(app);
+    app = await launchWithMiniPlayer(userDataDir);
+    await run(app);
   } finally {
-    // Always tear down, so a failed assertion cannot leave the app running or
-    // the temporary profile behind.
-    await app.close().catch(() => {});
+    if (app) {
+      try {
+        await app.close();
+      } catch (error) {
+        console.warn('mini player test: app.close() failed', error);
+      }
+    }
+
     fs.rmSync(userDataDir, { recursive: true, force: true });
   }
-});
+};
 
 const runAssertions = async (app) => {
   const miniPlayer = await getMiniPlayerWindow(app);

--- a/tests/mini-player.test.js
+++ b/tests/mini-player.test.js
@@ -82,7 +82,7 @@ test('Mini player - opens, renders pushed state and forwards controls', async ()
 
   expect(windowFlags.isAlwaysOnTop).toBe(true);
   expect(windowFlags.isResizable).toBe(true);
-  expect(windowFlags.size[0]).toBe(400);
+  expect(windowFlags.size[0]).toBe(480);
 
   // Push a song state through the same channel the backend uses.
   await app.evaluate(({ BrowserWindow }) => {
@@ -100,12 +100,20 @@ test('Mini player - opens, renders pushed state and forwards controls', async ()
       likeStatus: 'LIKE',
       volume: 60,
       isMuted: false,
+      isShuffled: true,
+      repeatMode: 'ONE',
     });
   });
 
   await expect(miniPlayer.locator('#title')).toHaveText('Bohemian Rhapsody');
   await expect(miniPlayer.locator('#artist')).toHaveText('Queen');
   await expect(miniPlayer.locator('#like')).toHaveClass(/liked/);
+  await expect(miniPlayer.locator('#shuffle')).toHaveClass(/active/);
+  await expect(miniPlayer.locator('#repeat')).toHaveClass(/active/);
+  await expect(miniPlayer.locator('#repeat')).toHaveAttribute(
+    'title',
+    'Repeat one',
+  );
 
   // 50s of 200s => the progress fill covers a quarter of the bar.
   const fillRatio = await miniPlayer.evaluate(() => {

--- a/tests/mini-player.test.js
+++ b/tests/mini-player.test.js
@@ -62,7 +62,19 @@ const getMiniPlayerWindow = async (app) => {
 test('Mini player - opens, renders pushed state and forwards controls', async () => {
   test.setTimeout(120_000);
 
-  const { app } = await launchWithMiniPlayer();
+  const { app, userDataDir } = await launchWithMiniPlayer();
+
+  try {
+    await runAssertions(app);
+  } finally {
+    // Always tear down, so a failed assertion cannot leave the app running or
+    // the temporary profile behind.
+    await app.close().catch(() => {});
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+  }
+});
+
+const runAssertions = async (app) => {
   const miniPlayer = await getMiniPlayerWindow(app);
 
   await miniPlayer.waitForSelector('#bar');
@@ -128,17 +140,16 @@ test('Mini player - opens, renders pushed state and forwards controls', async ()
   expect(fillRatio).toBeLessThan(0.35);
 
   // Clicking a control must reach the main process over the preload bridge.
-  const nextControl = app.evaluate(
-    ({ ipcMain }) =>
-      new Promise((resolve) => {
-        ipcMain.once('mini-player:control', (_event, action) =>
-          resolve(action),
-        );
-      }),
-  );
+  // Arm the listener in its own awaited step, otherwise the click can beat the
+  // registration and the test hangs until the timeout.
+  await app.evaluate(({ ipcMain }) => {
+    globalThis.__miniPlayerControl = new Promise((resolve) => {
+      ipcMain.once('mini-player:control', (_event, action) => resolve(action));
+    });
+  });
 
   await miniPlayer.locator('[data-action="next"]').click();
-  expect(await nextControl).toBe('next');
 
-  await app.close();
-});
+  const action = await app.evaluate(() => globalThis.__miniPlayerControl);
+  expect(action).toBe('next');
+};

--- a/tests/mini-player.test.js
+++ b/tests/mini-player.test.js
@@ -1,0 +1,136 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+
+import { test, expect, _electron as electron } from '@playwright/test';
+
+process.env.NODE_ENV = 'test';
+
+const appPath = path.resolve(import.meta.dirname, '..');
+
+/** Boot the app with the mini player enabled in a throwaway user data dir. */
+const launchWithMiniPlayer = async () => {
+  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ytm-mini-'));
+
+  fs.writeFileSync(
+    path.join(userDataDir, 'config.json'),
+    JSON.stringify({
+      __internal__: { migrations: { version: '3.12.0' } },
+      plugins: {
+        'mini-player': {
+          enabled: true,
+          openOnStart: true,
+          hideMainWindow: false,
+          opacity: 1,
+        },
+      },
+    }),
+  );
+
+  const app = await electron.launch({
+    cwd: appPath,
+    args: [
+      appPath,
+      `--user-data-dir=${userDataDir}`,
+      '--no-sandbox',
+      '--disable-gpu',
+      '--whitelisted-ips=',
+      '--disable-dev-shm-usage',
+    ],
+  });
+
+  return { app, userDataDir };
+};
+
+const getMiniPlayerWindow = async (app) => {
+  for (let attempt = 0; attempt < 60; attempt++) {
+    const window = app
+      .windows()
+      .find((candidate) => candidate.url().includes('mini-player'));
+
+    if (window) {
+      return window;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+
+  throw new Error('mini player window never appeared');
+};
+
+test('Mini player - opens, renders pushed state and forwards controls', async () => {
+  test.setTimeout(120_000);
+
+  const { app } = await launchWithMiniPlayer();
+  const miniPlayer = await getMiniPlayerWindow(app);
+
+  await miniPlayer.waitForSelector('#bar');
+
+  // The window must be frameless, transparent and on top.
+  const windowFlags = await app.evaluate(({ BrowserWindow }) => {
+    const window = BrowserWindow.getAllWindows().find((candidate) =>
+      candidate.webContents.getURL().includes('mini-player'),
+    );
+
+    return {
+      isAlwaysOnTop: window.isAlwaysOnTop(),
+      isResizable: window.isResizable(),
+      size: window.getSize(),
+    };
+  });
+
+  expect(windowFlags.isAlwaysOnTop).toBe(true);
+  expect(windowFlags.isResizable).toBe(true);
+  expect(windowFlags.size[0]).toBe(400);
+
+  // Push a song state through the same channel the backend uses.
+  await app.evaluate(({ BrowserWindow }) => {
+    const window = BrowserWindow.getAllWindows().find((candidate) =>
+      candidate.webContents.getURL().includes('mini-player'),
+    );
+
+    window.webContents.send('mini-player:state', {
+      title: 'Bohemian Rhapsody',
+      artist: 'Queen',
+      imageSrc: '',
+      isPaused: false,
+      songDuration: 200,
+      elapsedSeconds: 50,
+      likeStatus: 'LIKE',
+      volume: 60,
+      isMuted: false,
+    });
+  });
+
+  await expect(miniPlayer.locator('#title')).toHaveText('Bohemian Rhapsody');
+  await expect(miniPlayer.locator('#artist')).toHaveText('Queen');
+  await expect(miniPlayer.locator('#like')).toHaveClass(/liked/);
+
+  // 50s of 200s => the progress fill covers a quarter of the bar.
+  const fillRatio = await miniPlayer.evaluate(() => {
+    const fill = document.getElementById('fill');
+    const rail = document.getElementById('rail');
+    return (
+      fill.getBoundingClientRect().width / rail.getBoundingClientRect().width
+    );
+  });
+
+  expect(fillRatio).toBeGreaterThan(0.2);
+  expect(fillRatio).toBeLessThan(0.35);
+
+  // Clicking a control must reach the main process over the preload bridge.
+  const nextControl = app.evaluate(
+    ({ ipcMain }) =>
+      new Promise((resolve) => {
+        ipcMain.once('mini-player:control', (_event, action) =>
+          resolve(action),
+        );
+      }),
+  );
+
+  await miniPlayer.locator('[data-action="next"]').click();
+  expect(await nextControl).toBe('next');
+
+  await app.close();
+});


### PR DESCRIPTION
Closes #214.

Adds a `mini-player` plugin: a small, frameless, always-on-top window with the album art, the track title/artist and playback controls, so the player stays reachable while the main window is hidden.

![Mini player](https://raw.githubusercontent.com/dcgancan/pear-desktop/docs/mini-player-screenshots/mini-player/mini-player-bar.png)

On hover it reveals the elapsed/total time and a close button:

![Mini player on hover](https://raw.githubusercontent.com/dcgancan/pear-desktop/docs/mini-player-screenshots/mini-player/mini-player-bar-hover.png)

### What it does

- Album art, title and artist (the title scrolls when it does not fit)
- Like, volume, shuffle, previous, play-pause, next and repeat, all reflecting the current player state (repeat cycles none → all → one)
- Click-to-seek progress line along the bottom edge
- Volume: scroll anywhere on the bar, or hover the speaker icon and the bottom line turns into a volume slider
- Drag the bar to move it; hover the album art for ⤢ to bring the main window back (double-click does the same)
- Window position and size are remembered

### How it works

The mini player is a separate `BrowserWindow` that loads a self-contained asset from `assets/mini-player/`, with a small preload exposing only three channels over `contextBridge`. It does not touch the YouTube Music page: state comes from `registerCallback` in `providers/song-info` plus the existing `peard:volume-changed` / `peard:like-changed` / `peard:shuffle-changed` / `peard:repeat-changed` events, and every action goes back out through `providers/song-controls`. The main window keeps playing while hidden, with background throttling disabled for the duration.

Everything is configurable from the plugin menu: opacity, "fully opaque on hover", always-on-top, whether the main window hides, open-on-startup, the toggle hotkey (`CmdOrCtrl+Shift+M` by default) and a position/size reset. The plugin is disabled by default and does not need a restart to toggle.

### Platform notes

- `BrowserWindow.setOpacity` is a no-op on Linux, so the opacity setting is applied as CSS opacity on that platform instead
- `transparent: true` on Linux needs a running compositor, same caveat as `transparent-player`
- Developed and manually verified on macOS (arm64); Windows and Linux are covered by the build only

### Testing

`tests/mini-player.test.js` launches the app with the plugin enabled and asserts that the window opens with the right flags, that a pushed state renders (title, artist, like state, progress ratio) and that clicking a control reaches the main process through the preload bridge. `pnpm check` and `pnpm build` are clean.

### Notes

- Only `en.json` is touched; the other locales are left to Weblate
- This is separate from the Windows-taskbar widget in #4349 and the tray hover player in #4428 — this one is a standalone floating window, so they should not conflict, but happy to adjust if you would rather see these consolidated
- Happy to change the layout, defaults or the control set if you have a different shape in mind


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a floating mini-player with album artwork, track details, playback controls, progress and volume sliders, and draggable positioning.
  - Added synchronized playback, volume, mute, like, shuffle, repeat, and track information.
  - Added quick access from compatible player menus, plus options for opacity, startup behavior, hotkeys, window placement, sizing, and always-on-top display.
  - Added menu actions to open, close, configure, and reset the mini-player.

- **Tests**
  - Added coverage for mini-player launch, display, playback state, and control interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->