### PR TITLE
feat: auto-acknowledge content warnings that block playback

### DIFF
--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -375,6 +375,13 @@
         }
       }
     },
+    "auto-acknowledge": {
+      "description": "Automatically dismisses YouTube's suicide/self-harm player interstitial so playback is not blocked. Opt-in; does not dismiss age gates, sign-in, or other playability errors",
+      "menu": {
+        "debug": "Debug logging"
+      },
+      "name": "Auto-acknowledge content warnings"
+    },
     "blur-nav-bar": {
       "description": "Makes navigation bar transparent and blurry",
       "name": "Blur Navigation Bar"

--- a/src/plugins/auto-acknowledge/index.ts
+++ b/src/plugins/auto-acknowledge/index.ts
@@ -1,0 +1,164 @@
+import { createPlugin } from '@/utils';
+
+export type AutoAcknowledgeConfig = {
+  enabled: boolean;
+  debug: boolean;
+};
+
+export default createPlugin<
+  unknown,
+  unknown,
+  {
+    observer: MutationObserver | null;
+    interval: ReturnType<typeof setInterval> | null;
+    lastClick: number;
+    lastAttempt: number;
+    config: AutoAcknowledgeConfig | null;
+    isVisible: (el: Element) => boolean;
+    attempt: () => boolean;
+    startObserver: () => void;
+    stopObserver: () => void;
+  },
+  AutoAcknowledgeConfig
+>({
+  name: () => 'Auto-acknowledge',
+  description: () =>
+    'Automatically dismisses the player content-warning interstitial that blocks playback',
+  restartNeeded: false,
+  config: {
+    enabled: false,
+    debug: false,
+  } as AutoAcknowledgeConfig,
+
+  menu: async ({ getConfig, setConfig }) => {
+    const config = await getConfig();
+    return [
+      {
+        label: 'Debug logging',
+        type: 'checkbox',
+        checked: Boolean(config.debug),
+        click() {
+          setConfig({ debug: !config.debug });
+        },
+      },
+    ];
+  },
+
+  renderer: {
+    observer: null,
+    interval: null,
+    lastClick: 0,
+    lastAttempt: 0,
+    config: null,
+
+    isVisible(el: Element) {
+      const h = el as HTMLElement;
+      const style = window.getComputedStyle(h);
+      if (style.display === 'none' || style.visibility === 'hidden' || style.opacity === '0') {
+        return false;
+      }
+      const rect = h.getBoundingClientRect();
+      return rect.width > 0 && rect.height > 0;
+    },
+
+    attempt() {
+      const now = Date.now();
+      if (now - this.lastAttempt < 250) return false;
+      this.lastAttempt = now;
+      if (now - this.lastClick < 1200) return false;
+
+      const debug = Boolean(this.config?.debug);
+      const log = (...args: unknown[]) => {
+        if (debug) console.debug('[auto-acknowledge]', ...args);
+      };
+
+      // Strictly scoped: only the player playability error interstitial.
+      // This is <yt-player-error-message-renderer> inside <yt-playability-error-supported-renderers>,
+      // not a page-level yt-confirm-dialog-renderer (playlist delete etc.), so it cannot affect other UI.
+      const renderer = document.querySelector('yt-player-error-message-renderer');
+      if (!renderer) return false;
+      if (!this.isVisible(renderer)) return false;
+
+      // The interstitial has #reason / #subreason and a single #button.
+      // Clicking #button is language-agnostic (ID, not text) — works for translated UIs.
+      const btn = (renderer.querySelector('#button button') ??
+        renderer.querySelector('#button') ??
+        renderer.querySelector('button')) as HTMLElement | null;
+
+      if (!btn) {
+        log('no button in renderer');
+        return false;
+      }
+      if (!this.isVisible(btn)) return false;
+
+      // Extra safety: ensure this is a content-warning interstitial, not a generic
+      // "Video unavailable" error that happens to have a button. The warning always has
+      // #reason text; generic errors often have different structure.
+      const reasonEl =
+        renderer.querySelector('#reason') ?? renderer.querySelector('[id*="reason"]');
+      if (reasonEl) {
+        // If #reason is empty, don't click — unknown error type
+        const reasonText = (reasonEl.textContent ?? '').trim();
+        if (!reasonText) {
+          log('empty reason, skipping');
+          return false;
+        }
+        log('reason:', reasonText.slice(0, 120));
+      }
+
+      btn.click();
+      this.lastClick = now;
+      log('clicked player warning button', btn);
+      return true;
+    },
+
+    startObserver() {
+      try {
+        this.attempt();
+      } catch (e) {
+        if (this.config?.debug) console.debug('[auto-acknowledge] initial attempt failed', e);
+      }
+
+      this.observer = new MutationObserver(() => {
+        try {
+          this.attempt();
+        } catch (e) {
+          if (this.config?.debug) console.debug('[auto-acknowledge] observer failed', e);
+        }
+      });
+      this.observer.observe(document.documentElement, {
+        childList: true,
+        subtree: true,
+        characterData: true,
+      });
+
+      this.interval = setInterval(() => {
+        try {
+          this.attempt();
+        } catch {}
+      }, 800);
+    },
+
+    stopObserver() {
+      this.observer?.disconnect();
+      this.observer = null;
+      if (this.interval != null) {
+        clearInterval(this.interval);
+        this.interval = null;
+      }
+    },
+
+    async start({ getConfig }) {
+      this.config = await getConfig();
+      this.startObserver();
+    },
+
+    onConfigChange(newConfig) {
+      this.config = newConfig;
+    },
+
+    stop() {
+      this.stopObserver();
+    },
+  },
+});

--- a/src/plugins/auto-acknowledge/index.ts
+++ b/src/plugins/auto-acknowledge/index.ts
@@ -1,4 +1,18 @@
+import { t } from '@/i18n';
 import { createPlugin } from '@/utils';
+
+import {
+  ATTEMPT_DEBOUNCE_MS,
+  CLICK_THROTTLE_MS,
+  PLAYER_ROOT_SELECTOR,
+  POLL_MS,
+  findProceedButton,
+  findVisibleErrorRenderer,
+  readReasonText,
+  readSubreasonText,
+  shouldAcknowledge,
+  warningScreenKey,
+} from './matcher';
 
 export type AutoAcknowledgeConfig = {
   enabled: boolean;
@@ -11,34 +25,44 @@ export default createPlugin<
   {
     observer: MutationObserver | null;
     interval: ReturnType<typeof setInterval> | null;
+    playerWait: ReturnType<typeof setInterval> | null;
+    raf: number | null;
     lastClick: number;
     lastAttempt: number;
+    lastHandledKey: string | null;
+    lastVideoKey: string;
+    stopped: boolean;
     config: AutoAcknowledgeConfig | null;
-    isVisible: (el: Element) => boolean;
+    log: (...args: unknown[]) => void;
+    videoKey: () => string;
+    searchRoot: () => ParentNode;
     attempt: () => boolean;
+    scheduleAttempt: () => void;
+    attach: (root: Element) => void;
+    clearWatchers: () => void;
     startObserver: () => void;
     stopObserver: () => void;
   },
   AutoAcknowledgeConfig
 >({
-  name: () => 'Auto-acknowledge',
-  description: () =>
-    'Automatically dismisses the player content-warning interstitial that blocks playback',
+  name: () => t('plugins.auto-acknowledge.name'),
+  description: () => t('plugins.auto-acknowledge.description'),
+  addedVersion: '3.12.x',
   restartNeeded: false,
   config: {
     enabled: false,
     debug: false,
-  } as AutoAcknowledgeConfig,
+  },
 
   menu: async ({ getConfig, setConfig }) => {
     const config = await getConfig();
     return [
       {
-        label: 'Debug logging',
+        label: t('plugins.auto-acknowledge.menu.debug'),
         type: 'checkbox',
         checked: Boolean(config.debug),
-        click() {
-          setConfig({ debug: !config.debug });
+        click(item) {
+          setConfig({ debug: Boolean(item.checked) });
         },
       },
     ];
@@ -47,104 +71,162 @@ export default createPlugin<
   renderer: {
     observer: null,
     interval: null,
+    playerWait: null,
+    raf: null,
     lastClick: 0,
     lastAttempt: 0,
+    lastHandledKey: null,
+    lastVideoKey: '',
+    stopped: false,
     config: null,
 
-    isVisible(el: Element) {
-      const h = el as HTMLElement;
-      const style = window.getComputedStyle(h);
-      if (style.display === 'none' || style.visibility === 'hidden' || style.opacity === '0') {
-        return false;
+    log(...args: unknown[]) {
+      if (this.config?.debug) {
+        console.debug('[auto-acknowledge]', ...args);
       }
-      const rect = h.getBoundingClientRect();
-      return rect.width > 0 && rect.height > 0;
+    },
+
+    videoKey() {
+      const video = document.querySelector('video');
+      const src = video?.currentSrc || video?.src || '';
+      const title =
+        document.querySelector('.title.ytmusic-player-bar')?.textContent ?? '';
+      return `${src}|${title}`;
+    },
+
+    searchRoot() {
+      return document.querySelector(PLAYER_ROOT_SELECTOR) ?? document;
     },
 
     attempt() {
       const now = Date.now();
-      if (now - this.lastAttempt < 250) return false;
+      if (now - this.lastAttempt < ATTEMPT_DEBOUNCE_MS) return false;
       this.lastAttempt = now;
-      if (now - this.lastClick < 1200) return false;
+      if (now - this.lastClick < CLICK_THROTTLE_MS) return false;
 
-      const debug = Boolean(this.config?.debug);
-      const log = (...args: unknown[]) => {
-        if (debug) console.debug('[auto-acknowledge]', ...args);
-      };
+      const videoKey = this.videoKey();
+      if (videoKey !== this.lastVideoKey) {
+        this.lastHandledKey = null;
+        this.lastVideoKey = videoKey;
+      }
 
-      // Strictly scoped: only the player playability error interstitial.
-      // This is <yt-player-error-message-renderer> inside <yt-playability-error-supported-renderers>,
-      // not a page-level yt-confirm-dialog-renderer (playlist delete etc.), so it cannot affect other UI.
-      const renderer = document.querySelector('yt-player-error-message-renderer');
+      const renderer = findVisibleErrorRenderer(this.searchRoot());
       if (!renderer) return false;
-      if (!this.isVisible(renderer)) return false;
 
-      // The interstitial has #reason / #subreason and a single #button.
-      // Clicking #button is language-agnostic (ID, not text) — works for translated UIs.
-      const btn = (renderer.querySelector('#button button') ??
-        renderer.querySelector('#button') ??
-        renderer.querySelector('button')) as HTMLElement | null;
-
-      if (!btn) {
-        log('no button in renderer');
+      const reason = readReasonText(renderer);
+      const subreason = readSubreasonText(renderer);
+      const btn = findProceedButton(renderer);
+      if (
+        !btn ||
+        !shouldAcknowledge({
+          reason,
+          subreason,
+          hasProceedButton: true,
+        })
+      ) {
+        this.log('skip non-warning interstitial', reason?.slice(0, 120));
         return false;
       }
-      if (!this.isVisible(btn)) return false;
 
-      // Extra safety: ensure this is a content-warning interstitial, not a generic
-      // "Video unavailable" error that happens to have a button. The warning always has
-      // #reason text; generic errors often have different structure.
-      const reasonEl =
-        renderer.querySelector('#reason') ?? renderer.querySelector('[id*="reason"]');
-      if (reasonEl) {
-        // If #reason is empty, don't click — unknown error type
-        const reasonText = (reasonEl.textContent ?? '').trim();
-        if (!reasonText) {
-          log('empty reason, skipping');
-          return false;
-        }
-        log('reason:', reasonText.slice(0, 120));
+      if (!reason) return false;
+
+      const key = warningScreenKey(reason, videoKey);
+      if (this.lastHandledKey === key) {
+        this.log('already handled this screen');
+        return false;
       }
 
       btn.click();
       this.lastClick = now;
-      log('clicked player warning button', btn);
+      this.lastHandledKey = key;
+      this.log('clicked content-warning proceed button', reason.slice(0, 120));
       return true;
     },
 
-    startObserver() {
-      try {
-        this.attempt();
-      } catch (e) {
-        if (this.config?.debug) console.debug('[auto-acknowledge] initial attempt failed', e);
-      }
-
-      this.observer = new MutationObserver(() => {
+    scheduleAttempt() {
+      if (this.raf != null) return;
+      this.raf = window.requestAnimationFrame(() => {
+        this.raf = null;
         try {
           this.attempt();
-        } catch (e) {
-          if (this.config?.debug) console.debug('[auto-acknowledge] observer failed', e);
+        } catch (error) {
+          this.log('scheduled attempt failed', error);
         }
       });
-      this.observer.observe(document.documentElement, {
+    },
+
+    attach(root: Element) {
+      this.clearWatchers();
+      this.observer = new MutationObserver(() => this.scheduleAttempt());
+      this.observer.observe(root, {
         childList: true,
         subtree: true,
-        characterData: true,
       });
-
       this.interval = setInterval(() => {
         try {
           this.attempt();
-        } catch {}
-      }, 800);
+        } catch (error) {
+          this.log('poll failed', error);
+        }
+      }, POLL_MS);
+      try {
+        this.attempt();
+      } catch (error) {
+        this.log('initial attempt failed', error);
+      }
     },
 
-    stopObserver() {
+    clearWatchers() {
       this.observer?.disconnect();
       this.observer = null;
       if (this.interval != null) {
         clearInterval(this.interval);
         this.interval = null;
+      }
+      if (this.raf != null) {
+        cancelAnimationFrame(this.raf);
+        this.raf = null;
+      }
+    },
+
+    startObserver() {
+      this.stopped = false;
+      this.clearWatchers();
+      if (this.playerWait != null) {
+        clearInterval(this.playerWait);
+        this.playerWait = null;
+      }
+
+      const existing = document.querySelector(PLAYER_ROOT_SELECTOR);
+      if (existing) {
+        this.attach(existing);
+        return;
+      }
+
+      this.playerWait = setInterval(() => {
+        if (this.stopped) {
+          if (this.playerWait != null) {
+            clearInterval(this.playerWait);
+            this.playerWait = null;
+          }
+          return;
+        }
+        const root = document.querySelector(PLAYER_ROOT_SELECTOR);
+        if (!root) return;
+        if (this.playerWait != null) {
+          clearInterval(this.playerWait);
+          this.playerWait = null;
+        }
+        this.attach(root);
+      }, 200);
+    },
+
+    stopObserver() {
+      this.stopped = true;
+      this.clearWatchers();
+      if (this.playerWait != null) {
+        clearInterval(this.playerWait);
+        this.playerWait = null;
       }
     },
 

--- a/src/plugins/auto-acknowledge/matcher.test.ts
+++ b/src/plugins/auto-acknowledge/matcher.test.ts
@@ -1,0 +1,87 @@
+import { expect, test } from '@playwright/test';
+
+import {
+  isContentWarningText,
+  shouldAcknowledge,
+  warningScreenKey,
+} from './matcher';
+
+const WARNING_REASON =
+  'The following content may contain suicide or self-harm topics.';
+
+test('matches the English suicide/self-harm interstitial', () => {
+  expect(
+    isContentWarningText(
+      WARNING_REASON,
+      'Viewer discretion is advised. Learn more',
+    ),
+  ).toBe(true);
+});
+
+test('matches accented and non-English warning copy', () => {
+  expect(
+    isContentWarningText(
+      'O conteúdo a seguir pode conter tópicos sobre suicídio ou automutilação',
+    ),
+  ).toBe(true);
+  expect(
+    isContentWarningText(
+      'Die folgenden Inhalte können Themen wie Selbstmord oder Selbstverletzung enthalten',
+    ),
+  ).toBe(true);
+  expect(
+    isContentWarningText(
+      'Seuraava sisältö saattaa sisältää itsemurhaan tai itsensä vahingoittamiseen liittyviä aiheita.',
+    ),
+  ).toBe(true);
+  expect(
+    isContentWarningText(
+      '다음 콘텐츠에는 자살 또는 자해 주제가 포함될 수 있습니다.',
+    ),
+  ).toBe(true);
+});
+
+test('does not match generic playability errors or age gates', () => {
+  const negatives = [
+    'Video unavailable',
+    'This video is private',
+    'Sign in to confirm your age',
+    'This video may be inappropriate for some users.',
+    'Playback on other websites has been disabled by the video owner',
+    'YouTube Premium',
+    'Get YouTube Premium',
+    'Sign in to confirm you’re not a bot',
+    '',
+  ];
+  for (const reason of negatives) {
+    expect(
+      shouldAcknowledge({
+        reason,
+        subreason: '',
+        hasProceedButton: true,
+      }),
+      reason,
+    ).toBe(false);
+  }
+});
+
+test('requires a non-empty reason and a proceed button', () => {
+  expect(shouldAcknowledge({ reason: null, hasProceedButton: true })).toBe(
+    false,
+  );
+  expect(shouldAcknowledge({ reason: '   ', hasProceedButton: true })).toBe(
+    false,
+  );
+  expect(
+    shouldAcknowledge({ reason: WARNING_REASON, hasProceedButton: false }),
+  ).toBe(false);
+  expect(
+    shouldAcknowledge({ reason: WARNING_REASON, hasProceedButton: true }),
+  ).toBe(true);
+});
+
+test('screen key changes with video identity', () => {
+  expect(warningScreenKey(WARNING_REASON, 'a')).not.toBe(
+    warningScreenKey(WARNING_REASON, 'b'),
+  );
+});

--- a/src/plugins/auto-acknowledge/matcher.ts
+++ b/src/plugins/auto-acknowledge/matcher.ts
@@ -1,0 +1,115 @@
+export const ATTEMPT_DEBOUNCE_MS = 250;
+export const CLICK_THROTTLE_MS = 1200;
+export const POLL_MS = 800;
+
+export const PLAYER_ROOT_SELECTOR = 'ytmusic-player, #movie_player';
+export const SCOPED_ERROR_RENDERER_SELECTOR =
+  'yt-playability-error-supported-renderers yt-player-error-message-renderer';
+export const ERROR_RENDERER_SELECTOR = 'yt-player-error-message-renderer';
+export const PROCEED_BUTTON_SELECTOR = '#button button';
+
+/**
+ * Needles matched against folded `#reason` + `#subreason` text.
+ * Intentionally excludes age-gate / login / Premium / unavailable copy.
+ */
+const WARNING_NEEDLES = [
+  'suicide or self-harm',
+  'self-harm',
+  'self harm',
+  'suicid',
+  'viewer discretion',
+  'selbstmord',
+  'selbstverletzung',
+  'suizid',
+  'automutilation',
+  'autolesion',
+  'zelfmoord',
+  'zelfbeschadiging',
+  'самоубий',
+  'самоповрежд',
+  'суицид',
+  'samoboj',
+  'samookalecz',
+  'intihar',
+  'selvmord',
+  'sjalvmord',
+  'itsemurh',
+  'itsensa vahingoitt',
+  '自杀',
+  '自殺',
+  '自残',
+  '自殘',
+  '自傷',
+  '自伤',
+  '자살',
+  '자해',
+  'انتحار',
+];
+
+export const foldText = (value: string): string =>
+  value.toLowerCase().normalize('NFD').replaceAll(/\p{M}/gu, '');
+
+export const isContentWarningText = (
+  reason: string,
+  subreason = '',
+): boolean => {
+  const haystack = foldText(`${reason}\n${subreason}`);
+  if (!haystack.trim()) return false;
+  return WARNING_NEEDLES.some((needle) => haystack.includes(foldText(needle)));
+};
+
+export const shouldAcknowledge = (input: {
+  reason: string | null | undefined;
+  subreason?: string | null;
+  hasProceedButton: boolean;
+}): boolean => {
+  const reason = (input.reason ?? '').trim();
+  if (!reason) return false;
+  if (!input.hasProceedButton) return false;
+  return isContentWarningText(reason, input.subreason ?? '');
+};
+
+export const warningScreenKey = (reason: string, videoKey: string): string =>
+  `${videoKey}::${reason.trim()}`;
+
+export const isVisibleElement = (el: Element): boolean => {
+  const h = el as HTMLElement;
+  const style = window.getComputedStyle(h);
+  if (
+    style.display === 'none' ||
+    style.visibility === 'hidden' ||
+    style.opacity === '0'
+  ) {
+    return false;
+  }
+  const rect = h.getBoundingClientRect();
+  return rect.width > 0 && rect.height > 0;
+};
+
+export const findVisibleErrorRenderer = (root: ParentNode): Element | null => {
+  const scoped = root.querySelectorAll(SCOPED_ERROR_RENDERER_SELECTOR);
+  const nodes =
+    scoped.length > 0 ? scoped : root.querySelectorAll(ERROR_RENDERER_SELECTOR);
+  for (const node of nodes) {
+    if (isVisibleElement(node)) return node;
+  }
+  return null;
+};
+
+/** Primary proceed CTA only — never `#button` (a div) or a random `button`. */
+export const findProceedButton = (renderer: Element): HTMLElement | null => {
+  const btn = renderer.querySelector(PROCEED_BUTTON_SELECTOR);
+  if (!btn) return null;
+  if (!isVisibleElement(btn)) return null;
+  return btn as HTMLElement;
+};
+
+export const readReasonText = (renderer: Element): string | null => {
+  const reasonEl = renderer.querySelector('#reason');
+  if (!reasonEl) return null;
+  const text = (reasonEl.textContent ?? '').trim();
+  return text.length > 0 ? text : null;
+};
+
+export const readSubreasonText = (renderer: Element): string =>
+  (renderer.querySelector('#subreason')?.textContent ?? '').trim();


### PR DESCRIPTION
## Why

YouTube Music shows a blocking **player interstitial** on some tracks:

> The following content may contain suicide or self-harm topics.
> Viewer discretion is advised.
> **I understand and wish to proceed**

Restricted Mode off does not hide it. After `v3.12.0` removed Bypass Age Restrictions (#4623; restore attempt #4638), there is no way to keep the queue flowing.

This overlay is `yt-player-error-message-renderer` inside `yt-playability-error-supported-renderers`. That custom element is YouTube’s **generic playability error screen** (unavailable, age-gate, Premium, sign-in, retry) — not `yt-confirm-dialog-renderer` (playlist delete). A plugin that clicks “any visible player-error button with a `#reason`” would also hit those.

Dumped live on `music.youtube.com/watch?v=z-OM36Pg9aE` (`suicide note — Novulent`).

## What this does

Opt-in renderer plugin `auto-acknowledge` (**disabled by default**, `restartNeeded: false`):

- Positive match only: non-empty `#reason` whose folded text (plus `#subreason`) looks like a suicide/self-harm / viewer-discretion warning (EN + several locales). Age-gates, unavailable, Premium, sign-in, and retry are skipped even if they use the same renderer and the same proceed CTA.
- Clicks `#button button` only (the real `<button>`, language-agnostic). Never `div#button`, a bare `button`, `#dismiss-button`, or “Learn more”.
- `querySelectorAll` → first **visible** renderer (`getComputedStyle` + non-zero box). Leftover `display:none` / 0×0 Polymer nodes cannot steal the match.
- One click per `reason + video` key; no 1.2s retry storm if the overlay stays up.
- Observer on `ytmusic-player` / `#movie_player` (`childList` + `subtree`, **no `characterData`**), rAF-coalesced, plus an 800ms poll. `startObserver` tears down the previous observer/interval first.
- `en.json` name/description/debug. Menu checkbox uses `item.checked` (the plugin menu is built once and cached).

Unlike #4638 this does not proxy `youtubei`. It clicks the interstitial the user would click, and only that interstitial.

## How to test

1. Plugins → **Auto-acknowledge content warnings** → enable (optional: Debug logging).
2. Play a warning track (`suicide note — Novulent` / `z-OM36Pg9aE`). Overlay auto-dismisses once; playback continues. Console: `[auto-acknowledge] clicked content-warning proceed button …`.
3. Home / a normal track: no click.
4. Unavailable / age-gate / playlist delete: no click.
5. Disable the plugin while it is live: observer and interval are gone.

Live-checked on this branch via `--remote-debugging-port`: plugin loaded, one click on the warning track, audio playing, no click on home.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic acknowledgement of the YouTube player content-warning prompt.
  * Added configuration options to enable the feature and display debug information.
  * Detects eligible prompts as page content changes and through periodic checks.
  * Verifies prompt visibility and content before confirming, helping avoid unintended interactions.
  * Automatically manages detection while the feature is active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
