### PR TITLE
fix(navigation): clear children of navigation plugin on disable

### DIFF
--- a/src/plugins/navigation/index.tsx
+++ b/src/plugins/navigation/index.tsx
@@ -70,6 +70,7 @@ export default createPlugin({
     },
     stop() {
       this.buttonContainer.remove();
+      this.buttonContainer.replaceChildren();
     },
   },
 });


### PR DESCRIPTION
## Summary
Clears the child elements of the Navigation plugin, to stop the arrow buttons from duplicating every time the plugin is turned on.

Closes https://github.com/pear-devs/pear-desktop/issues/4629

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Navigation controls are now fully cleared when the navigation plugin is stopped, preventing leftover button elements from persisting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->