### PR TITLE
feat(plugins): add Skip AI Music and reduce idle CPU/memory

### DIFF
--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -695,7 +695,7 @@
       "name": "Notifications"
     },
     "performance-improvement": {
-      "description": "Improve performance by enabling experimental scripts",
+      "description": "Reduce CPU and memory use with timer taming, unused DOM cleanup, and pausing extra visual work while the window is hidden",
       "name": "Performance improvement [Beta]"
     },
     "picture-in-picture": {
@@ -821,6 +821,48 @@
           "label": "Choose Global Keybinds for Songs Control:",
           "title": "Global Keybinds"
         }
+      }
+    },
+    "skip-ai-music": {
+      "description": "Skip known AI-generated artists and custom blocked artists, songs, or title keywords, using the Soul Over AI community list",
+      "menu": {
+        "clear-blocked-songs": "Clear blocked songs ({{count}})",
+        "clear-blocked-songs-cancel": "Cancel",
+        "clear-blocked-songs-confirm": "Clear",
+        "clear-blocked-songs-message": "Remove every song you blocked from the player bar?",
+        "community-list": {
+          "never": "never",
+          "refresh": "Refresh community AI artist list",
+          "refresh-failed": "Could not download the community AI artist list",
+          "refresh-success": "Loaded {{count}} AI artists",
+          "status": "Community list: {{count}} artists (updated {{fetched}})"
+        },
+        "dislike-on-skip": "Dislike skipped tracks",
+        "edit-allowed-artists": "Edit allowed artists",
+        "edit-blocked-artists": "Edit blocked artists",
+        "edit-keywords": "Edit title keywords",
+        "show-player-buttons": "Show block buttons on the player bar",
+        "skip-common-keywords": "Skip common AI title keywords (Suno, AI cover, sped up, ...)",
+        "use-community-list": "Skip artists from the Soul Over AI list"
+      },
+      "name": "Skip AI Music",
+      "prompt": {
+        "allowed-artists": {
+          "label": "Artists that should always play, even if they are on a block list (comma-separated)",
+          "title": "Allowed artists"
+        },
+        "blocked-artists": {
+          "label": "Artists to skip (comma-separated). Blocking \"Prince\" will not skip \"Princess Nokia\".",
+          "title": "Blocked artists"
+        },
+        "keywords": {
+          "label": "Skip a track when its title or artist contains one of these phrases (comma-separated)",
+          "title": "Title keywords"
+        }
+      },
+      "renderer": {
+        "block-artist": "Block artist",
+        "block-song": "Block song"
       }
     },
     "skip-disliked-songs": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,7 +106,7 @@ app.commandLine.appendSwitch('ozone-platform-hint', 'auto');
 // WaylandWindowDecorations: Required for Wayland decorations
 app.commandLine.appendSwitch(
   'enable-features',
-  'OverlayScrollbar,SharedArrayBuffer,UseOzonePlatform,WaylandWindowDecorations',
+  'OverlayScrollbar,SharedArrayBuffer,UseOzonePlatform,WaylandWindowDecorations,IntensiveWakeUpThrottling,CalculateNativeWinOcclusion',
 );
 
 // Disable Fluent Scrollbar (for OverlayScrollbar)
@@ -367,8 +367,10 @@ async function createMainWindow() {
     backgroundColor: '#000',
     show: false,
     webPreferences: {
+      backgroundThrottling: true,
       contextIsolation: true,
       preload: path.join(__dirname, '..', 'preload', 'preload.cjs'),
+      spellcheck: false,
       ...(isTesting()
         ? undefined
         : {
@@ -403,10 +405,10 @@ async function createMainWindow() {
     const scaledY = windowY;
 
     if (
-      scaledX + (scaledWidth / 2) < display.bounds.x - 8 || // Left
-      scaledX + (scaledWidth / 2) > display.bounds.x + display.bounds.width || // Right
+      scaledX + scaledWidth / 2 < display.bounds.x - 8 || // Left
+      scaledX + scaledWidth / 2 > display.bounds.x + display.bounds.width || // Right
       scaledY < display.bounds.y - 8 || // Top
-      scaledY + (scaledHeight / 2) > display.bounds.y + display.bounds.height // Bottom
+      scaledY + scaledHeight / 2 > display.bounds.y + display.bounds.height // Bottom
     ) {
       // Window is offscreen
       if (is.dev()) {

--- a/src/plugins/ambient-mode/index.ts
+++ b/src/plugins/ambient-mode/index.ts
@@ -128,7 +128,7 @@ export default createPlugin({
             if (lastImageData) {
               const frameOffset =
                 (1 / this.buffer) * (1000 / this.interpolationTime);
-              context.globalAlpha = 1 - (frameOffset * 2); // because of alpha value must be < 1
+              context.globalAlpha = 1 - frameOffset * 2; // because of alpha value must be < 1
               context.putImageData(lastImageData, 0, 0);
               context.globalAlpha = frameOffset;
             }
@@ -175,14 +175,22 @@ export default createPlugin({
           canvasInterval = null;
         };
         const onPlay = () => {
+          if (document.hidden) {
+            return;
+          }
           if (canvasInterval) clearInterval(canvasInterval);
           canvasInterval = setInterval(
             onSync,
             Math.max(1, Math.ceil(1000 / this.buffer)),
           );
         };
+        const onVisibilityChange = () => {
+          if (document.hidden) onPause();
+          else onPlay();
+        };
         songVideo.addEventListener('pause', onPause);
         songVideo.addEventListener('play', onPlay);
+        document.addEventListener('visibilitychange', onVisibilityChange);
 
         /* injecting */
         videoWrapper.prepend(blurCanvas);
@@ -193,6 +201,7 @@ export default createPlugin({
 
           songVideo.removeEventListener('pause', onPause);
           songVideo.removeEventListener('play', onPlay);
+          document.removeEventListener('visibilitychange', onVisibilityChange);
 
           if (blurCanvas.isConnected) blurCanvas.remove();
         };
@@ -252,7 +261,9 @@ export default createPlugin({
         observer.observe(playerPage, { attributes: true });
 
         /* fallback ticker for when the observer isn't triggered */
-        this.interval = setInterval(injectBlurElement, 1000);
+        this.interval = setInterval(() => {
+          if (!document.hidden) injectBlurElement();
+        }, 1000);
       }
     },
     onConfigChange(newConfig) {

--- a/src/plugins/performance-improvement/index.ts
+++ b/src/plugins/performance-improvement/index.ts
@@ -4,6 +4,18 @@ import { createPlugin } from '@/utils';
 import { injectCpuTamer } from './scripts/cpu-tamer';
 import { injectRm3 } from './scripts/rm3';
 
+import type { MusicPlayer } from '@/types/music-player';
+
+const AUDIO_QUALITY = 'tiny';
+
+const isVideoPlayerVisible = () => {
+  const songVideo = document.querySelector<HTMLElement>('#song-video');
+  if (!songVideo) {
+    return false;
+  }
+  return getComputedStyle(songVideo).display != 'none';
+};
+
 export default createPlugin({
   name: () => t('plugins.performance-improvement.name'),
   description: () => t('plugins.performance-improvement.description'),
@@ -12,8 +24,64 @@ export default createPlugin({
   config: {
     enabled: true,
   },
-  renderer() {
-    injectRm3();
-    injectCpuTamer();
+  renderer: {
+    api: null as MusicPlayer | null,
+    restoredQuality: null as string | null,
+    onVisibilityChange: null as (() => void) | null,
+    start() {
+      injectRm3();
+      injectCpuTamer();
+    },
+    onPlayerApiReady(api: MusicPlayer) {
+      this.api = api;
+
+      this.onVisibilityChange = () => {
+        document.documentElement.classList.toggle(
+          'peard-window-hidden',
+          document.hidden,
+        );
+
+        if (!this.api) {
+          return;
+        }
+
+        if (document.hidden && isVideoPlayerVisible()) {
+          if (this.restoredQuality == null) {
+            this.restoredQuality = this.api.getPlaybackQuality();
+          }
+          try {
+            this.api.setPlaybackQualityRange(AUDIO_QUALITY);
+            this.api.setPlaybackQuality(AUDIO_QUALITY);
+          } catch {
+            // Quality APIs are best-effort and missing on some player builds.
+          }
+          return;
+        }
+
+        if (!document.hidden && this.restoredQuality) {
+          try {
+            this.api.setPlaybackQualityRange(this.restoredQuality);
+            this.api.setPlaybackQuality(this.restoredQuality);
+          } catch {
+            // Ignore restore failures; playback can continue at the current quality.
+          }
+          this.restoredQuality = null;
+        }
+      };
+
+      document.addEventListener('visibilitychange', this.onVisibilityChange);
+    },
+    stop() {
+      if (this.onVisibilityChange) {
+        document.removeEventListener(
+          'visibilitychange',
+          this.onVisibilityChange,
+        );
+        this.onVisibilityChange = null;
+      }
+      document.documentElement.classList.remove('peard-window-hidden');
+      this.api = null;
+      this.restoredQuality = null;
+    },
   },
 });

--- a/src/plugins/skip-ai-music/backend.ts
+++ b/src/plugins/skip-ai-music/backend.ts
@@ -1,0 +1,321 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { app } from 'electron';
+
+import { getSongControls } from '@/providers/song-controls';
+import {
+  registerCallback,
+  SongInfoEvent,
+  unregisterCallback,
+  type SongInfo,
+} from '@/providers/song-info';
+import { createBackend, LoggerPrefix } from '@/utils';
+
+import { shouldSkipTrack } from './match';
+import {
+  COMMUNITY_ARTISTS_URL,
+  COMMUNITY_REFRESH_INTERVAL_MS,
+  type SkipAiMusicPluginConfig,
+} from './types';
+
+type CommunityCache = {
+  artists: string[];
+  fetchedAt: number;
+};
+
+type CommunityArtistEntry = {
+  name?: string;
+  removed?: boolean;
+};
+
+let pluginConfig: SkipAiMusicPluginConfig | null = null;
+let communityArtists: string[] = [];
+let communityFetchedAt = 0;
+let refreshTimer: NodeJS.Timeout | null = null;
+let lastSongInfo: SongInfo | null = null;
+let lastSkippedVideoId = '';
+let lastSkipAt = 0;
+let consecutiveSkips = 0;
+let skipTimer: NodeJS.Timeout | null = null;
+let pluginWindow: Electron.BrowserWindow | null = null;
+
+const MAX_CONSECUTIVE_SKIPS = 12;
+const SKIP_WINDOW_MS = 30_000;
+const SKIP_RETRY_MS = 5_000;
+const DISLIKE_THEN_SKIP_MS = 350;
+
+const cachePath = () =>
+  path.join(app.getPath('userData'), 'skip-ai-music', 'artists.json');
+
+export const getCommunityStatus = () => ({
+  count: communityArtists.length,
+  fetchedAt: communityFetchedAt,
+});
+
+const parseCommunityArtists = (data: unknown): string[] => {
+  const names: string[] = [];
+
+  const pushName = (value: unknown) => {
+    if (typeof value == 'string' && value.trim()) {
+      names.push(value.trim());
+    }
+  };
+
+  if (Array.isArray(data)) {
+    for (const entry of data) {
+      if (typeof entry == 'string') {
+        pushName(entry);
+        continue;
+      }
+
+      if (entry && typeof entry == 'object') {
+        const item = entry as CommunityArtistEntry;
+        if (item.removed) {
+          continue;
+        }
+        pushName(item.name);
+      }
+    }
+    return names;
+  }
+
+  if (data && typeof data == 'object') {
+    const record = data as { artists?: unknown };
+    if (Array.isArray(record.artists)) {
+      return parseCommunityArtists(record.artists);
+    }
+  }
+
+  return names;
+};
+
+const loadCachedArtists = async () => {
+  try {
+    const raw = await readFile(cachePath(), 'utf8');
+    const parsed = JSON.parse(raw) as CommunityCache;
+    if (!Array.isArray(parsed.artists)) {
+      return;
+    }
+
+    communityArtists = parsed.artists.filter(
+      (name) => typeof name == 'string' && name.trim().length > 0,
+    );
+    communityFetchedAt = Number(parsed.fetchedAt) || 0;
+  } catch {
+    // First run or a corrupt cache is fine; a network refresh follows.
+  }
+};
+
+const saveCachedArtists = async () => {
+  const file = cachePath();
+  await mkdir(path.dirname(file), { recursive: true });
+  const payload: CommunityCache = {
+    artists: communityArtists,
+    fetchedAt: communityFetchedAt,
+  };
+  await writeFile(file, JSON.stringify(payload), 'utf8');
+};
+
+export const refreshCommunityArtists = async (force = false) => {
+  if (
+    !force &&
+    communityArtists.length > 0 &&
+    Date.now() - communityFetchedAt < COMMUNITY_REFRESH_INTERVAL_MS
+  ) {
+    return communityArtists;
+  }
+
+  const response = await fetch(COMMUNITY_ARTISTS_URL);
+  if (!response.ok) {
+    throw new Error(`Community list HTTP ${response.status}`);
+  }
+
+  const data: unknown = await response.json();
+  const names = parseCommunityArtists(data);
+  if (names.length == 0) {
+    throw new Error('Community list was empty');
+  }
+
+  communityArtists = names;
+  communityFetchedAt = Date.now();
+  await saveCachedArtists();
+  console.log(
+    LoggerPrefix,
+    `skip-ai-music: loaded ${communityArtists.length} community artists`,
+  );
+  return communityArtists;
+};
+
+const clearSkipTimer = () => {
+  if (skipTimer) {
+    clearTimeout(skipTimer);
+    skipTimer = null;
+  }
+};
+
+const skipCurrent = (
+  window: Electron.BrowserWindow,
+  songInfo: SongInfo,
+  dislike: boolean,
+) => {
+  const controls = getSongControls(window);
+  lastSkippedVideoId = songInfo.videoId;
+  lastSkipAt = Date.now();
+
+  if (dislike) {
+    controls.dislike();
+    clearSkipTimer();
+    skipTimer = setTimeout(() => {
+      if (lastSongInfo?.videoId == songInfo.videoId) {
+        controls.next();
+      }
+      skipTimer = null;
+    }, DISLIKE_THEN_SKIP_MS);
+    return;
+  }
+
+  controls.next();
+};
+
+const maybeSkip = (window: Electron.BrowserWindow, songInfo: SongInfo) => {
+  if (!pluginConfig?.enabled) {
+    return;
+  }
+
+  if (!songInfo.title && !songInfo.artist) {
+    return;
+  }
+
+  const result = shouldSkipTrack(
+    { artist: songInfo.artist, title: songInfo.title },
+    pluginConfig,
+    communityArtists,
+  );
+
+  if (!result.skip) {
+    consecutiveSkips = 0;
+    return;
+  }
+
+  const now = Date.now();
+  if (
+    lastSkippedVideoId == songInfo.videoId &&
+    now - lastSkipAt < SKIP_RETRY_MS
+  ) {
+    return;
+  }
+
+  if (now - lastSkipAt < SKIP_WINDOW_MS) {
+    consecutiveSkips += 1;
+  } else {
+    consecutiveSkips = 1;
+  }
+
+  if (consecutiveSkips > MAX_CONSECUTIVE_SKIPS) {
+    console.warn(
+      LoggerPrefix,
+      'skip-ai-music: too many consecutive skips, pausing playback',
+    );
+    getSongControls(window).pause();
+    consecutiveSkips = 0;
+    return;
+  }
+
+  console.log(
+    LoggerPrefix,
+    `skip-ai-music: skipping "${songInfo.artist} - ${songInfo.title}" (${result.reason}: ${result.matched})`,
+  );
+  skipCurrent(window, songInfo, pluginConfig.dislikeOnSkip);
+};
+
+const onSongInfo: (
+  window: Electron.BrowserWindow,
+) => (songInfo: SongInfo, event: SongInfoEvent) => void =
+  (window) => (songInfo, event) => {
+    lastSongInfo = songInfo;
+    if (event != SongInfoEvent.VideoSrcChanged) {
+      return;
+    }
+    maybeSkip(window, songInfo);
+  };
+
+const startCommunityRefresh = async () => {
+  try {
+    await refreshCommunityArtists();
+  } catch (error) {
+    console.warn(
+      LoggerPrefix,
+      'skip-ai-music: failed to refresh community list',
+      error,
+    );
+  }
+
+  if (refreshTimer) {
+    return;
+  }
+
+  refreshTimer = setInterval(() => {
+    refreshCommunityArtists().catch((error: unknown) => {
+      console.warn(
+        LoggerPrefix,
+        'skip-ai-music: failed to refresh community list',
+        error,
+      );
+    });
+  }, COMMUNITY_REFRESH_INTERVAL_MS);
+  refreshTimer.unref?.();
+};
+
+const stopCommunityRefresh = () => {
+  if (refreshTimer) {
+    clearInterval(refreshTimer);
+    refreshTimer = null;
+  }
+};
+
+export const backend = createBackend<
+  {
+    onSongInfo?: ReturnType<typeof onSongInfo>;
+  },
+  SkipAiMusicPluginConfig
+>({
+  async start({ getConfig, window }) {
+    pluginConfig = await getConfig();
+    pluginWindow = window;
+    await loadCachedArtists();
+
+    if (pluginConfig.useCommunityList) {
+      await startCommunityRefresh();
+    }
+
+    this.onSongInfo = onSongInfo(window);
+    registerCallback(this.onSongInfo);
+  },
+  stop() {
+    if (this.onSongInfo) {
+      unregisterCallback(this.onSongInfo);
+      this.onSongInfo = undefined;
+    }
+    stopCommunityRefresh();
+    clearSkipTimer();
+    pluginConfig = null;
+    pluginWindow = null;
+    lastSongInfo = null;
+  },
+  onConfigChange(newConfig) {
+    const shouldStartCommunity =
+      newConfig.useCommunityList && !pluginConfig?.useCommunityList;
+    pluginConfig = newConfig;
+
+    if (shouldStartCommunity) {
+      startCommunityRefresh();
+    } else if (!newConfig.useCommunityList) {
+      stopCommunityRefresh();
+    }
+
+    if (pluginWindow && lastSongInfo) {
+      maybeSkip(pluginWindow, lastSongInfo);
+    }
+  },
+});

--- a/src/plugins/skip-ai-music/index.ts
+++ b/src/plugins/skip-ai-music/index.ts
@@ -1,0 +1,20 @@
+import { t } from '@/i18n';
+import { createPlugin } from '@/utils';
+
+import { backend } from './backend';
+import { onMenu } from './menu';
+import { renderer } from './renderer';
+import style from './style.css?inline';
+import { defaultConfig } from './types';
+
+export default createPlugin({
+  name: () => t('plugins.skip-ai-music.name'),
+  description: () => t('plugins.skip-ai-music.description'),
+  restartNeeded: false,
+  addedVersion: '3.12.X',
+  config: defaultConfig,
+  stylesheets: [style],
+  menu: onMenu,
+  backend,
+  renderer,
+});

--- a/src/plugins/skip-ai-music/match.test.ts
+++ b/src/plugins/skip-ai-music/match.test.ts
@@ -1,0 +1,112 @@
+import { expect, test } from '@playwright/test';
+
+import { hasWholePhrase, shouldSkipTrack, splitArtists } from './match';
+import { defaultConfig, type SkipAiMusicPluginConfig } from './types';
+
+const config = (
+  overrides: Partial<SkipAiMusicPluginConfig> = {},
+): SkipAiMusicPluginConfig => ({
+  ...defaultConfig,
+  ...overrides,
+});
+
+test('blocking Prince does not block Princess Nokia', () => {
+  const result = shouldSkipTrack(
+    { artist: 'Princess Nokia', title: 'Mine' },
+    config({ blockedArtists: ['Prince'] }),
+  );
+
+  expect(result.skip).toBe(false);
+});
+
+test('exact artist match skips the track', () => {
+  const result = shouldSkipTrack(
+    { artist: 'Fake AI Band', title: 'A Song' },
+    config({ blockedArtists: ['Fake AI Band'] }),
+  );
+
+  expect(result.skip).toBe(true);
+  expect(result.reason).toBe('blocked-artist');
+});
+
+test('featured artists are matched independently', () => {
+  const result = shouldSkipTrack(
+    { artist: 'Real Artist feat. Fake AI Band', title: 'Collab' },
+    config({ blockedArtists: ['Fake AI Band'] }),
+  );
+
+  expect(result.skip).toBe(true);
+  expect(result.reason).toBe('blocked-artist');
+});
+
+test('community artists skip unless allowlisted', () => {
+  const skipped = shouldSkipTrack(
+    { artist: 'Slop Studio', title: 'Track' },
+    config({ useCommunityList: true }),
+    ['Slop Studio'],
+  );
+  expect(skipped.skip).toBe(true);
+  expect(skipped.reason).toBe('community-artist');
+
+  const allowed = shouldSkipTrack(
+    { artist: 'Slop Studio', title: 'Track' },
+    config({ allowedArtists: ['Slop Studio'], useCommunityList: true }),
+    ['Slop Studio'],
+  );
+  expect(allowed.skip).toBe(false);
+  expect(allowed.reason).toBe('allowed-artist');
+});
+
+test('blocked songs require both title and artist', () => {
+  const blocked = shouldSkipTrack(
+    { artist: 'Original', title: 'Cover Song' },
+    config({
+      blockedSongs: [{ artist: 'Original', title: 'Cover Song' }],
+    }),
+  );
+  expect(blocked.skip).toBe(true);
+
+  const cover = shouldSkipTrack(
+    { artist: 'Someone Else', title: 'Cover Song' },
+    config({
+      blockedSongs: [{ artist: 'Original', title: 'Cover Song' }],
+    }),
+  );
+  expect(cover.skip).toBe(false);
+});
+
+test('keywords use whole-phrase matching', () => {
+  expect(hasWholePhrase('Song (Sped Up)', 'sped up')).toBe(true);
+  expect(hasWholePhrase('Afterpiece', 'after')).toBe(false);
+
+  const result = shouldSkipTrack(
+    { artist: 'Band', title: 'Hit (Sped Up)' },
+    config({ blockedKeywords: ['sped up'] }),
+  );
+  expect(result.skip).toBe(true);
+  expect(result.reason).toBe('keyword');
+});
+
+test('common AI keywords are opt-in', () => {
+  const off = shouldSkipTrack(
+    { artist: 'Band', title: 'Love (AI Cover)' },
+    config({ skipCommonKeywords: false }),
+  );
+  expect(off.skip).toBe(false);
+
+  const on = shouldSkipTrack(
+    { artist: 'Band', title: 'Love (AI Cover)' },
+    config({ skipCommonKeywords: true }),
+  );
+  expect(on.skip).toBe(true);
+  expect(on.matched).toBe('ai cover');
+});
+
+test('splitArtists keeps the full byline and each credited name', () => {
+  expect(splitArtists('A & B feat. C • Topic')).toEqual([
+    'a & b feat. c',
+    'a',
+    'b',
+    'c',
+  ]);
+});

--- a/src/plugins/skip-ai-music/match.ts
+++ b/src/plugins/skip-ai-music/match.ts
@@ -1,0 +1,184 @@
+import { COMMON_AI_KEYWORDS, type SkipAiMusicPluginConfig } from './types';
+
+export type SkipMatchInput = {
+  artist: string;
+  title: string;
+};
+
+export type SkipMatchReason =
+  | 'allowed-artist'
+  | 'blocked-artist'
+  | 'blocked-song'
+  | 'community-artist'
+  | 'keyword';
+
+export type SkipMatchResult = {
+  matched?: string;
+  reason?: SkipMatchReason;
+  skip: boolean;
+};
+
+const ARTIST_SPLIT_RE =
+  /\s*(?:,|&|\/| x | feat\.? | ft\.? | featuring | vs\.? | versus )\s*/iu;
+
+const escapeRegExp = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+export const normalizeName = (value: string) =>
+  value.normalize('NFKC').toLowerCase().replace(/\s+/g, ' ').trim();
+
+export const foldName = (value: string) =>
+  normalizeName(value)
+    .replace(/[^\p{L}\p{N}\s]+/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+export const splitArtists = (artist: string): string[] => {
+  const normalized = normalizeName(artist);
+  if (!normalized) {
+    return [];
+  }
+
+  const withoutMeta = normalized.split('•')[0]?.trim() || normalized;
+  const tokens = withoutMeta
+    .split(ARTIST_SPLIT_RE)
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+
+  return [...new Set([withoutMeta, ...tokens])];
+};
+
+export const hasWholePhrase = (haystack: string, needle: string) => {
+  const phrase = normalizeName(needle);
+  if (!phrase) {
+    return false;
+  }
+
+  const source = normalizeName(haystack);
+  const regex = new RegExp(
+    `(^|[^\\p{L}\\p{N}_])${escapeRegExp(phrase)}($|[^\\p{L}\\p{N}_])`,
+    'iu',
+  );
+  return regex.test(source);
+};
+
+const toArtistSet = (artists: string[]) => {
+  const folded = new Set<string>();
+  for (const artist of artists) {
+    const value = foldName(artist);
+    if (value) {
+      folded.add(value);
+    }
+  }
+  return folded;
+};
+
+const songKey = (title: string, artist: string) =>
+  `${foldName(title)}\u0000${foldName(artist)}`;
+
+export const shouldSkipTrack = (
+  input: SkipMatchInput,
+  config: SkipAiMusicPluginConfig,
+  communityArtists: string[] = [],
+): SkipMatchResult => {
+  const title = input.title || '';
+  const artist = input.artist || '';
+  if (!title && !artist) {
+    return { skip: false };
+  }
+
+  const artistTokens = splitArtists(artist);
+  const foldedTokens = artistTokens.map((token) => foldName(token));
+  const allowed = toArtistSet(config.allowedArtists);
+
+  for (const token of foldedTokens) {
+    if (token && allowed.has(token)) {
+      return { matched: token, reason: 'allowed-artist', skip: false };
+    }
+  }
+
+  const blockedSongs = config.blockedSongs || [];
+  const titleFolded = foldName(title);
+  for (const song of blockedSongs) {
+    if (!song || !song.title) {
+      continue;
+    }
+
+    if (songKey(song.title, song.artist || '') == songKey(title, artist)) {
+      return {
+        matched: `${song.artist} - ${song.title}`,
+        reason: 'blocked-song',
+        skip: true,
+      };
+    }
+
+    // Title-only entries still require an artist match when one was stored.
+    if (!song.artist && foldName(song.title) == titleFolded) {
+      return {
+        matched: song.title,
+        reason: 'blocked-song',
+        skip: true,
+      };
+    }
+  }
+
+  const customArtists = toArtistSet(config.blockedArtists);
+  for (let i = 0; i < foldedTokens.length; i++) {
+    const token = foldedTokens[i];
+    if (token && customArtists.has(token)) {
+      return {
+        matched: artistTokens[i],
+        reason: 'blocked-artist',
+        skip: true,
+      };
+    }
+  }
+
+  if (config.useCommunityList) {
+    const community = toArtistSet(communityArtists);
+    for (let i = 0; i < foldedTokens.length; i++) {
+      const token = foldedTokens[i];
+      if (token && community.has(token)) {
+        return {
+          matched: artistTokens[i],
+          reason: 'community-artist',
+          skip: true,
+        };
+      }
+    }
+  }
+
+  const keywords = [
+    ...(config.blockedKeywords || []),
+    ...(config.skipCommonKeywords ? COMMON_AI_KEYWORDS : []),
+  ];
+  for (const keyword of keywords) {
+    if (hasWholePhrase(title, keyword) || hasWholePhrase(artist, keyword)) {
+      return { matched: keyword, reason: 'keyword', skip: true };
+    }
+  }
+
+  return { skip: false };
+};
+
+export const uniqueNormalized = (values: string[]) => {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const value of values) {
+    const normalized = value.trim();
+    if (!normalized) {
+      continue;
+    }
+
+    const key = foldName(normalized);
+    if (!key || seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    result.push(normalized);
+  }
+
+  return result;
+};

--- a/src/plugins/skip-ai-music/menu.ts
+++ b/src/plugins/skip-ai-music/menu.ts
@@ -1,0 +1,190 @@
+import prompt from 'custom-electron-prompt';
+import { dialog } from 'electron';
+
+import { t } from '@/i18n';
+import promptOptions from '@/providers/prompt-options';
+
+import { getCommunityStatus, refreshCommunityArtists } from './backend';
+import { uniqueNormalized } from './match';
+
+import type { SkipAiMusicPluginConfig } from './types';
+import type { MenuTemplate } from '@/menu';
+import type { MenuContext } from '@/types/contexts';
+
+const promptList = async (
+  window: Electron.BrowserWindow,
+  title: string,
+  label: string,
+  values: string[],
+) => {
+  const output = await prompt(
+    {
+      title,
+      label,
+      value: values.join(', '),
+      type: 'input',
+      width: 480,
+      ...promptOptions(),
+    },
+    window,
+  );
+
+  if (output == null) {
+    return values;
+  }
+
+  return uniqueNormalized(
+    String(output)
+      .split(/[\n,;]+/)
+      .map((item) => item.trim()),
+  );
+};
+
+export const onMenu = async ({
+  getConfig,
+  setConfig,
+  window,
+}: MenuContext<SkipAiMusicPluginConfig>): Promise<MenuTemplate> => {
+  const config = await getConfig();
+  const community = getCommunityStatus();
+  const fetched =
+    community.fetchedAt > 0
+      ? new Date(community.fetchedAt).toLocaleString()
+      : t('plugins.skip-ai-music.menu.community-list.never');
+
+  return [
+    {
+      label: t('plugins.skip-ai-music.menu.use-community-list'),
+      type: 'checkbox',
+      checked: config.useCommunityList,
+      click(item) {
+        setConfig({ useCommunityList: item.checked });
+      },
+    },
+    {
+      label: t('plugins.skip-ai-music.menu.community-list.status', {
+        count: community.count,
+        fetched,
+      }),
+      enabled: false,
+    },
+    {
+      label: t('plugins.skip-ai-music.menu.community-list.refresh'),
+      async click() {
+        try {
+          const artists = await refreshCommunityArtists(true);
+          await dialog.showMessageBox(window, {
+            type: 'info',
+            title: t('plugins.skip-ai-music.menu.community-list.refresh'),
+            message: t(
+              'plugins.skip-ai-music.menu.community-list.refresh-success',
+              { count: artists.length },
+            ),
+          });
+        } catch (error) {
+          await dialog.showMessageBox(window, {
+            type: 'error',
+            title: t('plugins.skip-ai-music.menu.community-list.refresh'),
+            message: t(
+              'plugins.skip-ai-music.menu.community-list.refresh-failed',
+            ),
+            detail: error instanceof Error ? error.message : String(error),
+          });
+        }
+      },
+    },
+    { type: 'separator' },
+    {
+      label: t('plugins.skip-ai-music.menu.dislike-on-skip'),
+      type: 'checkbox',
+      checked: config.dislikeOnSkip,
+      click(item) {
+        setConfig({ dislikeOnSkip: item.checked });
+      },
+    },
+    {
+      label: t('plugins.skip-ai-music.menu.show-player-buttons'),
+      type: 'checkbox',
+      checked: config.showPlayerButtons,
+      click(item) {
+        setConfig({ showPlayerButtons: item.checked });
+      },
+    },
+    {
+      label: t('plugins.skip-ai-music.menu.skip-common-keywords'),
+      type: 'checkbox',
+      checked: config.skipCommonKeywords,
+      click(item) {
+        setConfig({ skipCommonKeywords: item.checked });
+      },
+    },
+    { type: 'separator' },
+    {
+      label: t('plugins.skip-ai-music.menu.edit-blocked-artists'),
+      async click() {
+        const current = await getConfig();
+        setConfig({
+          blockedArtists: await promptList(
+            window,
+            t('plugins.skip-ai-music.prompt.blocked-artists.title'),
+            t('plugins.skip-ai-music.prompt.blocked-artists.label'),
+            current.blockedArtists,
+          ),
+        });
+      },
+    },
+    {
+      label: t('plugins.skip-ai-music.menu.edit-allowed-artists'),
+      async click() {
+        const current = await getConfig();
+        setConfig({
+          allowedArtists: await promptList(
+            window,
+            t('plugins.skip-ai-music.prompt.allowed-artists.title'),
+            t('plugins.skip-ai-music.prompt.allowed-artists.label'),
+            current.allowedArtists,
+          ),
+        });
+      },
+    },
+    {
+      label: t('plugins.skip-ai-music.menu.edit-keywords'),
+      async click() {
+        const current = await getConfig();
+        setConfig({
+          blockedKeywords: await promptList(
+            window,
+            t('plugins.skip-ai-music.prompt.keywords.title'),
+            t('plugins.skip-ai-music.prompt.keywords.label'),
+            current.blockedKeywords,
+          ),
+        });
+      },
+    },
+    {
+      label: t('plugins.skip-ai-music.menu.clear-blocked-songs', {
+        count: config.blockedSongs.length,
+      }),
+      enabled: config.blockedSongs.length > 0,
+      async click() {
+        const { response } = await dialog.showMessageBox(window, {
+          type: 'question',
+          buttons: [
+            t('plugins.skip-ai-music.menu.clear-blocked-songs-cancel'),
+            t('plugins.skip-ai-music.menu.clear-blocked-songs-confirm'),
+          ],
+          defaultId: 0,
+          cancelId: 0,
+          title: t('plugins.skip-ai-music.menu.clear-blocked-songs', {
+            count: config.blockedSongs.length,
+          }),
+          message: t('plugins.skip-ai-music.menu.clear-blocked-songs-message'),
+        });
+
+        if (response == 1) {
+          setConfig({ blockedSongs: [] });
+        }
+      },
+    },
+  ];
+};

--- a/src/plugins/skip-ai-music/renderer.ts
+++ b/src/plugins/skip-ai-music/renderer.ts
@@ -1,0 +1,156 @@
+import { t } from '@/i18n';
+import { getSongInfo } from '@/providers/song-info-front';
+import { waitForElement } from '@/utils/wait-for-element';
+
+import { uniqueNormalized } from './match';
+
+import type { BlockedSong, SkipAiMusicPluginConfig } from './types';
+import type { RendererContext } from '@/types/contexts';
+
+const CONTROLS_ID = 'skip-ai-music-controls';
+
+const currentTrack = () => {
+  const info = getSongInfo();
+  const title =
+    info.title ||
+    document.querySelector('ytmusic-player-bar .title')?.textContent?.trim() ||
+    '';
+  const artist =
+    info.artist ||
+    document.querySelector('ytmusic-player-bar .byline')?.textContent?.trim() ||
+    '';
+
+  return { artist, title };
+};
+
+const addUniqueSong = (songs: BlockedSong[], song: BlockedSong) => {
+  const exists = songs.some(
+    (item) =>
+      item.title.toLowerCase() == song.title.toLowerCase() &&
+      item.artist.toLowerCase() == song.artist.toLowerCase(),
+  );
+  if (exists) {
+    return songs;
+  }
+  return [...songs, song];
+};
+
+const createButton = (label: string, onClick: () => void) => {
+  const button = document.createElement('button');
+  button.className = 'skip-ai-music-button';
+  button.type = 'button';
+  button.textContent = label;
+  button.addEventListener('click', (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    onClick();
+  });
+  return button;
+};
+
+export const renderer = {
+  context: null as RendererContext<SkipAiMusicPluginConfig> | null,
+  buttonsMounted: false,
+
+  async start(ctx: RendererContext<SkipAiMusicPluginConfig>) {
+    this.context = ctx;
+    const config = await ctx.getConfig();
+    if (config.showPlayerButtons) {
+      await this.mountButtons();
+    }
+  },
+
+  async mountButtons() {
+    if (this.buttonsMounted) {
+      return;
+    }
+
+    const playerBar = await waitForElement<HTMLElement>('ytmusic-player-bar');
+    if (document.getElementById(CONTROLS_ID)) {
+      this.buttonsMounted = true;
+      return;
+    }
+
+    const threeDots =
+      playerBar.querySelector(
+        '.middle-controls-buttons ytmusic-menu-renderer',
+      ) || playerBar.querySelector('ytmusic-menu-renderer');
+    const parent =
+      threeDots?.parentElement ||
+      playerBar.querySelector('.middle-controls-buttons');
+    if (!parent) {
+      return;
+    }
+
+    const container = document.createElement('div');
+    container.id = CONTROLS_ID;
+    container.className = 'skip-ai-music-controls';
+
+    container.append(
+      createButton(t('plugins.skip-ai-music.renderer.block-artist'), () => {
+        this.blockArtist();
+      }),
+      createButton(t('plugins.skip-ai-music.renderer.block-song'), () => {
+        this.blockSong();
+      }),
+    );
+
+    if (threeDots?.nextSibling) {
+      parent.insertBefore(container, threeDots.nextSibling);
+    } else {
+      parent.append(container);
+    }
+
+    this.buttonsMounted = true;
+  },
+
+  unmountButtons() {
+    document.getElementById(CONTROLS_ID)?.remove();
+    this.buttonsMounted = false;
+  },
+
+  async blockArtist() {
+    if (!this.context) {
+      return;
+    }
+
+    const { artist } = currentTrack();
+    if (!artist) {
+      return;
+    }
+
+    const config = await this.context.getConfig();
+    await this.context.setConfig({
+      blockedArtists: uniqueNormalized([...config.blockedArtists, artist]),
+    });
+  },
+
+  async blockSong() {
+    if (!this.context) {
+      return;
+    }
+
+    const song = currentTrack();
+    if (!song.title) {
+      return;
+    }
+
+    const config = await this.context.getConfig();
+    await this.context.setConfig({
+      blockedSongs: addUniqueSong(config.blockedSongs, song),
+    });
+  },
+
+  async onConfigChange(newConfig: SkipAiMusicPluginConfig) {
+    if (newConfig.showPlayerButtons) {
+      await this.mountButtons();
+    } else {
+      this.unmountButtons();
+    }
+  },
+
+  stop() {
+    this.unmountButtons();
+    this.context = null;
+  },
+};

--- a/src/plugins/skip-ai-music/style.css
+++ b/src/plugins/skip-ai-music/style.css
@@ -1,0 +1,23 @@
+.skip-ai-music-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0 8px;
+}
+
+.skip-ai-music-button {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 14px;
+  color: var(--ytmusic-text-primary, #fff);
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  padding: 4px 10px;
+  text-transform: uppercase;
+}
+
+.skip-ai-music-button:hover {
+  background: rgba(255, 255, 255, 0.18);
+}

--- a/src/plugins/skip-ai-music/types.ts
+++ b/src/plugins/skip-ai-music/types.ts
@@ -1,0 +1,56 @@
+export type BlockedSong = {
+  artist: string;
+  title: string;
+};
+
+export type SkipAiMusicPluginConfig = {
+  enabled: boolean;
+  /**
+   * Sync and skip artists from the Soul Over AI community list.
+   */
+  useCommunityList: boolean;
+  /**
+   * Dislike a matched track before skipping it.
+   */
+  dislikeOnSkip: boolean;
+  /**
+   * Show block-artist / block-song buttons on the player bar.
+   */
+  showPlayerButtons: boolean;
+  /**
+   * Also skip titles that look like mass-produced AI or "slop" variants.
+   */
+  skipCommonKeywords: boolean;
+  blockedArtists: string[];
+  allowedArtists: string[];
+  blockedKeywords: string[];
+  blockedSongs: BlockedSong[];
+};
+
+export const COMMON_AI_KEYWORDS = [
+  'ai cover',
+  'ai generated',
+  'ai remix',
+  'ai version',
+  'nightcore',
+  'sped up',
+  'suno',
+  'udio',
+];
+
+export const defaultConfig: SkipAiMusicPluginConfig = {
+  enabled: false,
+  useCommunityList: true,
+  dislikeOnSkip: false,
+  showPlayerButtons: true,
+  skipCommonKeywords: false,
+  blockedArtists: [],
+  allowedArtists: [],
+  blockedKeywords: [],
+  blockedSongs: [],
+};
+
+export const COMMUNITY_ARTISTS_URL =
+  'https://raw.githubusercontent.com/xoundbyte/soul-over-ai/main/dist/artists.json';
+
+export const COMMUNITY_REFRESH_INTERVAL_MS = 24 * 60 * 60 * 1000;

--- a/src/plugins/skip-silences/renderer.ts
+++ b/src/plugins/skip-silences/renderer.ts
@@ -8,7 +8,7 @@ let hasAudioStarted = false;
 
 const smoothing = 0.1;
 const threshold = -100; // DB (-100 = absolute silence, 0 = loudest)
-const interval = 2; // Ms
+const interval = 25; // Ms
 const history = 10;
 const speakingHistory = Array.from({ length: history }).fill(0) as number[];
 

--- a/src/plugins/visualizer/visualizers/butterchurn.ts
+++ b/src/plugins/visualizer/visualizers/butterchurn.ts
@@ -9,6 +9,7 @@ class ButterchurnVisualizer extends Visualizer {
   private readonly visualizer: ReturnType<typeof Butterchurn.createVisualizer>;
   private destroyed: boolean = false;
   private animFrameHandle: number | null;
+  private readonly onVisibilityChange: () => void;
 
   constructor(
     audioContext: AudioContext,
@@ -23,6 +24,10 @@ class ButterchurnVisualizer extends Visualizer {
     const preset = ButterchurnPresets[config.butterchurn.preset];
     const renderVisualizer = () => {
       if (this.destroyed) return;
+      if (document.hidden) {
+        this.animFrameHandle = null;
+        return;
+      }
       this.visualizer.render();
       this.animFrameHandle = requestAnimationFrame(renderVisualizer);
     };
@@ -34,6 +39,14 @@ class ButterchurnVisualizer extends Visualizer {
     this.visualizer.loadPreset(preset, config.butterchurn.blendTimeInSeconds);
     this.visualizer.connectAudio(audioNode);
 
+    this.onVisibilityChange = () => {
+      if (this.destroyed || document.hidden || this.animFrameHandle != null) {
+        return;
+      }
+      this.animFrameHandle = requestAnimationFrame(renderVisualizer);
+    };
+    document.addEventListener('visibilitychange', this.onVisibilityChange);
+
     // Start animation request loop. Do not use setInterval!
     this.animFrameHandle = requestAnimationFrame(renderVisualizer);
   }
@@ -43,6 +56,7 @@ class ButterchurnVisualizer extends Visualizer {
   }
 
   destroy() {
+    document.removeEventListener('visibilitychange', this.onVisibilityChange);
     if (this.animFrameHandle) cancelAnimationFrame(this.animFrameHandle);
     this.destroyed = true;
     try {

--- a/src/plugins/visualizer/visualizers/vudio.ts
+++ b/src/plugins/visualizer/visualizers/vudio.ts
@@ -6,6 +6,7 @@ import type { VisualizerPluginConfig } from '../index';
 
 class VudioVisualizer extends Visualizer {
   private readonly visualizer: Vudio;
+  private readonly onVisibilityChange: () => void;
 
   constructor(
     _audioContext: AudioContext,
@@ -24,6 +25,15 @@ class VudioVisualizer extends Visualizer {
       ...config,
     });
 
+    this.onVisibilityChange = () => {
+      if (document.hidden) {
+        this.visualizer.pause();
+      } else {
+        this.visualizer.dance();
+      }
+    };
+    document.addEventListener('visibilitychange', this.onVisibilityChange);
+
     this.visualizer.dance();
   }
 
@@ -35,6 +45,7 @@ class VudioVisualizer extends Visualizer {
   }
 
   destroy() {
+    document.removeEventListener('visibilitychange', this.onVisibilityChange);
     this.visualizer.pause();
     try {
       this.audioSource.disconnect(this.audioNode);

--- a/src/providers/song-info-front.ts
+++ b/src/providers/song-info-front.ts
@@ -35,12 +35,19 @@ export const setupSeekedListener = singleton(() => {
 });
 
 export const setupTimeChangedListener = singleton(() => {
+  let lastSentSeconds = Number.NaN;
   const progressObserver = new MutationObserver((mutations) => {
     for (const mutation of mutations) {
       const target = mutation.target as Node & { value: string };
       const numberValue = Number(target.value);
-      window.ipcRenderer.send('peard:time-changed', numberValue);
-      songInfo.elapsedSeconds = numberValue;
+      const seconds = Math.floor(numberValue);
+      songInfo.elapsedSeconds = seconds;
+      // The progress bar mutates many times per second; plugins only need whole seconds.
+      if (seconds == lastSentSeconds || Number.isNaN(seconds)) {
+        continue;
+      }
+      lastSentSeconds = seconds;
+      window.ipcRenderer.send('peard:time-changed', seconds);
     }
   });
   const progressBar = document.querySelector('#progress-bar');
@@ -255,6 +262,17 @@ export const setupSongInfo = (api: MusicPlayer) => {
 
   const waitingEvent = new Set<string>();
   const waitingTimeouts = new Map<string, NodeJS.Timeout>();
+  const boundPlaybackVideos = new WeakSet<HTMLVideoElement>();
+
+  const bindPlaybackListeners = (video: HTMLVideoElement) => {
+    if (boundPlaybackVideos.has(video)) {
+      return;
+    }
+    boundPlaybackVideos.add(video);
+    for (const status of ['playing', 'pause'] as const) {
+      video.addEventListener(status, playPausedHandlers[status]);
+    }
+  };
 
   const clearVideoTimeout = (videoId: string) => {
     const timeoutId = waitingTimeouts.get(videoId);
@@ -278,9 +296,8 @@ export const setupSongInfo = (api: MusicPlayer) => {
       const video = document.querySelector<HTMLVideoElement>('video');
       video?.dispatchEvent(srcChangedEvent);
 
-      for (const status of ['playing', 'pause'] as const) {
-        // for fix issue that pause event not fired
-        video?.addEventListener(status, playPausedHandlers[status]);
+      if (video) {
+        bindPlaybackListeners(video);
       }
 
       clearVideoTimeout(videoData.videoId);
@@ -301,9 +318,7 @@ export const setupSongInfo = (api: MusicPlayer) => {
   const video = document.querySelector('video');
 
   if (video) {
-    for (const status of ['playing', 'pause'] as const) {
-      video.addEventListener(status, playPausedHandlers[status]);
-    }
+    bindPlaybackListeners(video);
 
     if (!isNaN(video.duration)) {
       const {

--- a/src/providers/song-info.ts
+++ b/src/providers/song-info.ts
@@ -187,6 +187,10 @@ export const registerCallback = (callback: SongInfoCallback) => {
   callbacks.add(callback);
 };
 
+export const unregisterCallback = (callback: SongInfoCallback) => {
+  callbacks.delete(callback);
+};
+
 const registerProvider = (win: BrowserWindow) => {
   const dataMutex = new Mutex();
   let songInfo: SongInfo | null = null;


### PR DESCRIPTION
## Summary
- Add a **Skip AI Music** plugin (off by default) that can skip community-listed AI artists plus custom blocked artists, songs, and title keywords
- Whole-token artist matching so blocking `Prince` does not skip `Princess Nokia`
- Optional dislike-before-skip, player-bar Block artist / Block song buttons, and common AI title keywords
- Throttle progress-bar IPC to whole seconds, bind play/pause listeners once per video, pause extra visual work while the window is hidden, drop music-video quality to `tiny` while hidden, slow skip-silences analysis, and enable Chromium wake-up / occlusion throttling with spellcheck off

Closes #4639

## Test plan
- [ ] Enable **Skip AI Music**, play a matching artist/title, confirm it skips
- [ ] Confirm an allowlisted artist still plays
- [ ] Confirm blocking `Prince` does not skip `Princess Nokia`
- [ ] Disable the plugin and confirm skip behavior stops
- [ ] Hide / minimize the window and confirm playback still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Skip AI Music, with configurable artist/song/keyword filtering, community-list support, optional dislikes, skip limits, and player-bar blocking controls.
  - Added English translations for Skip AI Music settings and actions.
- **Performance**
  - Reduced background visual work and improved handling of hidden windows, videos, and visualizers.
  - Hidden video playback can temporarily use lower audio quality and restore it when visible.
- **Bug Fixes**
  - Improved playback progress accuracy and prevented duplicate playback event handling.
  - Reduced unnecessary silence-detection polling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->