### PR TITLE
feat(plugins): add Seek Shortcuts plugin

### DIFF
--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -804,6 +804,10 @@
         }
       }
     },
+    "seek-shortcuts": {
+      "description": "Seek 5 seconds backward/forward with the left/right arrow keys",
+      "name": "Seek Shortcuts"
+    },
     "shortcuts": {
       "description": "Allows setting global hotkeys for playback (play/pause/next/previous) and turning off media OSD by overriding media keys, turning on Ctrl/CMD + F to search, turning on Linux MPRIS support for media keys, and custom hotkeys for advanced users",
       "menu": {

--- a/src/plugins/seek-shortcuts/index.ts
+++ b/src/plugins/seek-shortcuts/index.ts
@@ -1,0 +1,60 @@
+import { t } from '@/i18n';
+import { createPlugin } from '@/utils';
+
+import type { MusicPlayer } from '@/types/music-player';
+
+const SEEK_SECONDS = 5;
+
+const isTypingTarget = (target: EventTarget | null): boolean => {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target.isContentEditable) return true;
+  return target.tagName === 'INPUT' || target.tagName === 'TEXTAREA';
+};
+
+export default createPlugin({
+  name: () => t('plugins.seek-shortcuts.name'),
+  description: () => t('plugins.seek-shortcuts.description'),
+  restartNeeded: false,
+  config: {
+    enabled: false,
+  },
+
+  renderer: {
+    api: null as MusicPlayer | null,
+    listener: null as ((event: KeyboardEvent) => void) | null,
+
+    onPlayerApiReady(api) {
+      this.api = api;
+
+      this.listener = (event: KeyboardEvent) => {
+        if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey)
+          return;
+        if (isTypingTarget(event.target)) return;
+        if (
+          document.querySelector<HTMLElement & { opened: boolean }>(
+            'ytmusic-search-box',
+          )?.opened
+        ) {
+          return;
+        }
+
+        switch (event.code) {
+          case 'ArrowLeft':
+            event.preventDefault();
+            this.api?.seekBy(-SEEK_SECONDS);
+            break;
+          case 'ArrowRight':
+            event.preventDefault();
+            this.api?.seekBy(SEEK_SECONDS);
+            break;
+        }
+      };
+      window.addEventListener('keydown', this.listener);
+    },
+    stop() {
+      if (this.listener) window.removeEventListener('keydown', this.listener);
+      this.listener = null;
+      this.api = null;
+    },
+  },
+});


### PR DESCRIPTION
## Summary
Adds a "Seek Shortcuts" plugin: left/right arrow keys seek 5 seconds back/forward.

Ignored while typing in an input/textarea/contenteditable or while the search box is open, so it doesn't steal keystrokes from text entry.

## Test plan
- [x] `pnpm typecheck` / `pnpm lint` pass
- [x] Verified seeking works and doesn't fire while typing in search/text fields

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a plugin that lets you seek backward or forward five seconds using the left and right arrow keys.
  - Shortcuts work outside text fields and the YouTube Music search box.
  - Added English name and description text for the new plugin.
  - The plugin is disabled by default and can be enabled in settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->