### PR TITLE
feat: add toast auto-close plugin

### DIFF
--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -926,6 +926,10 @@
       "description": "Control playback from your Windows taskbar",
       "name": "Taskbar Media Control"
     },
+    "toast-autoclose": {
+      "description": "Automatically close YouTube Music toasts after three seconds",
+      "name": "Toast Auto-Close"
+    },
     "touchbar": {
       "description": "Adds a TouchBar widget for macOS users",
       "name": "TouchBar"

--- a/src/plugins/toast-autoclose/index.ts
+++ b/src/plugins/toast-autoclose/index.ts
@@ -1,0 +1,65 @@
+import { t } from '@/i18n';
+import { createPlugin } from '@/utils';
+
+const AUTO_CLOSE_MS = 3_000;
+
+type Toast = HTMLElement & { close?: () => void };
+
+export default createPlugin({
+  name: () => t('plugins.toast-autoclose.name'),
+  description: () => t('plugins.toast-autoclose.description'),
+  restartNeeded: false,
+  config: {
+    enabled: true,
+  },
+  renderer: {
+    start() {
+      const timers = new Map<Toast, ReturnType<typeof setTimeout>>();
+      const root =
+        document.querySelector<HTMLElement>('ytmusic-app') ?? document.body;
+
+      const arm = (toast: Toast) => {
+        if (timers.has(toast)) return;
+
+        timers.set(
+          toast,
+          setTimeout(() => {
+            timers.delete(toast);
+            if (!toast.classList.contains('paper-toast-open')) return;
+
+            const closeButton = toast.querySelector<HTMLElement>(
+              '#close-button button',
+            );
+            if (closeButton) closeButton.click();
+            else toast.close?.();
+          }, AUTO_CLOSE_MS),
+        );
+      };
+
+      const scan = () =>
+        root
+          .querySelectorAll<Toast>('tp-yt-paper-toast.paper-toast-open')
+          .forEach(arm);
+
+      scan();
+      this.observer = new MutationObserver(scan);
+      this.observer.observe(root, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ['class'],
+      });
+
+      this.timers = timers;
+    },
+    stop() {
+      this.observer?.disconnect();
+      this.observer = null;
+      this.timers?.forEach((timer) => clearTimeout(timer));
+      this.timers?.clear();
+      this.timers = null;
+    },
+    observer: null as MutationObserver | null,
+    timers: null as Map<Toast, ReturnType<typeof setTimeout>> | null,
+  },
+});

--- a/src/plugins/toast-autoclose/index.ts
+++ b/src/plugins/toast-autoclose/index.ts
@@ -38,7 +38,10 @@ export default createPlugin({
 
       const scan = () => {
         for (const [toast, timer] of timers) {
-          if (!toast.classList.contains('paper-toast-open')) {
+          if (
+            !toast.isConnected ||
+            !toast.classList.contains('paper-toast-open')
+          ) {
             clearTimeout(timer);
             timers.delete(toast);
           }
@@ -50,7 +53,23 @@ export default createPlugin({
       };
 
       scan();
-      this.observer = new MutationObserver(scan);
+      this.observer = new MutationObserver((mutations) => {
+        const isToastRelated = (node: Node) =>
+          node instanceof Element &&
+          (node.matches('tp-yt-paper-toast') ||
+            node.closest('tp-yt-paper-toast') !== null ||
+            node.querySelector('tp-yt-paper-toast') !== null);
+
+        if (
+          mutations.some(
+            ({ target, addedNodes, removedNodes }) =>
+              isToastRelated(target) ||
+              [...addedNodes, ...removedNodes].some(isToastRelated),
+          )
+        ) {
+          scan();
+        }
+      });
       this.observer.observe(root, {
         childList: true,
         subtree: true,

--- a/src/plugins/toast-autoclose/index.ts
+++ b/src/plugins/toast-autoclose/index.ts
@@ -36,10 +36,18 @@ export default createPlugin({
         );
       };
 
-      const scan = () =>
+      const scan = () => {
+        for (const [toast, timer] of timers) {
+          if (!toast.classList.contains('paper-toast-open')) {
+            clearTimeout(timer);
+            timers.delete(toast);
+          }
+        }
+
         root
           .querySelectorAll<Toast>('tp-yt-paper-toast.paper-toast-open')
           .forEach(arm);
+      };
 
       scan();
       this.observer = new MutationObserver(scan);


### PR DESCRIPTION
Whenever you like a song for instance there's a persistent toast that must be manually dismissed which is very annoying. This plugin fixes that.

## Summary

- add a renderer plugin that closes open YouTube Music toasts after 3 seconds
- observe dynamically created and reopened toast elements
- clean up the observer and pending timers when the plugin is disabled
- add English plugin metadata

## Verification

- TypeScript typecheck
- Oxlint
- Production electron-vite build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic closing for YouTube Music toast notifications after three seconds.
  * Toasts are detected when they appear, including dynamically added notifications.
  * Prevented duplicate close actions for the same toast.
  * Added English localization for the feature name and description.
  * Enabled by default without requiring an application restart.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->