### PR TITLE
Feat: Add flatpak build for arm64

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -54,6 +54,7 @@ linux:
     - target: flatpak
       arch:
         - x64
+        - arm64
     - target: deb
       arch:
         - x64


### PR DESCRIPTION
# Summary

---

This pull request aims to close #3576 by modifying `electron-builder.yml` to include `arm64` under `flatpak/arch` section.
Its possible to compile by running:
```bash
pnpm clean && pnpm build && pnpm electron-builder --linux flatpak:arm64 -p never
```

I don't have an ARM machine, however flatpak reports the package as `aarch64`. I confirmed it by running:

```bash
$ flatpak install --user YouTube\ Music-3.12.0-aarch64.flatpak
```
And inspecting the binary.
Getting these results:
```bash
$ LC_ALL=C flatpak info com.github.th_ch.youtube_music
            ID: com.github.th_ch.youtube_music
           Ref: app/com.github.th_ch.youtube_music/aarch64/master
          Arch: aarch64
        Branch: master
        Origin: youtube_music-origin
    Collection: 
  Installation: user
Installed Size: 373.8?MB
       Runtime: org.freedesktop.Platform/aarch64/24.08
           Sdk: org.freedesktop.Sdk/aarch64/24.08

        Commit: bc1ccfdfc53fc6bcb940efd49bd1232b4b5d8d2981308a2bcdeaff359be03ebf
       Subject: Export com.github.th_ch.youtube_music
          Date: 2026-08-24 19:25:36 +0000
```

Please let me know of any needed changes!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added arm64 support for Linux Flatpak packages, expanding compatibility with ARM-based devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->