### PR TITLE
fix(core): isolate per-plugin errors in onPlayerApiReady loop

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -4,6 +4,7 @@ import 'mdui/mdui.css';
 import 'mdui';
 
 import { loadI18n, setLanguage, t as i18t } from '@/i18n';
+import { LoggerPrefix } from '@/utils';
 import {
   defaultTrustedTypePolicy,
   registerWindowDefaultTrustedTypePolicy,
@@ -316,11 +317,25 @@ async function onApiLoaded() {
 
   for (const [id, plugin] of Object.entries(getAllLoadedRendererPlugins())) {
     if (typeof plugin.renderer !== 'function') {
-      await plugin.renderer?.onPlayerApiReady?.call(
-        plugin.renderer,
-        api!,
-        createContext(id),
-      );
+      try {
+        await plugin.renderer?.onPlayerApiReady?.call(
+          plugin.renderer,
+          api!,
+          createContext(id),
+        );
+      } catch (err) {
+        // One plugin's onPlayerApiReady throwing (e.g. a network-dependent
+        // fetch failing while offline) must not stop every other plugin
+        // later in this list from ever being initialized.
+        console.error(
+          LoggerPrefix,
+          i18t('common.console.plugins.execute-failed', {
+            pluginName: id,
+            contextName: 'onPlayerApiReady',
+          }),
+        );
+        console.trace(err);
+      }
     }
   }
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -24,7 +24,7 @@ import { setupSongInfo } from './providers/song-info-front';
 import type { MusicPlayer } from '@/types/music-player';
 import type { MusicPlayerAppElement } from '@/types/music-player-app-element';
 import type { QueueResponse } from '@/types/music-player-desktop-internal';
-import type { PluginConfig } from '@/types/plugins';
+import type { PluginConfig, PluginDef } from '@/types/plugins';
 import type { QueueElement } from '@/types/queue';
 import type { SearchBoxElement } from '@/types/search-box-element';
 
@@ -45,6 +45,34 @@ async function listenForApiLoad() {
 
       return;
     }
+  }
+}
+
+// One plugin's onPlayerApiReady throwing (e.g. a network-dependent fetch
+// failing while offline) must not stop the app from initializing every
+// other plugin - both the startup loop and the plugin:enable IPC handler
+// call this instead of invoking onPlayerApiReady directly.
+async function callOnPlayerApiReady(
+  id: string,
+  renderer: PluginDef<unknown, unknown, unknown>['renderer'],
+  playerApi: MusicPlayer,
+) {
+  if (typeof renderer === 'function') return;
+  try {
+    await renderer?.onPlayerApiReady?.call(
+      renderer,
+      playerApi,
+      createContext(id),
+    );
+  } catch (err) {
+    console.error(
+      LoggerPrefix,
+      i18t('common.console.plugins.execute-failed', {
+        pluginName: id,
+        contextName: 'onPlayerApiReady',
+      }),
+    );
+    console.trace(err);
   }
 }
 
@@ -317,25 +345,7 @@ async function onApiLoaded() {
 
   for (const [id, plugin] of Object.entries(getAllLoadedRendererPlugins())) {
     if (typeof plugin.renderer !== 'function') {
-      try {
-        await plugin.renderer?.onPlayerApiReady?.call(
-          plugin.renderer,
-          api!,
-          createContext(id),
-        );
-      } catch (err) {
-        // One plugin's onPlayerApiReady throwing (e.g. a network-dependent
-        // fetch failing while offline) must not stop every other plugin
-        // later in this list from ever being initialized.
-        console.error(
-          LoggerPrefix,
-          i18t('common.console.plugins.execute-failed', {
-            pluginName: id,
-            contextName: 'onPlayerApiReady',
-          }),
-        );
-        console.trace(err);
-      }
+      await callOnPlayerApiReady(id, plugin.renderer, api!);
     }
   }
 
@@ -473,13 +483,7 @@ const main = async () => {
     await forceLoadRendererPlugin(id);
     if (api) {
       const plugin = getLoadedRendererPlugin(id);
-      if (plugin && typeof plugin.renderer !== 'function') {
-        await plugin.renderer?.onPlayerApiReady?.call(
-          plugin.renderer,
-          api,
-          createContext(id),
-        );
-      }
+      if (plugin) await callOnPlayerApiReady(id, plugin.renderer, api);
     }
   });
 


### PR DESCRIPTION
## Summary
Plugins are initialized in a single `for` loop in `renderer.ts` with no error handling. If any one plugin's `onPlayerApiReady` throws (e.g. a network-dependent plugin failing while offline), the unhandled rejection stops the loop entirely and every plugin later in iteration order never gets initialized for that session.

This can make an otherwise-working plugin appear to "randomly stop working" with no visible cause, since the failure happens in a completely different plugin loaded earlier in the list.

## Fix
Wraps each plugin's `onPlayerApiReady` call in its own try/catch, logging the failure the same way `startPlugin` already does for `start()`/`stop()`, instead of letting one plugin's error take down every plugin after it.

## Test plan
- [x] `pnpm typecheck` / `pnpm lint` pass
- [x] Verified plugins still initialize normally in the built app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved plugin initialization resilience during startup and when enabling plugins.
  - If a plugin fails during setup, initialization continues for remaining plugins instead of stopping entirely.
  - Added diagnostic logging and stack traces to help identify plugin initialization failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->