### PR TITLE
feat(plugins): add Skip AI Music

### DIFF
--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -879,9 +879,10 @@
           "title": "Blocked artists"
         },
         "blocked-songs": {
-          "description": "Use Artist - Title to block a specific song. Title alone works when the artist is unknown.",
-          "placeholder": "Artist - Title",
-          "title": "Blocked songs"
+          "artist-placeholder": "Artist (optional)",
+          "description": "Add artist and title separately. Leave artist empty to block by title only.",
+          "title": "Blocked songs",
+          "title-placeholder": "Title"
         },
         "keywords": {
           "description": "Add a phrase to skip when it appears in the title or artist name.",

--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -823,6 +823,77 @@
         }
       }
     },
+    "skip-ai-music": {
+      "description": "Skip AI-related artists and tracks using Zoundhub, custom block lists, and title keywords",
+      "menu": {
+        "allowed-artists": {
+          "label": "Allowed artists ({{count}})"
+        },
+        "behavior": {
+          "label": "When skipping"
+        },
+        "blocked-artists": {
+          "label": "Blocked artists ({{count}})"
+        },
+        "blocked-songs": {
+          "label": "Blocked songs ({{count}})"
+        },
+        "dislike-on-skip": "Dislike skipped tracks",
+        "keywords": {
+          "label": "Title keywords ({{count}})"
+        },
+        "skip-common-keywords": "Skip common AI title keywords",
+        "use-community-list": "Use Zoundhub artist list",
+        "zoundhub": {
+          "label": "Zoundhub",
+          "never": "never",
+          "refresh": "Refresh list",
+          "status": "{{count}} artists at {{score}}%+ (updated {{fetched}})",
+          "threshold-value": "SubmitHub threshold: {{score}}%"
+        }
+      },
+      "name": "Skip AI Music",
+      "prompt": {
+        "threshold": {
+          "description": "Skip Zoundhub artists at or above this SubmitHub AI score.",
+          "title": "SubmitHub threshold",
+          "value": "{score}% or higher"
+        },
+        "list-editor": {
+          "add": "Add",
+          "cancel": "Cancel",
+          "duplicate": "{name} is already on the list",
+          "empty": "Nothing added yet",
+          "remove": "Remove",
+          "remove-named": "Remove {name}",
+          "save": "Save"
+        },
+        "allowed-artists": {
+          "description": "These artists always play, even if they are on a skip list.",
+          "placeholder": "Artist name",
+          "title": "Allowed artists"
+        },
+        "blocked-artists": {
+          "description": "Add each artist you want skipped.",
+          "placeholder": "Artist name",
+          "title": "Blocked artists"
+        },
+        "blocked-songs": {
+          "description": "Use Artist - Title to block a specific song. Title alone works when the artist is unknown.",
+          "placeholder": "Artist - Title",
+          "title": "Blocked songs"
+        },
+        "keywords": {
+          "description": "Add a phrase to skip when it appears in the title or artist name.",
+          "placeholder": "Phrase",
+          "title": "Title keywords"
+        }
+      },
+      "renderer": {
+        "block-artist": "Block artist",
+        "block-song": "Block song"
+      }
+    },
     "skip-disliked-songs": {
       "description": "Skips disliked songs",
       "name": "Skip Disliked Songs"

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -99,6 +99,7 @@ export const mainMenuTemplate = async (
           label: pluginLabel,
           sublabel: isNew ? t('main.menu.plugins.new') : undefined,
           toolTip: pluginDescription,
+          checked: true,
           submenu: [
             await pluginEnabledMenu(
               id,

--- a/src/plugins/in-app-menu/renderer/PanelItem.tsx
+++ b/src/plugins/in-app-menu/renderer/PanelItem.tsx
@@ -164,6 +164,7 @@ type SubmenuItemProps = BasePanelItemProps & {
   type: 'submenu';
   level: number[];
   children: JSX.Element;
+  checked?: boolean;
 };
 type RadioPanelItemProps = BasePanelItemProps & {
   type: 'radio';
@@ -297,7 +298,12 @@ export const PanelItem = (props: PanelItemProps) => {
       ref={setAnchor}
     >
       <Switch fallback={<div class={itemIconStyle()} />}>
-        <Match when={props.type === 'checkbox' && props.checked}>
+        <Match
+          when={
+            (props.type === 'checkbox' || props.type === 'submenu') &&
+            props.checked
+          }
+        >
           <svg
             class={itemIconStyle()}
             fill="none"

--- a/src/plugins/in-app-menu/renderer/TitleBar.tsx
+++ b/src/plugins/in-app-menu/renderer/TitleBar.tsx
@@ -130,6 +130,10 @@ const PanelRenderer = (props: PanelRendererProps) => {
             </Match>
             <Match when={subItem().type === 'submenu'}>
               <PanelItem
+                checked={
+                  subItem().submenu?.items?.[0]?.type === 'checkbox' &&
+                  subItem().submenu?.items?.[0]?.checked
+                }
                 chip={subItem().sublabel}
                 commandId={subItem().commandId}
                 level={[...(props.level ?? []), subItem().commandId]}

--- a/src/plugins/in-app-menu/renderer/TitleBar.tsx
+++ b/src/plugins/in-app-menu/renderer/TitleBar.tsx
@@ -130,10 +130,7 @@ const PanelRenderer = (props: PanelRendererProps) => {
             </Match>
             <Match when={subItem().type === 'submenu'}>
               <PanelItem
-                checked={
-                  subItem().submenu?.items?.[0]?.type === 'checkbox' &&
-                  subItem().submenu?.items?.[0]?.checked
-                }
+                checked={subItem().checked === true}
                 chip={subItem().sublabel}
                 commandId={subItem().commandId}
                 level={[...(props.level ?? []), subItem().commandId]}

--- a/src/plugins/skip-ai-music/backend.ts
+++ b/src/plugins/skip-ai-music/backend.ts
@@ -1,0 +1,392 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { app } from 'electron';
+
+import { store } from '@/config/store';
+import { getSongControls } from '@/providers/song-controls';
+import {
+  registerCallback,
+  SongInfoEvent,
+  unregisterCallback,
+  type SongInfo,
+} from '@/providers/song-info';
+import { createBackend, LoggerPrefix } from '@/utils';
+
+import { shouldSkipTrack } from './match';
+import {
+  COMMUNITY_ARTISTS_URL,
+  COMMUNITY_CACHE_VERSION,
+  COMMUNITY_REFRESH_INTERVAL_MS,
+  clampCommunityMinScore,
+  type SkipAiMusicPluginConfig,
+} from './types';
+
+type ScoredArtist = {
+  name: string;
+  score: number;
+};
+
+type CommunityCache = {
+  artists: ScoredArtist[];
+  fetchedAt: number;
+  version?: number;
+};
+
+type CommunityArtistEntry = {
+  name?: string;
+  removed?: boolean;
+  submithub_score?: unknown;
+};
+
+let pluginConfig: SkipAiMusicPluginConfig | null = null;
+let scoredArtists: ScoredArtist[] = [];
+let communityArtists: string[] = [];
+let communityFetchedAt = 0;
+let refreshTimer: NodeJS.Timeout | null = null;
+let lastSongInfo: SongInfo | null = null;
+let lastSkippedVideoId = '';
+let lastSkipAt = 0;
+let consecutiveSkips = 0;
+let skipTimer: NodeJS.Timeout | null = null;
+let pluginWindow: Electron.BrowserWindow | null = null;
+
+const MAX_CONSECUTIVE_SKIPS = 12;
+const SKIP_WINDOW_MS = 30_000;
+const SKIP_RETRY_MS = 5_000;
+const DISLIKE_THEN_SKIP_MS = 350;
+
+const cachePath = () =>
+  path.join(app.getPath('userData'), 'skip-ai-music', 'artists.json');
+
+export const getCommunityStatus = () => ({
+  count: communityArtists.length,
+  fetchedAt: communityFetchedAt,
+  minScore: clampCommunityMinScore(pluginConfig?.communityMinScore),
+});
+
+const minScoreFromConfig = () =>
+  clampCommunityMinScore(pluginConfig?.communityMinScore);
+
+const applyScoreFilter = () => {
+  const minScore = minScoreFromConfig();
+  communityArtists = scoredArtists
+    .filter((artist) => artist.score >= minScore)
+    .map((artist) => artist.name);
+};
+
+const parseCommunityArtists = (data: unknown): ScoredArtist[] => {
+  const artists: ScoredArtist[] = [];
+
+  const pushArtist = (name: unknown, score: unknown) => {
+    if (typeof name != 'string' || !name.trim()) {
+      return;
+    }
+    const value = Number(score);
+    if (!Number.isFinite(value)) {
+      return;
+    }
+    artists.push({ name: name.trim(), score: value });
+  };
+
+  if (Array.isArray(data)) {
+    for (const entry of data) {
+      if (!entry || typeof entry != 'object') {
+        continue;
+      }
+
+      const item = entry as CommunityArtistEntry;
+      if (item.removed) {
+        continue;
+      }
+      pushArtist(item.name, item.submithub_score);
+    }
+    return artists;
+  }
+
+  if (data && typeof data == 'object') {
+    const record = data as { artists?: unknown };
+    if (Array.isArray(record.artists)) {
+      return parseCommunityArtists(record.artists);
+    }
+  }
+
+  return artists;
+};
+
+const loadCachedArtists = async () => {
+  try {
+    const raw = await readFile(cachePath(), 'utf8');
+    const parsed = JSON.parse(raw) as CommunityCache;
+    if (!Array.isArray(parsed.artists)) {
+      return;
+    }
+
+    const cached: ScoredArtist[] = [];
+    for (const entry of parsed.artists) {
+      if (!entry || typeof entry != 'object') {
+        continue;
+      }
+      if (typeof entry.name != 'string' || !entry.name.trim()) {
+        continue;
+      }
+      const score = Number(entry.score);
+      if (!Number.isFinite(score)) {
+        continue;
+      }
+      cached.push({ name: entry.name.trim(), score });
+    }
+
+    scoredArtists = cached;
+    applyScoreFilter();
+    communityFetchedAt =
+      Number(parsed.version) == COMMUNITY_CACHE_VERSION && cached.length > 0
+        ? Number(parsed.fetchedAt) || 0
+        : 0;
+  } catch {
+    // First run or a corrupt cache is fine; a network refresh follows.
+  }
+};
+
+const saveCachedArtists = async () => {
+  const file = cachePath();
+  await mkdir(path.dirname(file), { recursive: true });
+  const payload: CommunityCache = {
+    artists: scoredArtists,
+    fetchedAt: communityFetchedAt,
+    version: COMMUNITY_CACHE_VERSION,
+  };
+  await writeFile(file, JSON.stringify(payload), 'utf8');
+};
+
+export const refreshCommunityArtists = async (
+  force = false,
+  minScoreOverride?: number,
+) => {
+  if (minScoreOverride != null && pluginConfig) {
+    pluginConfig = {
+      ...pluginConfig,
+      communityMinScore: clampCommunityMinScore(minScoreOverride),
+    };
+  }
+
+  if (
+    !force &&
+    scoredArtists.length > 0 &&
+    Date.now() - communityFetchedAt < COMMUNITY_REFRESH_INTERVAL_MS
+  ) {
+    applyScoreFilter();
+    return communityArtists;
+  }
+
+  const response = await fetch(COMMUNITY_ARTISTS_URL);
+  if (!response.ok) {
+    throw new Error(`Community list HTTP ${response.status}`);
+  }
+
+  const data: unknown = await response.json();
+  const artists = parseCommunityArtists(data);
+  if (artists.length == 0) {
+    throw new Error('Community list was empty');
+  }
+
+  scoredArtists = artists;
+  applyScoreFilter();
+  communityFetchedAt = Date.now();
+  await saveCachedArtists();
+  console.log(
+    LoggerPrefix,
+    `skip-ai-music: loaded ${communityArtists.length} community artists at ${minScoreFromConfig()}%+`,
+  );
+  return communityArtists;
+};
+
+const clearSkipTimer = () => {
+  if (skipTimer) {
+    clearTimeout(skipTimer);
+    skipTimer = null;
+  }
+};
+
+const skipCurrent = (
+  window: Electron.BrowserWindow,
+  songInfo: SongInfo,
+  dislike: boolean,
+) => {
+  const controls = getSongControls(window);
+  lastSkippedVideoId = songInfo.videoId;
+  lastSkipAt = Date.now();
+
+  if (dislike) {
+    controls.dislike();
+    clearSkipTimer();
+    skipTimer = setTimeout(() => {
+      if (lastSongInfo?.videoId == songInfo.videoId) {
+        controls.next();
+      }
+      skipTimer = null;
+    }, DISLIKE_THEN_SKIP_MS);
+    return;
+  }
+
+  controls.next();
+};
+
+const maybeSkip = (window: Electron.BrowserWindow, songInfo: SongInfo) => {
+  if (!pluginConfig?.enabled) {
+    return;
+  }
+
+  if (!songInfo.title && !songInfo.artist) {
+    return;
+  }
+
+  const result = shouldSkipTrack(
+    { artist: songInfo.artist, title: songInfo.title },
+    pluginConfig,
+    communityArtists,
+  );
+
+  if (!result.skip) {
+    consecutiveSkips = 0;
+    return;
+  }
+
+  const now = Date.now();
+  if (
+    lastSkippedVideoId == songInfo.videoId &&
+    now - lastSkipAt < SKIP_RETRY_MS
+  ) {
+    return;
+  }
+
+  if (now - lastSkipAt < SKIP_WINDOW_MS) {
+    consecutiveSkips += 1;
+  } else {
+    consecutiveSkips = 1;
+  }
+
+  if (consecutiveSkips > MAX_CONSECUTIVE_SKIPS) {
+    console.warn(
+      LoggerPrefix,
+      'skip-ai-music: too many consecutive skips, pausing playback',
+    );
+    getSongControls(window).pause();
+    consecutiveSkips = 0;
+    return;
+  }
+
+  console.log(
+    LoggerPrefix,
+    `skip-ai-music: skipping "${songInfo.artist} - ${songInfo.title}" (${result.reason}: ${result.matched})`,
+  );
+  skipCurrent(window, songInfo, pluginConfig.dislikeOnSkip);
+};
+
+const onSongInfo: (
+  window: Electron.BrowserWindow,
+) => (songInfo: SongInfo, event: SongInfoEvent) => void =
+  (window) => (songInfo, event) => {
+    lastSongInfo = songInfo;
+    if (event != SongInfoEvent.VideoSrcChanged) {
+      return;
+    }
+    maybeSkip(window, songInfo);
+  };
+
+const startCommunityRefresh = async () => {
+  try {
+    await refreshCommunityArtists();
+  } catch (error) {
+    console.warn(
+      LoggerPrefix,
+      'skip-ai-music: failed to refresh community list',
+      error,
+    );
+  }
+
+  if (refreshTimer) {
+    return;
+  }
+
+  refreshTimer = setInterval(() => {
+    refreshCommunityArtists().catch((error: unknown) => {
+      console.warn(
+        LoggerPrefix,
+        'skip-ai-music: failed to refresh community list',
+        error,
+      );
+    });
+  }, COMMUNITY_REFRESH_INTERVAL_MS);
+  refreshTimer.unref?.();
+};
+
+const stopCommunityRefresh = () => {
+  if (refreshTimer) {
+    clearInterval(refreshTimer);
+    refreshTimer = null;
+  }
+};
+
+export const backend = createBackend<
+  {
+    onSongInfo?: ReturnType<typeof onSongInfo>;
+  },
+  SkipAiMusicPluginConfig
+>({
+  async start({ getConfig, window }) {
+    if (store.get('plugins.skip-ai-music.showPlayerButtons') != null) {
+      store.delete('plugins.skip-ai-music.showPlayerButtons');
+    }
+
+    pluginConfig = await getConfig();
+    pluginConfig.communityMinScore = clampCommunityMinScore(
+      pluginConfig.communityMinScore,
+    );
+    pluginWindow = window;
+    await loadCachedArtists();
+
+    if (pluginConfig.useCommunityList) {
+      await startCommunityRefresh();
+    }
+
+    this.onSongInfo = onSongInfo(window);
+    registerCallback(this.onSongInfo);
+  },
+  stop() {
+    if (this.onSongInfo) {
+      unregisterCallback(this.onSongInfo);
+      this.onSongInfo = undefined;
+    }
+    stopCommunityRefresh();
+    clearSkipTimer();
+    pluginConfig = null;
+    pluginWindow = null;
+    lastSongInfo = null;
+  },
+  onConfigChange(newConfig) {
+    const shouldStartCommunity =
+      newConfig.useCommunityList && !pluginConfig?.useCommunityList;
+    const scoreChanged =
+      clampCommunityMinScore(newConfig.communityMinScore) !=
+      clampCommunityMinScore(pluginConfig?.communityMinScore);
+    pluginConfig = {
+      ...newConfig,
+      communityMinScore: clampCommunityMinScore(newConfig.communityMinScore),
+    };
+
+    if (scoreChanged) {
+      applyScoreFilter();
+    }
+
+    if (shouldStartCommunity) {
+      startCommunityRefresh();
+    } else if (!newConfig.useCommunityList) {
+      stopCommunityRefresh();
+    }
+
+    if (pluginWindow && lastSongInfo) {
+      maybeSkip(pluginWindow, lastSongInfo);
+    }
+  },
+});

--- a/src/plugins/skip-ai-music/backend.ts
+++ b/src/plugins/skip-ai-music/backend.ts
@@ -3,7 +3,6 @@ import path from 'node:path';
 
 import { app } from 'electron';
 
-import { store } from '@/config/store';
 import { getSongControls } from '@/providers/song-controls';
 import {
   registerCallback,
@@ -13,7 +12,7 @@ import {
 } from '@/providers/song-info';
 import { createBackend, LoggerPrefix } from '@/utils';
 
-import { shouldSkipTrack } from './match';
+import { buildCommunityArtistSet, shouldSkipTrack } from './match';
 import {
   COMMUNITY_ARTISTS_URL,
   COMMUNITY_CACHE_VERSION,
@@ -42,8 +41,10 @@ type CommunityArtistEntry = {
 let pluginConfig: SkipAiMusicPluginConfig | null = null;
 let scoredArtists: ScoredArtist[] = [];
 let communityArtists: string[] = [];
+let communityArtistSet = new Set<string>();
 let communityFetchedAt = 0;
 let refreshTimer: NodeJS.Timeout | null = null;
+let refreshInFlight: Promise<string[]> | null = null;
 let lastSongInfo: SongInfo | null = null;
 let lastSkippedVideoId = '';
 let lastSkipAt = 0;
@@ -73,6 +74,7 @@ const applyScoreFilter = () => {
   communityArtists = scoredArtists
     .filter((artist) => artist.score >= minScore)
     .map((artist) => artist.name);
+  communityArtistSet = buildCommunityArtistSet(communityArtists);
 };
 
 const parseCommunityArtists = (data: unknown): ScoredArtist[] => {
@@ -179,26 +181,40 @@ export const refreshCommunityArtists = async (
     return communityArtists;
   }
 
-  const response = await fetch(COMMUNITY_ARTISTS_URL);
-  if (!response.ok) {
-    throw new Error(`Community list HTTP ${response.status}`);
+  if (refreshInFlight) {
+    return refreshInFlight;
   }
 
-  const data: unknown = await response.json();
-  const artists = parseCommunityArtists(data);
-  if (artists.length == 0) {
-    throw new Error('Community list was empty');
-  }
+  refreshInFlight = (async () => {
+    try {
+      const response = await fetch(COMMUNITY_ARTISTS_URL, {
+        signal: AbortSignal.timeout(15_000),
+      });
+      if (!response.ok) {
+        throw new Error(`Community list HTTP ${response.status}`);
+      }
 
-  scoredArtists = artists;
-  applyScoreFilter();
-  communityFetchedAt = Date.now();
-  await saveCachedArtists();
-  console.log(
-    LoggerPrefix,
-    `skip-ai-music: loaded ${communityArtists.length} community artists at ${minScoreFromConfig()}%+`,
-  );
-  return communityArtists;
+      const data: unknown = await response.json();
+      const artists = parseCommunityArtists(data);
+      if (artists.length == 0) {
+        throw new Error('Community list was empty');
+      }
+
+      scoredArtists = artists;
+      applyScoreFilter();
+      communityFetchedAt = Date.now();
+      await saveCachedArtists();
+      console.log(
+        LoggerPrefix,
+        `skip-ai-music: loaded ${communityArtists.length} community artists at ${minScoreFromConfig()}%+`,
+      );
+      return communityArtists;
+    } finally {
+      refreshInFlight = null;
+    }
+  })();
+
+  return refreshInFlight;
 };
 
 const clearSkipTimer = () => {
@@ -244,7 +260,7 @@ const maybeSkip = (window: Electron.BrowserWindow, songInfo: SongInfo) => {
   const result = shouldSkipTrack(
     { artist: songInfo.artist, title: songInfo.title },
     pluginConfig,
-    communityArtists,
+    communityArtistSet,
   );
 
   if (!result.skip) {
@@ -334,15 +350,15 @@ export const backend = createBackend<
   },
   SkipAiMusicPluginConfig
 >({
-  async start({ getConfig, window }) {
-    if (store.get('plugins.skip-ai-music.showPlayerButtons') != null) {
-      store.delete('plugins.skip-ai-music.showPlayerButtons');
-    }
-
+  async start({ getConfig, setConfig, window }) {
     pluginConfig = await getConfig();
-    pluginConfig.communityMinScore = clampCommunityMinScore(
+    const clampedScore = clampCommunityMinScore(
       pluginConfig.communityMinScore,
     );
+    if (clampedScore != pluginConfig.communityMinScore) {
+      await setConfig({ communityMinScore: clampedScore });
+      pluginConfig.communityMinScore = clampedScore;
+    }
     pluginWindow = window;
     await loadCachedArtists();
 

--- a/src/plugins/skip-ai-music/editor-utils.ts
+++ b/src/plugins/skip-ai-music/editor-utils.ts
@@ -1,0 +1,37 @@
+import { writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { app } from 'electron';
+
+let preloadPath: string | null = null;
+
+export const serializeEditorPayload = (payload: Record<string, unknown>) =>
+  JSON.stringify(payload).replace(/</g, '\\u003c');
+
+export const getEditorPreloadPath = async () => {
+  if (preloadPath) {
+    return preloadPath;
+  }
+
+  const file = path.join(
+    app.getPath('temp'),
+    'skip-ai-music-editor-preload.js',
+  );
+  await writeFile(
+    file,
+    `const { contextBridge, ipcRenderer } = require('electron');
+contextBridge.exposeInMainWorld('skipAiMusicEditor', {
+  send: (channel, value) => ipcRenderer.send(channel, value),
+});
+`,
+    'utf8',
+  );
+  preloadPath = file;
+  return file;
+};
+
+export const editorWebPreferences = async () => ({
+  preload: await getEditorPreloadPath(),
+  contextIsolation: true,
+  nodeIntegration: false,
+});

--- a/src/plugins/skip-ai-music/index.ts
+++ b/src/plugins/skip-ai-music/index.ts
@@ -1,0 +1,20 @@
+import { t } from '@/i18n';
+import { createPlugin } from '@/utils';
+
+import { backend } from './backend';
+import { onMenu } from './menu';
+import { renderer } from './renderer';
+import style from './style.css?inline';
+import { defaultConfig } from './types';
+
+export default createPlugin({
+  name: () => t('plugins.skip-ai-music.name'),
+  description: () => t('plugins.skip-ai-music.description'),
+  restartNeeded: false,
+  addedVersion: '3.12.X',
+  config: defaultConfig,
+  stylesheets: [style],
+  menu: onMenu,
+  backend,
+  renderer,
+});

--- a/src/plugins/skip-ai-music/list-editor.ts
+++ b/src/plugins/skip-ai-music/list-editor.ts
@@ -363,68 +363,78 @@ export const promptStringList = (
   options: ListEditorOptions,
 ): Promise<string[] | null> =>
   new Promise((resolve) => {
-    void (async () => {
-    const channel = `skip-ai-music-list-editor:${Date.now()}-${Math.random()}`;
-    const { icon } = promptOptions();
-    let settled = false;
-    const file = path.join(
-      app.getPath('temp'),
-      `skip-ai-music-list-${Date.now()}.html`,
-    );
-    const editor = new BrowserWindow({
-      parent,
-      modal: true,
-      width: 480,
-      height: 540,
-      minWidth: 400,
-      minHeight: 420,
-      show: false,
-      autoHideMenuBar: true,
-      title: options.title,
-      icon: icon || undefined,
-      backgroundColor: '#0f0f0f',
-      webPreferences: await editorWebPreferences(),
-    });
+    const run = async () => {
+      const channel = `skip-ai-music-list-editor:${Date.now()}-${Math.random()}`;
+      const { icon } = promptOptions();
+      let settled = false;
+      let editor: BrowserWindow | undefined;
+      const file = path.join(
+        app.getPath('temp'),
+        `skip-ai-music-list-${Date.now()}.html`,
+      );
 
-    const finish = (value: string[] | null) => {
-      if (settled) {
-        return;
+      const finish = (value: string[] | null) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        ipcMain.removeAllListeners(channel);
+        unlink(file).catch(() => {});
+        if (editor && !editor.isDestroyed()) {
+          editor.destroy();
+        }
+        resolve(value);
+      };
+
+      try {
+        const webPreferences = await editorWebPreferences();
+        editor = new BrowserWindow({
+          parent,
+          modal: true,
+          width: 480,
+          height: 540,
+          minWidth: 400,
+          minHeight: 420,
+          show: false,
+          autoHideMenuBar: true,
+          title: options.title,
+          icon: icon || undefined,
+          backgroundColor: '#0f0f0f',
+          webPreferences,
+        });
+
+        ipcMain.once(channel, (_event, value: string[] | null) => {
+          finish(Array.isArray(value) ? value : null);
+        });
+
+        editor.once('closed', () => {
+          finish(null);
+        });
+
+        editor.once('ready-to-show', () => {
+          if (editor && !editor.isDestroyed()) {
+            editor.show();
+          }
+        });
+
+        editor.setMenu(null);
+        await writeFile(
+          file,
+          editorHtml({
+            ...options,
+            channel,
+          }),
+          'utf8',
+        );
+        await editor.loadFile(file);
+      } catch (error: unknown) {
+        console.error(error);
+        finish(null);
       }
-      settled = true;
-      ipcMain.removeAllListeners(channel);
-      unlink(file).catch(() => {});
-      if (!editor.isDestroyed()) {
-        editor.destroy();
-      }
-      resolve(value);
     };
 
-    ipcMain.once(channel, (_event, value: string[] | null) => {
-      finish(Array.isArray(value) ? value : null);
-    });
-
-    editor.once('closed', () => {
-      finish(null);
-    });
-
-    editor.once('ready-to-show', () => {
-      editor.show();
-    });
-
-    editor.setMenu(null);
-    try {
-      await writeFile(
-        file,
-        editorHtml({
-          ...options,
-          channel,
-        }),
-        'utf8',
-      );
-      await editor.loadFile(file);
-    } catch (error: unknown) {
+    run().catch((error: unknown) => {
       console.error(error);
-      finish(null);
-    }
-    })();
+      resolve(null);
+    });
   });

--- a/src/plugins/skip-ai-music/list-editor.ts
+++ b/src/plugins/skip-ai-music/list-editor.ts
@@ -1,0 +1,423 @@
+import { unlink, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { app, BrowserWindow, ipcMain } from 'electron';
+
+import promptOptions from '@/providers/prompt-options';
+
+export type ListEditorOptions = {
+  addLabel: string;
+  cancelLabel: string;
+  description: string;
+  duplicateLabel: string;
+  emptyLabel: string;
+  placeholder: string;
+  removeLabel: string;
+  removeNamedLabel: string;
+  saveLabel: string;
+  title: string;
+  values: string[];
+};
+
+const editorHtml = (payload: Record<string, unknown>) => `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title></title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #0f0f0f;
+      --panel: #181818;
+      --border: rgba(255, 255, 255, 0.1);
+      --text: #f1f1f1;
+      --muted: #aaa;
+      --accent: #3ea6ff;
+    }
+    * {
+      box-sizing: border-box;
+    }
+    html, body {
+      margin: 0;
+      height: 100%;
+      background: var(--bg);
+      color: var(--text);
+      font: 14px/1.5 "Segoe UI", -apple-system, BlinkMacSystemFont, Roboto, sans-serif;
+    }
+    body {
+      display: flex;
+      flex-direction: column;
+      padding: 14px;
+    }
+    #container {
+      display: flex;
+      flex-direction: column;
+      flex: 1;
+      min-height: 0;
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      overflow: hidden;
+    }
+    #content {
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+      padding: 20px 20px 16px;
+      flex: 1;
+      min-height: 0;
+    }
+    #header {
+      text-align: center;
+    }
+    h1 {
+      margin: 0 0 6px;
+      font-size: 18px;
+      font-weight: 650;
+    }
+    #description {
+      margin: 0;
+      color: var(--muted);
+      font-size: 13px;
+      max-width: 36ch;
+      margin-inline: auto;
+    }
+    #count {
+      font-size: 12px;
+      color: var(--muted);
+      text-align: right;
+    }
+    #list-wrap {
+      flex: 1;
+      min-height: 160px;
+      overflow: auto;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: rgba(0, 0, 0, 0.25);
+    }
+    #list {
+      margin: 0;
+    }
+    #empty {
+      margin: 0;
+      padding: 28px 16px;
+      color: var(--muted);
+      text-align: center;
+      font-size: 13px;
+    }
+    .row {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 9px 12px;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+    }
+    .row:last-child {
+      border-bottom: 0;
+    }
+    .name {
+      flex: 1;
+      overflow-wrap: anywhere;
+      font-size: 13px;
+    }
+    #add-form {
+      display: flex;
+      gap: 8px;
+    }
+    #add-form label {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+    input, button {
+      font: inherit;
+    }
+    #item-input {
+      flex: 1;
+      min-width: 0;
+      color: var(--text);
+      background: rgba(0, 0, 0, 0.35);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 9px 11px;
+    }
+    #item-input:focus {
+      outline: none;
+      border-color: rgba(255, 255, 255, 0.22);
+    }
+    button {
+      cursor: pointer;
+      border-radius: 999px;
+      padding: 9px 14px;
+    }
+    .row-remove {
+      color: var(--muted);
+      background: transparent;
+      border: 1px solid transparent;
+      padding: 4px 10px;
+      font-size: 12px;
+    }
+    .row-remove:hover, .row-remove:focus-visible {
+      color: var(--text);
+      border-color: var(--border);
+      outline: none;
+    }
+    #add {
+      color: var(--text);
+      background: rgba(255, 255, 255, 0.06);
+      border: 1px solid var(--border);
+      white-space: nowrap;
+    }
+    #add:hover, #add:focus-visible {
+      background: rgba(255, 255, 255, 0.1);
+      outline: none;
+    }
+    #actions {
+      display: flex;
+      justify-content: flex-end;
+      gap: 10px;
+      padding: 14px 18px;
+      border-top: 1px solid var(--border);
+      background: rgba(0, 0, 0, 0.2);
+    }
+    #cancel {
+      color: var(--text);
+      background: transparent;
+      border: 1px solid var(--border);
+      min-width: 96px;
+    }
+    #cancel:hover, #cancel:focus-visible {
+      background: rgba(255, 255, 255, 0.06);
+      outline: none;
+    }
+    #save {
+      color: #fff;
+      background: #ff0033;
+      border: 1px solid #ff0033;
+      font-weight: 600;
+      min-width: 96px;
+    }
+    #save:hover, #save:focus-visible {
+      background: #ff3355;
+      border-color: #ff3355;
+      outline: none;
+    }
+    #status {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+    }
+  </style>
+</head>
+<body>
+  <div id="container">
+    <div id="content">
+      <div id="header">
+        <h1 id="title"></h1>
+        <p id="description"></p>
+      </div>
+      <div id="count"></div>
+      <div id="list-wrap">
+        <div id="list" role="list"></div>
+        <p id="empty" hidden></p>
+      </div>
+      <form id="add-form">
+        <label for="item-input"></label>
+        <input id="item-input" type="text" autocomplete="off" />
+        <button id="add" type="submit"></button>
+      </form>
+      <div id="status" aria-live="polite"></div>
+    </div>
+    <div id="actions">
+      <button id="cancel" type="button"></button>
+      <button id="save" type="button"></button>
+    </div>
+  </div>
+  <script>
+    const payload = ${JSON.stringify(payload)};
+    const { ipcRenderer } = require('electron');
+    const items = [...payload.values];
+    const list = document.getElementById('list');
+    const empty = document.getElementById('empty');
+    const count = document.getElementById('count');
+    const input = document.getElementById('item-input');
+    const status = document.getElementById('status');
+
+    document.title = payload.title;
+    document.getElementById('title').textContent = payload.title;
+    document.getElementById('description').textContent = payload.description;
+    empty.textContent = payload.emptyLabel;
+    document.querySelector('#add-form label').textContent = payload.placeholder;
+    input.placeholder = payload.placeholder;
+    document.getElementById('add').textContent = payload.addLabel;
+    document.getElementById('cancel').textContent = payload.cancelLabel;
+    document.getElementById('save').textContent = payload.saveLabel;
+
+    const close = (value) => {
+      ipcRenderer.send(payload.channel, value);
+    };
+
+    const sameName = (left, right) =>
+      left.trim().toLowerCase() == right.trim().toLowerCase();
+
+    const sortItems = () => {
+      items.sort((left, right) =>
+        left.localeCompare(right, undefined, { sensitivity: 'base' }),
+      );
+    };
+
+    const render = () => {
+      sortItems();
+      list.replaceChildren();
+      empty.hidden = items.length > 0;
+      count.textContent = items.length > 0 ? items.length + ' entries' : '';
+
+      for (const name of items) {
+        const row = document.createElement('div');
+        row.className = 'row';
+        row.setAttribute('role', 'listitem');
+
+        const label = document.createElement('span');
+        label.className = 'name';
+        label.textContent = name;
+
+        const remove = document.createElement('button');
+        remove.type = 'button';
+        remove.className = 'row-remove';
+        remove.textContent = payload.removeLabel;
+        remove.setAttribute(
+          'aria-label',
+          payload.removeNamedLabel.replace('{name}', name),
+        );
+        remove.addEventListener('click', () => {
+          const index = items.findIndex((item) => sameName(item, name));
+          if (index >= 0) {
+            items.splice(index, 1);
+            status.textContent = payload.removeNamedLabel.replace('{name}', name);
+            render();
+            input.focus();
+          }
+        });
+
+        row.append(label, remove);
+        list.append(row);
+      }
+    };
+
+    document.getElementById('add-form').addEventListener('submit', (event) => {
+      event.preventDefault();
+      const value = input.value.trim();
+      if (!value) {
+        return;
+      }
+      if (items.some((item) => sameName(item, value))) {
+        status.textContent = payload.duplicateLabel.replace('{name}', value);
+        input.select();
+        return;
+      }
+      items.push(value);
+      input.value = '';
+      status.textContent = value;
+      render();
+      input.focus();
+    });
+
+    document.getElementById('cancel').addEventListener('click', () => close(null));
+    document.getElementById('save').addEventListener('click', () => {
+      sortItems();
+      close(items);
+    });
+    window.addEventListener('keydown', (event) => {
+      if (event.key == 'Escape') {
+        close(null);
+      }
+      if (event.key == 'Enter' && document.activeElement != input) {
+        sortItems();
+        close(items);
+      }
+    });
+
+    render();
+    input.focus();
+  </script>
+</body>
+</html>
+`;
+
+export const promptStringList = (
+  parent: Electron.BrowserWindow,
+  options: ListEditorOptions,
+): Promise<string[] | null> =>
+  new Promise((resolve) => {
+    const channel = `skip-ai-music-list-editor:${Date.now()}-${Math.random()}`;
+    const { icon } = promptOptions();
+    let settled = false;
+    const file = path.join(
+      app.getPath('temp'),
+      `skip-ai-music-list-${Date.now()}.html`,
+    );
+    const editor = new BrowserWindow({
+      parent,
+      modal: true,
+      width: 480,
+      height: 540,
+      minWidth: 400,
+      minHeight: 420,
+      show: false,
+      autoHideMenuBar: true,
+      title: options.title,
+      icon: icon || undefined,
+      backgroundColor: '#0f0f0f',
+      webPreferences: {
+        nodeIntegration: true,
+        contextIsolation: false,
+      },
+    });
+
+    const finish = (value: string[] | null) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      ipcMain.removeAllListeners(channel);
+      unlink(file).catch(() => {});
+      if (!editor.isDestroyed()) {
+        editor.destroy();
+      }
+      resolve(value);
+    };
+
+    ipcMain.once(channel, (_event, value: string[] | null) => {
+      finish(Array.isArray(value) ? value : null);
+    });
+
+    editor.once('closed', () => {
+      finish(null);
+    });
+
+    editor.once('ready-to-show', () => {
+      editor.show();
+    });
+
+    editor.setMenu(null);
+    writeFile(
+      file,
+      editorHtml({
+        ...options,
+        channel,
+      }),
+      'utf8',
+    )
+      .then(() => editor.loadFile(file))
+      .catch((error: unknown) => {
+        console.error(error);
+        finish(null);
+      });
+  });

--- a/src/plugins/skip-ai-music/match.test.ts
+++ b/src/plugins/skip-ai-music/match.test.ts
@@ -1,0 +1,112 @@
+import { expect, test } from '@playwright/test';
+
+import { hasWholePhrase, shouldSkipTrack, splitArtists } from './match';
+import { defaultConfig, type SkipAiMusicPluginConfig } from './types';
+
+const config = (
+  overrides: Partial<SkipAiMusicPluginConfig> = {},
+): SkipAiMusicPluginConfig => ({
+  ...defaultConfig,
+  ...overrides,
+});
+
+test('blocking Prince does not block Princess Nokia', () => {
+  const result = shouldSkipTrack(
+    { artist: 'Princess Nokia', title: 'Mine' },
+    config({ blockedArtists: ['Prince'] }),
+  );
+
+  expect(result.skip).toBe(false);
+});
+
+test('exact artist match skips the track', () => {
+  const result = shouldSkipTrack(
+    { artist: 'Fake AI Band', title: 'A Song' },
+    config({ blockedArtists: ['Fake AI Band'] }),
+  );
+
+  expect(result.skip).toBe(true);
+  expect(result.reason).toBe('blocked-artist');
+});
+
+test('featured artists are matched independently', () => {
+  const result = shouldSkipTrack(
+    { artist: 'Real Artist feat. Fake AI Band', title: 'Collab' },
+    config({ blockedArtists: ['Fake AI Band'] }),
+  );
+
+  expect(result.skip).toBe(true);
+  expect(result.reason).toBe('blocked-artist');
+});
+
+test('community artists skip unless allowlisted', () => {
+  const skipped = shouldSkipTrack(
+    { artist: 'Slop Studio', title: 'Track' },
+    config({ useCommunityList: true }),
+    ['Slop Studio'],
+  );
+  expect(skipped.skip).toBe(true);
+  expect(skipped.reason).toBe('community-artist');
+
+  const allowed = shouldSkipTrack(
+    { artist: 'Slop Studio', title: 'Track' },
+    config({ allowedArtists: ['Slop Studio'], useCommunityList: true }),
+    ['Slop Studio'],
+  );
+  expect(allowed.skip).toBe(false);
+  expect(allowed.reason).toBe('allowed-artist');
+});
+
+test('blocked songs require both title and artist', () => {
+  const blocked = shouldSkipTrack(
+    { artist: 'Original', title: 'Cover Song' },
+    config({
+      blockedSongs: [{ artist: 'Original', title: 'Cover Song' }],
+    }),
+  );
+  expect(blocked.skip).toBe(true);
+
+  const cover = shouldSkipTrack(
+    { artist: 'Someone Else', title: 'Cover Song' },
+    config({
+      blockedSongs: [{ artist: 'Original', title: 'Cover Song' }],
+    }),
+  );
+  expect(cover.skip).toBe(false);
+});
+
+test('keywords use whole-phrase matching', () => {
+  expect(hasWholePhrase('Song (Sped Up)', 'sped up')).toBe(true);
+  expect(hasWholePhrase('Afterpiece', 'after')).toBe(false);
+
+  const result = shouldSkipTrack(
+    { artist: 'Band', title: 'Hit (Sped Up)' },
+    config({ blockedKeywords: ['sped up'] }),
+  );
+  expect(result.skip).toBe(true);
+  expect(result.reason).toBe('keyword');
+});
+
+test('common AI keywords are opt-in', () => {
+  const off = shouldSkipTrack(
+    { artist: 'Band', title: 'Love (AI Cover)' },
+    config({ skipCommonKeywords: false }),
+  );
+  expect(off.skip).toBe(false);
+
+  const on = shouldSkipTrack(
+    { artist: 'Band', title: 'Love (AI Cover)' },
+    config({ skipCommonKeywords: true }),
+  );
+  expect(on.skip).toBe(true);
+  expect(on.matched).toBe('ai cover');
+});
+
+test('splitArtists keeps the full byline and each credited name', () => {
+  expect(splitArtists('A & B feat. C • Topic')).toEqual([
+    'a & b feat. c',
+    'a',
+    'b',
+    'c',
+  ]);
+});

--- a/src/plugins/skip-ai-music/match.test.ts
+++ b/src/plugins/skip-ai-music/match.test.ts
@@ -75,6 +75,30 @@ test('blocked songs require both title and artist', () => {
   expect(cover.skip).toBe(false);
 });
 
+test('blocked songs match featured artist tokens', () => {
+  const result = shouldSkipTrack(
+    { artist: 'Original feat. Someone', title: 'Cover Song' },
+    config({
+      blockedSongs: [{ artist: 'Original', title: 'Cover Song' }],
+    }),
+  );
+
+  expect(result.skip).toBe(true);
+  expect(result.reason).toBe('blocked-song');
+});
+
+test('title-only blocked songs skip any artist', () => {
+  const result = shouldSkipTrack(
+    { artist: 'Anyone', title: 'Cover Song' },
+    config({
+      blockedSongs: [{ artist: '', title: 'Cover Song' }],
+    }),
+  );
+
+  expect(result.skip).toBe(true);
+  expect(result.reason).toBe('blocked-song');
+});
+
 test('keywords use whole-phrase matching', () => {
   expect(hasWholePhrase('Song (Sped Up)', 'sped up')).toBe(true);
   expect(hasWholePhrase('Afterpiece', 'after')).toBe(false);

--- a/src/plugins/skip-ai-music/match.ts
+++ b/src/plugins/skip-ai-music/match.ts
@@ -1,0 +1,184 @@
+import { COMMON_AI_KEYWORDS, type SkipAiMusicPluginConfig } from './types';
+
+export type SkipMatchInput = {
+  artist: string;
+  title: string;
+};
+
+export type SkipMatchReason =
+  | 'allowed-artist'
+  | 'blocked-artist'
+  | 'blocked-song'
+  | 'community-artist'
+  | 'keyword';
+
+export type SkipMatchResult = {
+  matched?: string;
+  reason?: SkipMatchReason;
+  skip: boolean;
+};
+
+const ARTIST_SPLIT_RE =
+  /\s*(?:,|&|\/| x | feat\.? | ft\.? | featuring | vs\.? | versus )\s*/iu;
+
+const escapeRegExp = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+export const normalizeName = (value: string) =>
+  value.normalize('NFKC').toLowerCase().replace(/\s+/g, ' ').trim();
+
+export const foldName = (value: string) =>
+  normalizeName(value)
+    .replace(/[^\p{L}\p{N}\s]+/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+export const splitArtists = (artist: string): string[] => {
+  const normalized = normalizeName(artist);
+  if (!normalized) {
+    return [];
+  }
+
+  const withoutMeta = normalized.split('•')[0]?.trim() || normalized;
+  const tokens = withoutMeta
+    .split(ARTIST_SPLIT_RE)
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+
+  return [...new Set([withoutMeta, ...tokens])];
+};
+
+export const hasWholePhrase = (haystack: string, needle: string) => {
+  const phrase = normalizeName(needle);
+  if (!phrase) {
+    return false;
+  }
+
+  const source = normalizeName(haystack);
+  const regex = new RegExp(
+    `(^|[^\\p{L}\\p{N}_])${escapeRegExp(phrase)}($|[^\\p{L}\\p{N}_])`,
+    'iu',
+  );
+  return regex.test(source);
+};
+
+const toArtistSet = (artists: string[]) => {
+  const folded = new Set<string>();
+  for (const artist of artists) {
+    const value = foldName(artist);
+    if (value) {
+      folded.add(value);
+    }
+  }
+  return folded;
+};
+
+const songKey = (title: string, artist: string) =>
+  `${foldName(title)}\u0000${foldName(artist)}`;
+
+export const shouldSkipTrack = (
+  input: SkipMatchInput,
+  config: SkipAiMusicPluginConfig,
+  communityArtists: string[] = [],
+): SkipMatchResult => {
+  const title = input.title || '';
+  const artist = input.artist || '';
+  if (!title && !artist) {
+    return { skip: false };
+  }
+
+  const artistTokens = splitArtists(artist);
+  const foldedTokens = artistTokens.map((token) => foldName(token));
+  const allowed = toArtistSet(config.allowedArtists);
+
+  for (const token of foldedTokens) {
+    if (token && allowed.has(token)) {
+      return { matched: token, reason: 'allowed-artist', skip: false };
+    }
+  }
+
+  const blockedSongs = config.blockedSongs || [];
+  const titleFolded = foldName(title);
+  for (const song of blockedSongs) {
+    if (!song || !song.title) {
+      continue;
+    }
+
+    if (songKey(song.title, song.artist || '') == songKey(title, artist)) {
+      return {
+        matched: `${song.artist} - ${song.title}`,
+        reason: 'blocked-song',
+        skip: true,
+      };
+    }
+
+    // Title-only entries still require an artist match when one was stored.
+    if (!song.artist && foldName(song.title) == titleFolded) {
+      return {
+        matched: song.title,
+        reason: 'blocked-song',
+        skip: true,
+      };
+    }
+  }
+
+  const customArtists = toArtistSet(config.blockedArtists);
+  for (let i = 0; i < foldedTokens.length; i++) {
+    const token = foldedTokens[i];
+    if (token && customArtists.has(token)) {
+      return {
+        matched: artistTokens[i],
+        reason: 'blocked-artist',
+        skip: true,
+      };
+    }
+  }
+
+  if (config.useCommunityList) {
+    const community = toArtistSet(communityArtists);
+    for (let i = 0; i < foldedTokens.length; i++) {
+      const token = foldedTokens[i];
+      if (token && community.has(token)) {
+        return {
+          matched: artistTokens[i],
+          reason: 'community-artist',
+          skip: true,
+        };
+      }
+    }
+  }
+
+  const keywords = [
+    ...(config.blockedKeywords || []),
+    ...(config.skipCommonKeywords ? COMMON_AI_KEYWORDS : []),
+  ];
+  for (const keyword of keywords) {
+    if (hasWholePhrase(title, keyword) || hasWholePhrase(artist, keyword)) {
+      return { matched: keyword, reason: 'keyword', skip: true };
+    }
+  }
+
+  return { skip: false };
+};
+
+export const uniqueNormalized = (values: string[]) => {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const value of values) {
+    const normalized = value.trim();
+    if (!normalized) {
+      continue;
+    }
+
+    const key = foldName(normalized);
+    if (!key || seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    result.push(normalized);
+  }
+
+  return result;
+};

--- a/src/plugins/skip-ai-music/match.ts
+++ b/src/plugins/skip-ai-music/match.ts
@@ -73,13 +73,16 @@ const toArtistSet = (artists: string[]) => {
   return folded;
 };
 
+export const buildCommunityArtistSet = (artists: string[]) =>
+  toArtistSet(artists);
+
 const songKey = (title: string, artist: string) =>
   `${foldName(title)}\u0000${foldName(artist)}`;
 
 export const shouldSkipTrack = (
   input: SkipMatchInput,
   config: SkipAiMusicPluginConfig,
-  communityArtists: string[] = [],
+  communityArtists: Set<string> | string[] = [],
 ): SkipMatchResult => {
   const title = input.title || '';
   const artist = input.artist || '';
@@ -99,12 +102,16 @@ export const shouldSkipTrack = (
 
   const blockedSongs = config.blockedSongs || [];
   const titleFolded = foldName(title);
+  const titleKeys = new Set(
+    foldedTokens.map((token) => songKey(title, token)),
+  );
+  titleKeys.add(songKey(title, artist));
   for (const song of blockedSongs) {
     if (!song || !song.title) {
       continue;
     }
 
-    if (songKey(song.title, song.artist || '') == songKey(title, artist)) {
+    if (song.artist && titleKeys.has(songKey(song.title, song.artist))) {
       return {
         matched: `${song.artist} - ${song.title}`,
         reason: 'blocked-song',
@@ -112,7 +119,7 @@ export const shouldSkipTrack = (
       };
     }
 
-    // Title-only entries still require an artist match when one was stored.
+    // Entries stored without an artist match on title alone.
     if (!song.artist && foldName(song.title) == titleFolded) {
       return {
         matched: song.title,
@@ -135,7 +142,10 @@ export const shouldSkipTrack = (
   }
 
   if (config.useCommunityList) {
-    const community = toArtistSet(communityArtists);
+    const community =
+      communityArtists instanceof Set
+        ? communityArtists
+        : toArtistSet(communityArtists);
     for (let i = 0; i < foldedTokens.length; i++) {
       const token = foldedTokens[i];
       if (token && community.has(token)) {

--- a/src/plugins/skip-ai-music/menu.ts
+++ b/src/plugins/skip-ai-music/menu.ts
@@ -3,6 +3,7 @@ import { t } from '@/i18n';
 import { refreshCommunityArtists, getCommunityStatus } from './backend';
 import { promptStringList } from './list-editor';
 import { uniqueNormalized } from './match';
+import { promptSongList } from './song-list-editor';
 import { promptThreshold } from './threshold-picker';
 import {
   clampCommunityMinScore,
@@ -12,11 +13,32 @@ import {
 import type { MenuTemplate } from '@/menu';
 import type { MenuContext } from '@/types/contexts';
 
-const songLabel = (song: BlockedSong) => {
-  if (song.artist && song.title) {
-    return `${song.artist} - ${song.title}`;
-  }
-  return song.title || song.artist;
+const promptBlockedSongs = async (
+  window: Electron.BrowserWindow,
+  songs: BlockedSong[],
+) => {
+  const output = await promptSongList(window, {
+    title: t('plugins.skip-ai-music.prompt.blocked-songs.title'),
+    description: t('plugins.skip-ai-music.prompt.blocked-songs.description'),
+    artistPlaceholder: t(
+      'plugins.skip-ai-music.prompt.blocked-songs.artist-placeholder',
+    ),
+    titlePlaceholder: t(
+      'plugins.skip-ai-music.prompt.blocked-songs.title-placeholder',
+    ),
+    songs,
+    addLabel: t('plugins.skip-ai-music.prompt.list-editor.add'),
+    cancelLabel: t('plugins.skip-ai-music.prompt.list-editor.cancel'),
+    duplicateLabel: t('plugins.skip-ai-music.prompt.list-editor.duplicate'),
+    emptyLabel: t('plugins.skip-ai-music.prompt.list-editor.empty'),
+    removeLabel: t('plugins.skip-ai-music.prompt.list-editor.remove'),
+    removeNamedLabel: t(
+      'plugins.skip-ai-music.prompt.list-editor.remove-named',
+    ),
+    saveLabel: t('plugins.skip-ai-music.prompt.list-editor.save'),
+  });
+
+  return output ?? songs;
 };
 
 const promptList = async (
@@ -47,46 +69,6 @@ const promptList = async (
   }
 
   return uniqueNormalized(output);
-};
-
-const promptBlockedSongs = async (
-  window: Electron.BrowserWindow,
-  songs: BlockedSong[],
-) => {
-  const output = await promptStringList(window, {
-    title: t('plugins.skip-ai-music.prompt.blocked-songs.title'),
-    description: t('plugins.skip-ai-music.prompt.blocked-songs.description'),
-    placeholder: t('plugins.skip-ai-music.prompt.blocked-songs.placeholder'),
-    values: songs.map((song) => songLabel(song)),
-    addLabel: t('plugins.skip-ai-music.prompt.list-editor.add'),
-    cancelLabel: t('plugins.skip-ai-music.prompt.list-editor.cancel'),
-    duplicateLabel: t('plugins.skip-ai-music.prompt.list-editor.duplicate'),
-    emptyLabel: t('plugins.skip-ai-music.prompt.list-editor.empty'),
-    removeLabel: t('plugins.skip-ai-music.prompt.list-editor.remove'),
-    removeNamedLabel: t(
-      'plugins.skip-ai-music.prompt.list-editor.remove-named',
-    ),
-    saveLabel: t('plugins.skip-ai-music.prompt.list-editor.save'),
-  });
-
-  if (output == null) {
-    return songs;
-  }
-
-  const next: BlockedSong[] = [];
-  for (const entry of output) {
-    const split = entry.split(' - ');
-    if (split.length >= 2) {
-      const titlePart = split.pop()?.trim() || '';
-      const artistPart = split.join(' - ').trim();
-      if (titlePart) {
-        next.push({ artist: artistPart, title: titlePart });
-        continue;
-      }
-    }
-    next.push({ artist: '', title: entry.trim() });
-  }
-  return next;
 };
 
 export const onMenu = async ({

--- a/src/plugins/skip-ai-music/menu.ts
+++ b/src/plugins/skip-ai-music/menu.ts
@@ -1,0 +1,254 @@
+import { t } from '@/i18n';
+
+import { refreshCommunityArtists, getCommunityStatus } from './backend';
+import { promptStringList } from './list-editor';
+import { uniqueNormalized } from './match';
+import { promptThreshold } from './threshold-picker';
+import {
+  clampCommunityMinScore,
+  type BlockedSong,
+  type SkipAiMusicPluginConfig,
+} from './types';
+import type { MenuTemplate } from '@/menu';
+import type { MenuContext } from '@/types/contexts';
+
+const songLabel = (song: BlockedSong) => {
+  if (song.artist && song.title) {
+    return `${song.artist} - ${song.title}`;
+  }
+  return song.title || song.artist;
+};
+
+const promptList = async (
+  window: Electron.BrowserWindow,
+  title: string,
+  description: string,
+  placeholder: string,
+  values: string[],
+) => {
+  const output = await promptStringList(window, {
+    title,
+    description,
+    placeholder,
+    values,
+    addLabel: t('plugins.skip-ai-music.prompt.list-editor.add'),
+    cancelLabel: t('plugins.skip-ai-music.prompt.list-editor.cancel'),
+    duplicateLabel: t('plugins.skip-ai-music.prompt.list-editor.duplicate'),
+    emptyLabel: t('plugins.skip-ai-music.prompt.list-editor.empty'),
+    removeLabel: t('plugins.skip-ai-music.prompt.list-editor.remove'),
+    removeNamedLabel: t(
+      'plugins.skip-ai-music.prompt.list-editor.remove-named',
+    ),
+    saveLabel: t('plugins.skip-ai-music.prompt.list-editor.save'),
+  });
+
+  if (output == null) {
+    return values;
+  }
+
+  return uniqueNormalized(output);
+};
+
+const promptBlockedSongs = async (
+  window: Electron.BrowserWindow,
+  songs: BlockedSong[],
+) => {
+  const output = await promptStringList(window, {
+    title: t('plugins.skip-ai-music.prompt.blocked-songs.title'),
+    description: t('plugins.skip-ai-music.prompt.blocked-songs.description'),
+    placeholder: t('plugins.skip-ai-music.prompt.blocked-songs.placeholder'),
+    values: songs.map((song) => songLabel(song)),
+    addLabel: t('plugins.skip-ai-music.prompt.list-editor.add'),
+    cancelLabel: t('plugins.skip-ai-music.prompt.list-editor.cancel'),
+    duplicateLabel: t('plugins.skip-ai-music.prompt.list-editor.duplicate'),
+    emptyLabel: t('plugins.skip-ai-music.prompt.list-editor.empty'),
+    removeLabel: t('plugins.skip-ai-music.prompt.list-editor.remove'),
+    removeNamedLabel: t(
+      'plugins.skip-ai-music.prompt.list-editor.remove-named',
+    ),
+    saveLabel: t('plugins.skip-ai-music.prompt.list-editor.save'),
+  });
+
+  if (output == null) {
+    return songs;
+  }
+
+  const next: BlockedSong[] = [];
+  for (const entry of output) {
+    const split = entry.split(' - ');
+    if (split.length >= 2) {
+      const titlePart = split.pop()?.trim() || '';
+      const artistPart = split.join(' - ').trim();
+      if (titlePart) {
+        next.push({ artist: artistPart, title: titlePart });
+        continue;
+      }
+    }
+    next.push({ artist: '', title: entry.trim() });
+  }
+  return next;
+};
+
+export const onMenu = async ({
+  getConfig,
+  setConfig,
+  window,
+  refresh,
+}: MenuContext<SkipAiMusicPluginConfig>): Promise<MenuTemplate> => {
+  const config = await getConfig();
+  const minScore = clampCommunityMinScore(config.communityMinScore);
+  const community = getCommunityStatus();
+  const fetched =
+    community.fetchedAt > 0
+      ? new Date(community.fetchedAt).toLocaleString()
+      : t('plugins.skip-ai-music.menu.zoundhub.never');
+
+  return [
+    {
+      label: t('plugins.skip-ai-music.menu.zoundhub.label'),
+      submenu: [
+        {
+          label: t('plugins.skip-ai-music.menu.use-community-list'),
+          type: 'checkbox',
+          checked: config.useCommunityList,
+          click(item) {
+            setConfig({ useCommunityList: item.checked });
+            refresh();
+          },
+        },
+        {
+          label: t('plugins.skip-ai-music.menu.zoundhub.status', {
+            count: community.count,
+            fetched,
+            score: minScore,
+          }),
+          enabled: false,
+        },
+        {
+          label: t('plugins.skip-ai-music.menu.zoundhub.threshold-value', {
+            score: minScore,
+          }),
+          async click() {
+            const current = await getConfig();
+            const output = await promptThreshold(window, {
+              title: t('plugins.skip-ai-music.prompt.threshold.title'),
+              description: t('plugins.skip-ai-music.prompt.threshold.description'),
+              value: clampCommunityMinScore(current.communityMinScore),
+              valueLabel: t('plugins.skip-ai-music.prompt.threshold.value'),
+              cancelLabel: t('plugins.skip-ai-music.prompt.list-editor.cancel'),
+              saveLabel: t('plugins.skip-ai-music.prompt.list-editor.save'),
+            });
+
+            if (output != null) {
+              const score = clampCommunityMinScore(output);
+              setConfig({ communityMinScore: score });
+              await refreshCommunityArtists(false, score);
+              await refresh();
+            }
+          },
+        },
+        {
+          label: t('plugins.skip-ai-music.menu.zoundhub.refresh'),
+          async click() {
+            await refreshCommunityArtists(true);
+            await refresh();
+          },
+        },
+      ],
+    },
+    { type: 'separator' },
+    {
+      label: t('plugins.skip-ai-music.menu.behavior.label'),
+      submenu: [
+        {
+          label: t('plugins.skip-ai-music.menu.dislike-on-skip'),
+          type: 'checkbox',
+          checked: config.dislikeOnSkip,
+          click(item) {
+            setConfig({ dislikeOnSkip: item.checked });
+            refresh();
+          },
+        },
+        {
+          label: t('plugins.skip-ai-music.menu.skip-common-keywords'),
+          type: 'checkbox',
+          checked: config.skipCommonKeywords,
+          click(item) {
+            setConfig({ skipCommonKeywords: item.checked });
+            refresh();
+          },
+        },
+      ],
+    },
+    { type: 'separator' },
+    {
+      label: t('plugins.skip-ai-music.menu.blocked-artists.label', {
+        count: config.blockedArtists.length,
+      }),
+      async click() {
+        const current = await getConfig();
+        setConfig({
+          blockedArtists: await promptList(
+            window,
+            t('plugins.skip-ai-music.prompt.blocked-artists.title'),
+            t('plugins.skip-ai-music.prompt.blocked-artists.description'),
+            t('plugins.skip-ai-music.prompt.blocked-artists.placeholder'),
+            current.blockedArtists,
+          ),
+        });
+        await refresh();
+      },
+    },
+    {
+      label: t('plugins.skip-ai-music.menu.blocked-songs.label', {
+        count: config.blockedSongs.length,
+      }),
+      async click() {
+        const current = await getConfig();
+        setConfig({
+          blockedSongs: await promptBlockedSongs(
+            window,
+            current.blockedSongs,
+          ),
+        });
+        await refresh();
+      },
+    },
+    {
+      label: t('plugins.skip-ai-music.menu.keywords.label', {
+        count: config.blockedKeywords.length,
+      }),
+      async click() {
+        const current = await getConfig();
+        setConfig({
+          blockedKeywords: await promptList(
+            window,
+            t('plugins.skip-ai-music.prompt.keywords.title'),
+            t('plugins.skip-ai-music.prompt.keywords.description'),
+            t('plugins.skip-ai-music.prompt.keywords.placeholder'),
+            current.blockedKeywords,
+          ),
+        });
+        await refresh();
+      },
+    },
+    {
+      label: t('plugins.skip-ai-music.menu.allowed-artists.label', {
+        count: config.allowedArtists.length,
+      }),
+      async click() {
+        const current = await getConfig();
+        setConfig({
+          allowedArtists: await promptList(
+            window,
+            t('plugins.skip-ai-music.prompt.allowed-artists.title'),
+            t('plugins.skip-ai-music.prompt.allowed-artists.description'),
+            t('plugins.skip-ai-music.prompt.allowed-artists.placeholder'),
+            current.allowedArtists,
+          ),
+        });
+        await refresh();
+      },
+    },
+  ];
+};

--- a/src/plugins/skip-ai-music/renderer.tsx
+++ b/src/plugins/skip-ai-music/renderer.tsx
@@ -1,0 +1,189 @@
+import { render } from 'solid-js/web';
+
+import { t } from '@/i18n';
+import {
+  isMusicOrVideoTrack,
+  isPlayerMenu,
+} from '@/plugins/utils/renderer/check';
+import { getSongMenu } from '@/providers/dom-elements';
+import { getSongInfo } from '@/providers/song-info-front';
+import { waitForElement } from '@/utils/wait-for-element';
+
+import { uniqueNormalized } from './match';
+import { SkipAiMusicMenuItem } from './templates/menu-item';
+
+import type { BlockedSong, SkipAiMusicPluginConfig } from './types';
+import type { RendererContext } from '@/types/contexts';
+
+const ARTIST_ITEM_ID = 'skip-ai-music-block-artist';
+const SONG_ITEM_ID = 'skip-ai-music-block-song';
+
+const PERSON_ICON =
+  'M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z';
+const SONG_ICON =
+  'M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z';
+
+const currentTrack = () => {
+  const info = getSongInfo();
+  const title =
+    info.title ||
+    document.querySelector('ytmusic-player-bar .title')?.textContent?.trim() ||
+    '';
+  const artist =
+    info.artist ||
+    document.querySelector('ytmusic-player-bar .byline')?.textContent?.trim() ||
+    '';
+
+  return { artist, title };
+};
+
+const addUniqueSong = (songs: BlockedSong[], song: BlockedSong) => {
+  const exists = songs.some(
+    (item) =>
+      item.title.toLowerCase() == song.title.toLowerCase() &&
+      item.artist.toLowerCase() == song.artist.toLowerCase(),
+  );
+  if (exists) {
+    return songs;
+  }
+  return [...songs, song];
+};
+
+const closeOpenMenu = () => {
+  document
+    .querySelector<HTMLElement>('tp-yt-iron-overlay-backdrop')
+    ?.click();
+};
+
+const createMenuContainer = (id: string) => {
+  const container = document.createElement('div');
+  container.id = id;
+  container.classList.add(
+    'style-scope',
+    'menu-item',
+    'ytmusic-menu-popup-renderer',
+  );
+  container.setAttribute('aria-disabled', 'false');
+  container.setAttribute('aria-selected', 'false');
+  container.setAttribute('role', 'option');
+  container.setAttribute('tabindex', '-1');
+  return container;
+};
+
+export const renderer = {
+  context: null as RendererContext<SkipAiMusicPluginConfig> | null,
+  artistItem: null as HTMLElement | null,
+  songItem: null as HTMLElement | null,
+  menuObserver: null as MutationObserver | null,
+
+  async start(ctx: RendererContext<SkipAiMusicPluginConfig>) {
+    this.context = ctx;
+
+    this.artistItem = createMenuContainer(ARTIST_ITEM_ID);
+    render(
+      () => (
+        <SkipAiMusicMenuItem
+          id={ARTIST_ITEM_ID}
+          label={t('plugins.skip-ai-music.renderer.block-artist')}
+          pathD={PERSON_ICON}
+          onClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            this.blockArtist();
+            closeOpenMenu();
+          }}
+        />
+      ),
+      this.artistItem,
+    );
+
+    this.songItem = createMenuContainer(SONG_ITEM_ID);
+    render(
+      () => (
+        <SkipAiMusicMenuItem
+          id={SONG_ITEM_ID}
+          label={t('plugins.skip-ai-music.renderer.block-song')}
+          pathD={SONG_ICON}
+          onClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            this.blockSong();
+            closeOpenMenu();
+          }}
+        />
+      ),
+      this.songItem,
+    );
+
+    const popup = await waitForElement<HTMLElement>('ytmusic-popup-container');
+    this.menuObserver = new MutationObserver(() => {
+      this.injectMenuItems();
+    });
+    this.menuObserver.observe(popup, {
+      childList: true,
+      subtree: true,
+    });
+  },
+
+  injectMenuItems() {
+    const menu = getSongMenu();
+    if (
+      !menu ||
+      !this.artistItem ||
+      !this.songItem ||
+      !isMusicOrVideoTrack() ||
+      !isPlayerMenu(menu)
+    ) {
+      return;
+    }
+
+    if (!menu.contains(this.artistItem)) {
+      menu.append(this.artistItem);
+    }
+    if (!menu.contains(this.songItem)) {
+      menu.append(this.songItem);
+    }
+  },
+
+  async blockArtist() {
+    if (!this.context) {
+      return;
+    }
+
+    const { artist } = currentTrack();
+    if (!artist) {
+      return;
+    }
+
+    const config = await this.context.getConfig();
+    await this.context.setConfig({
+      blockedArtists: uniqueNormalized([...config.blockedArtists, artist]),
+    });
+  },
+
+  async blockSong() {
+    if (!this.context) {
+      return;
+    }
+
+    const song = currentTrack();
+    if (!song.title) {
+      return;
+    }
+
+    const config = await this.context.getConfig();
+    await this.context.setConfig({
+      blockedSongs: addUniqueSong(config.blockedSongs, song),
+    });
+  },
+
+  stop() {
+    this.menuObserver?.disconnect();
+    this.menuObserver = null;
+    this.artistItem?.remove();
+    this.songItem?.remove();
+    this.artistItem = null;
+    this.songItem = null;
+    this.context = null;
+  },
+};

--- a/src/plugins/skip-ai-music/song-list-editor.ts
+++ b/src/plugins/skip-ai-music/song-list-editor.ts
@@ -262,19 +262,17 @@ const editorHtml = (payload: Record<string, unknown>) => {
 
         const artistField = document.createElement('div');
         artistField.className = 'field';
-        artistField.innerHTML =
-          '<span class="field-label">' +
-          payload.artistPlaceholder +
-          '</span>' +
-          (song.artist || '—');
+        const artistLabel = document.createElement('span');
+        artistLabel.className = 'field-label';
+        artistLabel.textContent = payload.artistPlaceholder;
+        artistField.append(artistLabel, song.artist || '—');
 
         const titleField = document.createElement('div');
         titleField.className = 'field';
-        titleField.innerHTML =
-          '<span class="field-label">' +
-          payload.titlePlaceholder +
-          '</span>' +
-          song.title;
+        const titleLabel = document.createElement('span');
+        titleLabel.className = 'field-label';
+        titleLabel.textContent = payload.titlePlaceholder;
+        titleField.append(titleLabel, song.title);
 
         const remove = document.createElement('button');
         remove.type = 'button';
@@ -348,10 +346,11 @@ export const promptSongList = (
   options: SongListEditorOptions,
 ): Promise<BlockedSong[] | null> =>
   new Promise((resolve) => {
-    void (async () => {
+    const run = async () => {
       const channel = `skip-ai-music-song-editor:${Date.now()}-${Math.random()}`;
       const { icon } = promptOptions();
       let settled = false;
+      let editor: BrowserWindow | undefined;
       const file = path.join(
         app.getPath('temp'),
         `skip-ai-music-songs-${Date.now()}.html`,
@@ -364,52 +363,55 @@ export const promptSongList = (
         settled = true;
         ipcMain.removeAllListeners(channel);
         unlink(file).catch(() => {});
-        if (!editor.isDestroyed()) {
+        if (editor && !editor.isDestroyed()) {
           editor.destroy();
         }
         resolve(value);
       };
 
-      const editor = new BrowserWindow({
-        parent,
-        modal: true,
-        width: 560,
-        height: 560,
-        minWidth: 480,
-        minHeight: 440,
-        show: false,
-        autoHideMenuBar: true,
-        title: options.title,
-        icon: icon || undefined,
-        backgroundColor: '#0f0f0f',
-        webPreferences: await editorWebPreferences(),
-      });
-
-      ipcMain.once(channel, (_event, value: BlockedSong[] | null) => {
-        if (!Array.isArray(value)) {
-          finish(null);
-          return;
-        }
-        finish(
-          value
-            .map((song) => ({
-              artist: String(song?.artist || '').trim(),
-              title: String(song?.title || '').trim(),
-            }))
-            .filter((song) => song.title || song.artist),
-        );
-      });
-
-      editor.once('closed', () => {
-        finish(null);
-      });
-
-      editor.once('ready-to-show', () => {
-        editor.show();
-      });
-
-      editor.setMenu(null);
       try {
+        const webPreferences = await editorWebPreferences();
+        editor = new BrowserWindow({
+          parent,
+          modal: true,
+          width: 560,
+          height: 560,
+          minWidth: 480,
+          minHeight: 440,
+          show: false,
+          autoHideMenuBar: true,
+          title: options.title,
+          icon: icon || undefined,
+          backgroundColor: '#0f0f0f',
+          webPreferences,
+        });
+
+        ipcMain.once(channel, (_event, value: BlockedSong[] | null) => {
+          if (!Array.isArray(value)) {
+            finish(null);
+            return;
+          }
+          finish(
+            value
+              .map((song) => ({
+                artist: String(song?.artist || '').trim(),
+                title: String(song?.title || '').trim(),
+              }))
+              .filter((song) => song.title || song.artist),
+          );
+        });
+
+        editor.once('closed', () => {
+          finish(null);
+        });
+
+        editor.once('ready-to-show', () => {
+          if (editor && !editor.isDestroyed()) {
+            editor.show();
+          }
+        });
+
+        editor.setMenu(null);
         await writeFile(
           file,
           editorHtml({
@@ -423,5 +425,10 @@ export const promptSongList = (
         console.error(error);
         finish(null);
       }
-    })();
+    };
+
+    run().catch((error: unknown) => {
+      console.error(error);
+      resolve(null);
+    });
   });

--- a/src/plugins/skip-ai-music/song-list-editor.ts
+++ b/src/plugins/skip-ai-music/song-list-editor.ts
@@ -9,19 +9,21 @@ import {
   editorWebPreferences,
   serializeEditorPayload,
 } from './editor-utils';
+import type { BlockedSong } from './types';
 
-export type ListEditorOptions = {
+export type SongListEditorOptions = {
   addLabel: string;
+  artistPlaceholder: string;
   cancelLabel: string;
   description: string;
   duplicateLabel: string;
   emptyLabel: string;
-  placeholder: string;
   removeLabel: string;
   removeNamedLabel: string;
   saveLabel: string;
+  songs: BlockedSong[];
   title: string;
-  values: string[];
+  titlePlaceholder: string;
 };
 
 const editorHtml = (payload: Record<string, unknown>) => {
@@ -39,11 +41,8 @@ const editorHtml = (payload: Record<string, unknown>) => {
       --border: rgba(255, 255, 255, 0.1);
       --text: #f1f1f1;
       --muted: #aaa;
-      --accent: #3ea6ff;
     }
-    * {
-      box-sizing: border-box;
-    }
+    * { box-sizing: border-box; }
     html, body {
       margin: 0;
       height: 100%;
@@ -51,11 +50,7 @@ const editorHtml = (payload: Record<string, unknown>) => {
       color: var(--text);
       font: 14px/1.5 "Segoe UI", -apple-system, BlinkMacSystemFont, Roboto, sans-serif;
     }
-    body {
-      display: flex;
-      flex-direction: column;
-      padding: 14px;
-    }
+    body { display: flex; flex-direction: column; padding: 14px; }
     #container {
       display: flex;
       flex-direction: column;
@@ -74,26 +69,16 @@ const editorHtml = (payload: Record<string, unknown>) => {
       flex: 1;
       min-height: 0;
     }
-    #header {
-      text-align: center;
-    }
-    h1 {
-      margin: 0 0 6px;
-      font-size: 18px;
-      font-weight: 650;
-    }
+    #header { text-align: center; }
+    h1 { margin: 0 0 6px; font-size: 18px; font-weight: 650; }
     #description {
       margin: 0;
       color: var(--muted);
       font-size: 13px;
-      max-width: 36ch;
+      max-width: 40ch;
       margin-inline: auto;
     }
-    #count {
-      font-size: 12px;
-      color: var(--muted);
-      text-align: right;
-    }
+    #count { font-size: 12px; color: var(--muted); text-align: right; }
     #list-wrap {
       flex: 1;
       min-height: 160px;
@@ -102,9 +87,7 @@ const editorHtml = (payload: Record<string, unknown>) => {
       border-radius: 8px;
       background: rgba(0, 0, 0, 0.25);
     }
-    #list {
-      margin: 0;
-    }
+    #list { margin: 0; }
     #empty {
       margin: 0;
       padding: 28px 16px;
@@ -113,40 +96,31 @@ const editorHtml = (payload: Record<string, unknown>) => {
       font-size: 13px;
     }
     .row {
-      display: flex;
+      display: grid;
+      grid-template-columns: 1fr 1fr auto;
+      gap: 8px;
       align-items: center;
-      gap: 10px;
       padding: 9px 12px;
       border-bottom: 1px solid rgba(255, 255, 255, 0.05);
     }
-    .row:last-child {
-      border-bottom: 0;
-    }
-    .name {
-      flex: 1;
+    .row:last-child { border-bottom: 0; }
+    .field {
       overflow-wrap: anywhere;
       font-size: 13px;
     }
+    .field-label {
+      display: block;
+      font-size: 10px;
+      color: var(--muted);
+      margin-bottom: 2px;
+    }
     #add-form {
-      display: flex;
+      display: grid;
+      grid-template-columns: 1fr 1fr auto;
       gap: 8px;
     }
-    #add-form label {
-      position: absolute;
-      width: 1px;
-      height: 1px;
-      padding: 0;
-      margin: -1px;
-      overflow: hidden;
-      clip: rect(0, 0, 0, 0);
-      white-space: nowrap;
-      border: 0;
-    }
-    input, button {
-      font: inherit;
-    }
-    #item-input {
-      flex: 1;
+    input, button { font: inherit; }
+    #add-form input {
       min-width: 0;
       color: var(--text);
       background: rgba(0, 0, 0, 0.35);
@@ -154,15 +128,11 @@ const editorHtml = (payload: Record<string, unknown>) => {
       border-radius: 8px;
       padding: 9px 11px;
     }
-    #item-input:focus {
+    #add-form input:focus {
       outline: none;
       border-color: rgba(255, 255, 255, 0.22);
     }
-    button {
-      cursor: pointer;
-      border-radius: 999px;
-      padding: 9px 14px;
-    }
+    button { cursor: pointer; border-radius: 999px; padding: 9px 14px; }
     .row-remove {
       color: var(--muted);
       background: transparent;
@@ -181,10 +151,6 @@ const editorHtml = (payload: Record<string, unknown>) => {
       border: 1px solid var(--border);
       white-space: nowrap;
     }
-    #add:hover, #add:focus-visible {
-      background: rgba(255, 255, 255, 0.1);
-      outline: none;
-    }
     #actions {
       display: flex;
       justify-content: flex-end;
@@ -199,21 +165,12 @@ const editorHtml = (payload: Record<string, unknown>) => {
       border: 1px solid var(--border);
       min-width: 96px;
     }
-    #cancel:hover, #cancel:focus-visible {
-      background: rgba(255, 255, 255, 0.06);
-      outline: none;
-    }
     #save {
       color: #fff;
       background: #ff0033;
       border: 1px solid #ff0033;
       font-weight: 600;
       min-width: 96px;
-    }
-    #save:hover, #save:focus-visible {
-      background: #ff3355;
-      border-color: #ff3355;
-      outline: none;
     }
     #status {
       position: absolute;
@@ -236,8 +193,8 @@ const editorHtml = (payload: Record<string, unknown>) => {
         <p id="empty" hidden></p>
       </div>
       <form id="add-form">
-        <label for="item-input"></label>
-        <input id="item-input" type="text" autocomplete="off" />
+        <input id="artist-input" type="text" autocomplete="off" />
+        <input id="title-input" type="text" autocomplete="off" />
         <button id="add" type="submit"></button>
       </form>
       <div id="status" aria-live="polite"></div>
@@ -249,19 +206,23 @@ const editorHtml = (payload: Record<string, unknown>) => {
   </div>
   <script>
     const payload = ${serializedPayload};
-    const items = [...payload.values];
+    const items = payload.songs.map((song) => ({
+      artist: String(song.artist || '').trim(),
+      title: String(song.title || '').trim(),
+    }));
     const list = document.getElementById('list');
     const empty = document.getElementById('empty');
     const count = document.getElementById('count');
-    const input = document.getElementById('item-input');
+    const artistInput = document.getElementById('artist-input');
+    const titleInput = document.getElementById('title-input');
     const status = document.getElementById('status');
 
     document.title = payload.title;
     document.getElementById('title').textContent = payload.title;
     document.getElementById('description').textContent = payload.description;
     empty.textContent = payload.emptyLabel;
-    document.querySelector('#add-form label').textContent = payload.placeholder;
-    input.placeholder = payload.placeholder;
+    artistInput.placeholder = payload.artistPlaceholder;
+    titleInput.placeholder = payload.titlePlaceholder;
     document.getElementById('add').textContent = payload.addLabel;
     document.getElementById('cancel').textContent = payload.cancelLabel;
     document.getElementById('save').textContent = payload.saveLabel;
@@ -270,12 +231,21 @@ const editorHtml = (payload: Record<string, unknown>) => {
       window.skipAiMusicEditor.send(payload.channel, value);
     };
 
-    const sameName = (left, right) =>
-      left.trim().toLowerCase() == right.trim().toLowerCase();
+    const displayName = (song) => {
+      if (song.artist && song.title) {
+        return song.artist + ' - ' + song.title;
+      }
+      return song.title || song.artist;
+    };
+
+    const songKey = (song) =>
+      (song.artist + '\\u0000' + song.title).trim().toLowerCase();
 
     const sortItems = () => {
       items.sort((left, right) =>
-        left.localeCompare(right, undefined, { sensitivity: 'base' }),
+        displayName(left).localeCompare(displayName(right), undefined, {
+          sensitivity: 'base',
+        }),
       );
     };
 
@@ -285,54 +255,73 @@ const editorHtml = (payload: Record<string, unknown>) => {
       empty.hidden = items.length > 0;
       count.textContent = items.length > 0 ? items.length + ' entries' : '';
 
-      for (const name of items) {
+      for (const song of items) {
         const row = document.createElement('div');
         row.className = 'row';
         row.setAttribute('role', 'listitem');
 
-        const label = document.createElement('span');
-        label.className = 'name';
-        label.textContent = name;
+        const artistField = document.createElement('div');
+        artistField.className = 'field';
+        artistField.innerHTML =
+          '<span class="field-label">' +
+          payload.artistPlaceholder +
+          '</span>' +
+          (song.artist || '—');
+
+        const titleField = document.createElement('div');
+        titleField.className = 'field';
+        titleField.innerHTML =
+          '<span class="field-label">' +
+          payload.titlePlaceholder +
+          '</span>' +
+          song.title;
 
         const remove = document.createElement('button');
         remove.type = 'button';
         remove.className = 'row-remove';
         remove.textContent = payload.removeLabel;
+        const label = displayName(song);
         remove.setAttribute(
           'aria-label',
-          payload.removeNamedLabel.replace('{name}', name),
+          payload.removeNamedLabel.replace('{name}', label),
         );
         remove.addEventListener('click', () => {
-          const index = items.findIndex((item) => sameName(item, name));
+          const index = items.findIndex((item) => songKey(item) == songKey(song));
           if (index >= 0) {
             items.splice(index, 1);
-            status.textContent = payload.removeNamedLabel.replace('{name}', name);
+            status.textContent = payload.removeNamedLabel.replace('{name}', label);
             render();
-            input.focus();
+            titleInput.focus();
           }
         });
 
-        row.append(label, remove);
+        row.append(artistField, titleField, remove);
         list.append(row);
       }
     };
 
     document.getElementById('add-form').addEventListener('submit', (event) => {
       event.preventDefault();
-      const value = input.value.trim();
-      if (!value) {
+      const artist = artistInput.value.trim();
+      const title = titleInput.value.trim();
+      if (!title) {
         return;
       }
-      if (items.some((item) => sameName(item, value))) {
-        status.textContent = payload.duplicateLabel.replace('{name}', value);
-        input.select();
+      const next = { artist, title };
+      if (items.some((item) => songKey(item) == songKey(next))) {
+        status.textContent = payload.duplicateLabel.replace(
+          '{name}',
+          displayName(next),
+        );
+        titleInput.select();
         return;
       }
-      items.push(value);
-      input.value = '';
-      status.textContent = value;
+      items.push(next);
+      artistInput.value = '';
+      titleInput.value = '';
+      status.textContent = displayName(next);
       render();
-      input.focus();
+      titleInput.focus();
     });
 
     document.getElementById('cancel').addEventListener('click', () => close(null));
@@ -344,87 +333,95 @@ const editorHtml = (payload: Record<string, unknown>) => {
       if (event.key == 'Escape') {
         close(null);
       }
-      if (event.key == 'Enter' && document.activeElement != input) {
-        sortItems();
-        close(items);
-      }
     });
 
     render();
-    input.focus();
+    titleInput.focus();
   </script>
 </body>
 </html>
 `;
 };
 
-export const promptStringList = (
+export const promptSongList = (
   parent: Electron.BrowserWindow,
-  options: ListEditorOptions,
-): Promise<string[] | null> =>
+  options: SongListEditorOptions,
+): Promise<BlockedSong[] | null> =>
   new Promise((resolve) => {
     void (async () => {
-    const channel = `skip-ai-music-list-editor:${Date.now()}-${Math.random()}`;
-    const { icon } = promptOptions();
-    let settled = false;
-    const file = path.join(
-      app.getPath('temp'),
-      `skip-ai-music-list-${Date.now()}.html`,
-    );
-    const editor = new BrowserWindow({
-      parent,
-      modal: true,
-      width: 480,
-      height: 540,
-      minWidth: 400,
-      minHeight: 420,
-      show: false,
-      autoHideMenuBar: true,
-      title: options.title,
-      icon: icon || undefined,
-      backgroundColor: '#0f0f0f',
-      webPreferences: await editorWebPreferences(),
-    });
-
-    const finish = (value: string[] | null) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      ipcMain.removeAllListeners(channel);
-      unlink(file).catch(() => {});
-      if (!editor.isDestroyed()) {
-        editor.destroy();
-      }
-      resolve(value);
-    };
-
-    ipcMain.once(channel, (_event, value: string[] | null) => {
-      finish(Array.isArray(value) ? value : null);
-    });
-
-    editor.once('closed', () => {
-      finish(null);
-    });
-
-    editor.once('ready-to-show', () => {
-      editor.show();
-    });
-
-    editor.setMenu(null);
-    try {
-      await writeFile(
-        file,
-        editorHtml({
-          ...options,
-          channel,
-        }),
-        'utf8',
+      const channel = `skip-ai-music-song-editor:${Date.now()}-${Math.random()}`;
+      const { icon } = promptOptions();
+      let settled = false;
+      const file = path.join(
+        app.getPath('temp'),
+        `skip-ai-music-songs-${Date.now()}.html`,
       );
-      await editor.loadFile(file);
-    } catch (error: unknown) {
-      console.error(error);
-      finish(null);
-    }
+
+      const finish = (value: BlockedSong[] | null) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        ipcMain.removeAllListeners(channel);
+        unlink(file).catch(() => {});
+        if (!editor.isDestroyed()) {
+          editor.destroy();
+        }
+        resolve(value);
+      };
+
+      const editor = new BrowserWindow({
+        parent,
+        modal: true,
+        width: 560,
+        height: 560,
+        minWidth: 480,
+        minHeight: 440,
+        show: false,
+        autoHideMenuBar: true,
+        title: options.title,
+        icon: icon || undefined,
+        backgroundColor: '#0f0f0f',
+        webPreferences: await editorWebPreferences(),
+      });
+
+      ipcMain.once(channel, (_event, value: BlockedSong[] | null) => {
+        if (!Array.isArray(value)) {
+          finish(null);
+          return;
+        }
+        finish(
+          value
+            .map((song) => ({
+              artist: String(song?.artist || '').trim(),
+              title: String(song?.title || '').trim(),
+            }))
+            .filter((song) => song.title || song.artist),
+        );
+      });
+
+      editor.once('closed', () => {
+        finish(null);
+      });
+
+      editor.once('ready-to-show', () => {
+        editor.show();
+      });
+
+      editor.setMenu(null);
+      try {
+        await writeFile(
+          file,
+          editorHtml({
+            ...options,
+            channel,
+          }),
+          'utf8',
+        );
+        await editor.loadFile(file);
+      } catch (error: unknown) {
+        console.error(error);
+        finish(null);
+      }
     })();
   });

--- a/src/plugins/skip-ai-music/style.css
+++ b/src/plugins/skip-ai-music/style.css
@@ -1,0 +1,21 @@
+.skip-ai-music-menu-icon {
+  display: var(--ytmusic-menu-item_-_display);
+  height: var(--ytmusic-menu-item_-_height);
+  align-items: var(--ytmusic-menu-item_-_align-items);
+  padding: var(--ytmusic-menu-item_-_padding);
+  cursor: pointer;
+}
+
+.skip-ai-music-menu-icon {
+  flex: var(--ytmusic-menu-item-icon_-_flex);
+  margin: var(--ytmusic-menu-item-icon_-_margin);
+  fill: var(--ytmusic-menu-item-icon_-_fill);
+  stroke: var(--iron-icon-stroke-color, none);
+  width: var(--iron-icon-width, 24px);
+  height: var(--iron-icon-height, 24px);
+}
+
+#skip-ai-music-block-artist .yt-simple-endpoint:hover,
+#skip-ai-music-block-song .yt-simple-endpoint:hover {
+  background-color: var(--ytmusic-menu-item-hover-background-color);
+}

--- a/src/plugins/skip-ai-music/templates/menu-item.tsx
+++ b/src/plugins/skip-ai-music/templates/menu-item.tsx
@@ -35,7 +35,6 @@ export const SkipAiMusicMenuItem = (props: SkipAiMusicMenuItemProps) => (
     </div>
     <div
       class="text style-scope ytmusic-menu-navigation-item-renderer"
-      id={props.id}
     >
       {props.label}
     </div>

--- a/src/plugins/skip-ai-music/templates/menu-item.tsx
+++ b/src/plugins/skip-ai-music/templates/menu-item.tsx
@@ -1,0 +1,43 @@
+export type SkipAiMusicMenuItemProps = {
+  id: string;
+  label: string;
+  onClick?: (event: MouseEvent) => void;
+  pathD: string;
+};
+
+export const SkipAiMusicMenuItem = (props: SkipAiMusicMenuItemProps) => (
+  <a
+    class="yt-simple-endpoint style-scope ytmusic-menu-navigation-item-renderer"
+    id="navigation-endpoint"
+    onClick={(event) => props.onClick?.(event)}
+    tabindex={-1}
+  >
+    <div class="icon skip-ai-music-menu-icon style-scope ytmusic-menu-navigation-item-renderer">
+      <svg
+        class="style-scope yt-icon"
+        preserveAspectRatio="xMidYMid meet"
+        style={{
+          'pointer-events': 'none',
+          'display': 'block',
+          'width': '100%',
+          'height': '100%',
+        }}
+        viewBox="0 0 24 24"
+      >
+        <g class="style-scope yt-icon">
+          <path
+            class="style-scope yt-icon"
+            d={props.pathD}
+            fill="#aaaaaa"
+          />
+        </g>
+      </svg>
+    </div>
+    <div
+      class="text style-scope ytmusic-menu-navigation-item-renderer"
+      id={props.id}
+    >
+      {props.label}
+    </div>
+  </a>
+);

--- a/src/plugins/skip-ai-music/threshold-picker.ts
+++ b/src/plugins/skip-ai-music/threshold-picker.ts
@@ -1,0 +1,346 @@
+import { unlink, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { app, BrowserWindow, ipcMain } from 'electron';
+
+import promptOptions from '@/providers/prompt-options';
+
+export type ThresholdPickerOptions = {
+  cancelLabel: string;
+  description: string;
+  saveLabel: string;
+  title: string;
+  value: number;
+  valueLabel: string;
+};
+
+const pickerHtml = (payload: Record<string, unknown>) => `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title></title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #0f0f0f;
+      --panel: #181818;
+      --border: rgba(255, 255, 255, 0.1);
+      --text: #f1f1f1;
+      --muted: #aaa;
+      --accent: #3ea6ff;
+    }
+    * {
+      box-sizing: border-box;
+    }
+    html, body {
+      margin: 0;
+      height: 100%;
+      background: var(--bg);
+      color: var(--text);
+      font: 14px/1.5 "Segoe UI", -apple-system, BlinkMacSystemFont, Roboto, sans-serif;
+    }
+    body {
+      display: flex;
+      flex-direction: column;
+      padding: 14px;
+    }
+    #container {
+      display: flex;
+      flex-direction: column;
+      flex: 1;
+      min-height: 0;
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      overflow: hidden;
+    }
+    #content {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+      padding: 20px 20px 16px;
+    }
+    #header {
+      text-align: center;
+    }
+    h1 {
+      margin: 0 0 6px;
+      font-size: 18px;
+      font-weight: 650;
+    }
+    #description {
+      margin: 0;
+      color: var(--muted);
+      font-size: 13px;
+      max-width: 34ch;
+      margin-inline: auto;
+    }
+    #value-display {
+      font-size: 32px;
+      font-weight: 700;
+      line-height: 1;
+      color: var(--text);
+      text-align: center;
+    }
+    #slider-block {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      padding: 0 2px;
+    }
+    .slider-shell {
+      position: relative;
+      height: 28px;
+      display: flex;
+      align-items: center;
+    }
+    #slider-track {
+      position: absolute;
+      left: 0;
+      right: 0;
+      height: 6px;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.1);
+      overflow: hidden;
+      pointer-events: none;
+    }
+    #slider-fill {
+      height: 100%;
+      width: 0;
+      border-radius: inherit;
+      background: var(--accent);
+    }
+    #score-slider {
+      -webkit-appearance: none;
+      appearance: none;
+      width: 100%;
+      height: 28px;
+      margin: 0;
+      background: transparent;
+      cursor: pointer;
+    }
+    #score-slider:focus {
+      outline: none;
+    }
+    #score-slider::-webkit-slider-runnable-track {
+      height: 6px;
+      background: transparent;
+    }
+    #score-slider::-webkit-slider-thumb {
+      -webkit-appearance: none;
+      appearance: none;
+      width: 18px;
+      height: 18px;
+      margin-top: -6px;
+      border: 2px solid #fff;
+      border-radius: 50%;
+      background: var(--accent);
+    }
+    #score-slider::-moz-range-track {
+      height: 6px;
+      background: transparent;
+      border: 0;
+    }
+    #score-slider::-moz-range-thumb {
+      width: 18px;
+      height: 18px;
+      border: 2px solid #fff;
+      border-radius: 50%;
+      background: var(--accent);
+    }
+    #slider-labels {
+      display: flex;
+      justify-content: space-between;
+      color: var(--muted);
+      font-size: 11px;
+      font-variant-numeric: tabular-nums;
+    }
+    #actions {
+      display: flex;
+      justify-content: flex-end;
+      gap: 10px;
+      padding: 14px 18px;
+      border-top: 1px solid var(--border);
+      background: rgba(0, 0, 0, 0.2);
+    }
+    button {
+      font: inherit;
+      min-width: 96px;
+      padding: 9px 16px;
+      border-radius: 999px;
+      cursor: pointer;
+    }
+    #cancel {
+      color: var(--text);
+      background: transparent;
+      border: 1px solid var(--border);
+    }
+    #cancel:hover, #cancel:focus-visible {
+      background: rgba(255, 255, 255, 0.06);
+      outline: none;
+    }
+    #save {
+      color: #fff;
+      background: #ff0033;
+      border: 1px solid #ff0033;
+      font-weight: 600;
+    }
+    #save:hover, #save:focus-visible {
+      background: #ff3355;
+      border-color: #ff3355;
+      outline: none;
+    }
+  </style>
+</head>
+<body>
+  <div id="container">
+    <div id="content">
+      <div id="header">
+        <h1 id="title"></h1>
+        <p id="description"></p>
+      </div>
+      <div id="value-display"></div>
+      <div id="slider-block">
+        <div class="slider-shell">
+          <div id="slider-track" aria-hidden="true">
+            <div id="slider-fill"></div>
+          </div>
+          <input id="score-slider" type="range" min="0" max="100" step="1" aria-valuemin="0" aria-valuemax="100" />
+        </div>
+        <div id="slider-labels">
+          <span>0%</span>
+          <span>50%</span>
+          <span>100%</span>
+        </div>
+      </div>
+    </div>
+    <div id="actions">
+      <button id="cancel" type="button"></button>
+      <button id="save" type="button"></button>
+    </div>
+  </div>
+  <script>
+    const payload = ${JSON.stringify(payload)};
+    const { ipcRenderer } = require('electron');
+    const slider = document.getElementById('score-slider');
+    const valueDisplay = document.getElementById('value-display');
+    const sliderFill = document.getElementById('slider-fill');
+
+    document.title = payload.title;
+    document.getElementById('title').textContent = payload.title;
+    document.getElementById('description').textContent = payload.description;
+    document.getElementById('cancel').textContent = payload.cancelLabel;
+    document.getElementById('save').textContent = payload.saveLabel;
+
+    const formatValue = (score) =>
+      payload.valueLabel.replace('{score}', String(score));
+
+    const setValue = (score) => {
+      slider.value = String(score);
+      valueDisplay.textContent = formatValue(score);
+      slider.setAttribute('aria-valuenow', String(score));
+      sliderFill.style.width = score + '%';
+    };
+
+    const close = (value) => {
+      ipcRenderer.send(payload.channel, value);
+    };
+
+    setValue(payload.value);
+    slider.addEventListener('input', () => {
+      setValue(Number(slider.value));
+    });
+
+    document.getElementById('cancel').addEventListener('click', () => close(null));
+    document.getElementById('save').addEventListener('click', () => {
+      close(Number(slider.value));
+    });
+    window.addEventListener('keydown', (event) => {
+      if (event.key == 'Escape') {
+        close(null);
+      }
+      if (event.key == 'Enter') {
+        close(Number(slider.value));
+      }
+    });
+    document.getElementById('save').focus();
+  </script>
+</body>
+</html>
+`;
+
+export const promptThreshold = (
+  parent: Electron.BrowserWindow,
+  options: ThresholdPickerOptions,
+): Promise<number | null> =>
+  new Promise((resolve) => {
+    const channel = `skip-ai-music-threshold:${Date.now()}-${Math.random()}`;
+    const { icon } = promptOptions();
+    let settled = false;
+    const file = path.join(
+      app.getPath('temp'),
+      `skip-ai-music-threshold-${Date.now()}.html`,
+    );
+    const editor = new BrowserWindow({
+      parent,
+      modal: true,
+      width: 440,
+      height: 340,
+      minWidth: 380,
+      minHeight: 320,
+      show: false,
+      resizable: false,
+      autoHideMenuBar: true,
+      title: options.title,
+      icon: icon || undefined,
+      backgroundColor: '#0f0f0f',
+      webPreferences: {
+        nodeIntegration: true,
+        contextIsolation: false,
+      },
+    });
+
+    const finish = (value: number | null) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      ipcMain.removeAllListeners(channel);
+      unlink(file).catch(() => {});
+      if (!editor.isDestroyed()) {
+        editor.destroy();
+      }
+      resolve(value);
+    };
+
+    ipcMain.once(channel, (_event, value: number | null) => {
+      if (value == null || !Number.isFinite(Number(value))) {
+        finish(null);
+        return;
+      }
+      finish(Math.round(Number(value)));
+    });
+
+    editor.once('closed', () => {
+      finish(null);
+    });
+
+    editor.once('ready-to-show', () => {
+      editor.show();
+    });
+
+    editor.setMenu(null);
+    writeFile(
+      file,
+      pickerHtml({
+        ...options,
+        channel,
+      }),
+      'utf8',
+    )
+      .then(() => editor.loadFile(file))
+      .catch((error: unknown) => {
+        console.error(error);
+        finish(null);
+      });
+  });

--- a/src/plugins/skip-ai-music/threshold-picker.ts
+++ b/src/plugins/skip-ai-music/threshold-picker.ts
@@ -5,6 +5,11 @@ import { app, BrowserWindow, ipcMain } from 'electron';
 
 import promptOptions from '@/providers/prompt-options';
 
+import {
+  editorWebPreferences,
+  serializeEditorPayload,
+} from './editor-utils';
+
 export type ThresholdPickerOptions = {
   cancelLabel: string;
   description: string;
@@ -14,7 +19,9 @@ export type ThresholdPickerOptions = {
   valueLabel: string;
 };
 
-const pickerHtml = (payload: Record<string, unknown>) => `<!DOCTYPE html>
+const pickerHtml = (payload: Record<string, unknown>) => {
+  const serializedPayload = serializeEditorPayload(payload);
+  return `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8" />
@@ -220,8 +227,7 @@ const pickerHtml = (payload: Record<string, unknown>) => `<!DOCTYPE html>
     </div>
   </div>
   <script>
-    const payload = ${JSON.stringify(payload)};
-    const { ipcRenderer } = require('electron');
+    const payload = ${serializedPayload};
     const slider = document.getElementById('score-slider');
     const valueDisplay = document.getElementById('value-display');
     const sliderFill = document.getElementById('slider-fill');
@@ -243,7 +249,7 @@ const pickerHtml = (payload: Record<string, unknown>) => `<!DOCTYPE html>
     };
 
     const close = (value) => {
-      ipcRenderer.send(payload.channel, value);
+      window.skipAiMusicEditor.send(payload.channel, value);
     };
 
     setValue(payload.value);
@@ -268,12 +274,14 @@ const pickerHtml = (payload: Record<string, unknown>) => `<!DOCTYPE html>
 </body>
 </html>
 `;
+};
 
 export const promptThreshold = (
   parent: Electron.BrowserWindow,
   options: ThresholdPickerOptions,
 ): Promise<number | null> =>
   new Promise((resolve) => {
+    void (async () => {
     const channel = `skip-ai-music-threshold:${Date.now()}-${Math.random()}`;
     const { icon } = promptOptions();
     let settled = false;
@@ -294,10 +302,7 @@ export const promptThreshold = (
       title: options.title,
       icon: icon || undefined,
       backgroundColor: '#0f0f0f',
-      webPreferences: {
-        nodeIntegration: true,
-        contextIsolation: false,
-      },
+      webPreferences: await editorWebPreferences(),
     });
 
     const finish = (value: number | null) => {
@@ -330,17 +335,19 @@ export const promptThreshold = (
     });
 
     editor.setMenu(null);
-    writeFile(
-      file,
-      pickerHtml({
-        ...options,
-        channel,
-      }),
-      'utf8',
-    )
-      .then(() => editor.loadFile(file))
-      .catch((error: unknown) => {
-        console.error(error);
-        finish(null);
-      });
+    try {
+      await writeFile(
+        file,
+        pickerHtml({
+          ...options,
+          channel,
+        }),
+        'utf8',
+      );
+      await editor.loadFile(file);
+    } catch (error: unknown) {
+      console.error(error);
+      finish(null);
+    }
+    })();
   });

--- a/src/plugins/skip-ai-music/threshold-picker.ts
+++ b/src/plugins/skip-ai-music/threshold-picker.ts
@@ -281,73 +281,83 @@ export const promptThreshold = (
   options: ThresholdPickerOptions,
 ): Promise<number | null> =>
   new Promise((resolve) => {
-    void (async () => {
-    const channel = `skip-ai-music-threshold:${Date.now()}-${Math.random()}`;
-    const { icon } = promptOptions();
-    let settled = false;
-    const file = path.join(
-      app.getPath('temp'),
-      `skip-ai-music-threshold-${Date.now()}.html`,
-    );
-    const editor = new BrowserWindow({
-      parent,
-      modal: true,
-      width: 440,
-      height: 340,
-      minWidth: 380,
-      minHeight: 320,
-      show: false,
-      resizable: false,
-      autoHideMenuBar: true,
-      title: options.title,
-      icon: icon || undefined,
-      backgroundColor: '#0f0f0f',
-      webPreferences: await editorWebPreferences(),
-    });
+    const run = async () => {
+      const channel = `skip-ai-music-threshold:${Date.now()}-${Math.random()}`;
+      const { icon } = promptOptions();
+      let settled = false;
+      let editor: BrowserWindow | undefined;
+      const file = path.join(
+        app.getPath('temp'),
+        `skip-ai-music-threshold-${Date.now()}.html`,
+      );
 
-    const finish = (value: number | null) => {
-      if (settled) {
-        return;
+      const finish = (value: number | null) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        ipcMain.removeAllListeners(channel);
+        unlink(file).catch(() => {});
+        if (editor && !editor.isDestroyed()) {
+          editor.destroy();
+        }
+        resolve(value);
+      };
+
+      try {
+        const webPreferences = await editorWebPreferences();
+        editor = new BrowserWindow({
+          parent,
+          modal: true,
+          width: 440,
+          height: 340,
+          minWidth: 380,
+          minHeight: 320,
+          show: false,
+          resizable: false,
+          autoHideMenuBar: true,
+          title: options.title,
+          icon: icon || undefined,
+          backgroundColor: '#0f0f0f',
+          webPreferences,
+        });
+
+        ipcMain.once(channel, (_event, value: number | null) => {
+          if (value == null || !Number.isFinite(Number(value))) {
+            finish(null);
+            return;
+          }
+          finish(Math.round(Number(value)));
+        });
+
+        editor.once('closed', () => {
+          finish(null);
+        });
+
+        editor.once('ready-to-show', () => {
+          if (editor && !editor.isDestroyed()) {
+            editor.show();
+          }
+        });
+
+        editor.setMenu(null);
+        await writeFile(
+          file,
+          pickerHtml({
+            ...options,
+            channel,
+          }),
+          'utf8',
+        );
+        await editor.loadFile(file);
+      } catch (error: unknown) {
+        console.error(error);
+        finish(null);
       }
-      settled = true;
-      ipcMain.removeAllListeners(channel);
-      unlink(file).catch(() => {});
-      if (!editor.isDestroyed()) {
-        editor.destroy();
-      }
-      resolve(value);
     };
 
-    ipcMain.once(channel, (_event, value: number | null) => {
-      if (value == null || !Number.isFinite(Number(value))) {
-        finish(null);
-        return;
-      }
-      finish(Math.round(Number(value)));
-    });
-
-    editor.once('closed', () => {
-      finish(null);
-    });
-
-    editor.once('ready-to-show', () => {
-      editor.show();
-    });
-
-    editor.setMenu(null);
-    try {
-      await writeFile(
-        file,
-        pickerHtml({
-          ...options,
-          channel,
-        }),
-        'utf8',
-      );
-      await editor.loadFile(file);
-    } catch (error: unknown) {
+    run().catch((error: unknown) => {
       console.error(error);
-      finish(null);
-    }
-    })();
+      resolve(null);
+    });
   });

--- a/src/plugins/skip-ai-music/types.ts
+++ b/src/plugins/skip-ai-music/types.ts
@@ -1,0 +1,61 @@
+export type BlockedSong = {
+  artist: string;
+  title: string;
+};
+
+export type SkipAiMusicPluginConfig = {
+  allowedArtists: string[];
+  blockedArtists: string[];
+  blockedKeywords: string[];
+  blockedSongs: BlockedSong[];
+  dislikeOnSkip: boolean;
+  enabled: boolean;
+  skipCommonKeywords: boolean;
+  useCommunityList: boolean;
+  communityMinScore: number;
+};
+
+export const COMMON_AI_KEYWORDS = [
+  'ai cover',
+  'ai generated',
+  'ai remix',
+  'ai version',
+  'nightcore',
+  'sped up',
+  'suno',
+  'udio',
+];
+
+export const defaultConfig: SkipAiMusicPluginConfig = {
+  allowedArtists: [],
+  blockedArtists: [],
+  blockedKeywords: [],
+  blockedSongs: [],
+  dislikeOnSkip: false,
+  enabled: false,
+  skipCommonKeywords: false,
+  useCommunityList: true,
+  communityMinScore: 90,
+};
+
+export const COMMUNITY_ARTISTS_URL = 'https://zoundhub.com/api/artists/all';
+
+export const DEFAULT_COMMUNITY_MIN_SCORE = 90;
+
+export const COMMUNITY_CACHE_VERSION = 3;
+
+export const clampCommunityMinScore = (value: unknown): number => {
+  const score = Math.round(Number(value));
+  if (!Number.isFinite(score)) {
+    return DEFAULT_COMMUNITY_MIN_SCORE;
+  }
+  if (score < 0) {
+    return 0;
+  }
+  if (score > 100) {
+    return 100;
+  }
+  return score;
+};
+
+export const COMMUNITY_REFRESH_INTERVAL_MS = 24 * 60 * 60 * 1000;

--- a/src/plugins/skip-ai-music/types.ts
+++ b/src/plugins/skip-ai-music/types.ts
@@ -26,6 +26,8 @@ export const COMMON_AI_KEYWORDS = [
   'udio',
 ];
 
+export const DEFAULT_COMMUNITY_MIN_SCORE = 90;
+
 export const defaultConfig: SkipAiMusicPluginConfig = {
   allowedArtists: [],
   blockedArtists: [],
@@ -35,12 +37,10 @@ export const defaultConfig: SkipAiMusicPluginConfig = {
   enabled: false,
   skipCommonKeywords: false,
   useCommunityList: true,
-  communityMinScore: 90,
+  communityMinScore: DEFAULT_COMMUNITY_MIN_SCORE,
 };
 
 export const COMMUNITY_ARTISTS_URL = 'https://zoundhub.com/api/artists/all';
-
-export const DEFAULT_COMMUNITY_MIN_SCORE = 90;
 
 export const COMMUNITY_CACHE_VERSION = 3;
 

--- a/src/providers/song-info.ts
+++ b/src/providers/song-info.ts
@@ -187,6 +187,10 @@ export const registerCallback = (callback: SongInfoCallback) => {
   callbacks.add(callback);
 };
 
+export const unregisterCallback = (callback: SongInfoCallback) => {
+  callbacks.delete(callback);
+};
+
 const registerProvider = (win: BrowserWindow) => {
   const dataMutex = new Mutex();
   let songInfo: SongInfo | null = null;


### PR DESCRIPTION
## Summary

Adds a Skip AI Music plugin. It uses the Zoundhub community artist list (with a configurable SubmitHub threshold) and supports custom blocked/allowed artists, blocked songs, and title keywords. Skips run on track change, with a cap so it does not loop forever on a bad queue.

Also adds block artist / block song actions in the player menu

## Test plan

- [ ] Enable the plugin and play something from an artist above your Zoundhub threshold — it should skip
- [ ] Block an artist from the player menu and confirm the next play skips
- [ ] Change the threshold, save, and check the Zoundhub artist count updates
- [ ] Run `pnpm exec playwright test src/plugins/skip-ai-music/match.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added the Skip AI Music plugin to automatically identify and skip AI-generated tracks.
- Added controls for blocked artists, songs, keywords, and allowed artists.
- Added community artist-list support with score thresholds, caching, refresh controls, and status details.
- Added player-menu actions to block the current artist or song.
- Added localized settings, dialogs, menu styling, and configurable skip behavior.
- Added clearer checkmarks for enabled menu options.

## Bug Fixes
- Improved callback cleanup when the plugin is disabled or stopped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->