### PR TITLE
fix: make volume writes round-trip with the reported volume

### DIFF
--- a/src/plugins/shortcuts/mpris.ts
+++ b/src/plugins/shortcuts/mpris.ts
@@ -7,7 +7,6 @@ import MprisPlayer, {
 } from '@jellybrick/mpris-service';
 import { type BrowserWindow, ipcMain } from 'electron';
 
-import * as config from '@/config';
 import { APPLICATION_NAME } from '@/i18n';
 import { getSongControls } from '@/providers/song-controls';
 import {
@@ -308,13 +307,8 @@ export function registerMPRIS(win: BrowserWindow) {
         : Number.parseFloat((newVolumeState.state / 100).toFixed(2));
     });
 
-    player.on('volume', async (newVolume: number) => {
-      if (await config.plugins.isEnabled('precise-volume')) {
-        // With precise volume we can set the volume to the exact value.
-        win.webContents.send('setVolume', ~~(newVolume * 100));
-      } else {
-        setVolume(newVolume * 100);
-      }
+    player.on('volume', (newVolume: number) => {
+      setVolume(newVolume * 100);
     });
 
     registerCallback((songInfo: SongInfo, event) => {

--- a/src/providers/song-controls.ts
+++ b/src/providers/song-controls.ts
@@ -1,6 +1,7 @@
 // This is used for to control the songs
 import { type BrowserWindow, ipcMain } from 'electron';
 
+import * as config from '@/config';
 import { LikeType } from '@/types/datahost-get-state';
 
 // see protocol-handler.ts
@@ -75,10 +76,16 @@ export const getSongControls = (win: BrowserWindow) => {
       }
     },
     // General
-    setVolume: (volume: ArgsType<number>) => {
+    setVolume: async (volume: ArgsType<number>) => {
       const volumeNumber = parseNumberFromArgsType(volume);
-      if (volumeNumber !== null) {
-        win.webContents.send('peard:update-volume', volume);
+      if (volumeNumber === null) return;
+
+      if (await config.plugins.isEnabled('precise-volume')) {
+        // precise-volume owns the volume UI (saved volume, tooltip, slider,
+        // HUD), so let it apply the change instead of writing the player.
+        win.webContents.send('setVolume', volumeNumber);
+      } else {
+        win.webContents.send('peard:update-volume', volumeNumber);
       }
     },
     setFullscreen: (isFullscreen: ArgsType<boolean>) => {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -131,11 +131,21 @@ async function onApiLoaded() {
     }
   });
   window.ipcRenderer.on('peard:update-volume', (_, volume: number) => {
-    document
-      .querySelector<HTMLElement & { updateVolume: (volume: number) => void }>(
-        'ytmusic-player-bar',
-      )
-      ?.updateVolume(volume);
+    const value = Math.min(100, Math.max(0, Math.round(volume)));
+
+    // Write through the player API instead of `ytmusic-player-bar.updateVolume`:
+    // the player bar applies its own curve, so writing there does not round-trip
+    // with `getVolume()`, which is what `peard:volume-changed` reports.
+    api?.setVolume(value);
+
+    // The player bar only syncs its sliders for changes it drives itself.
+    for (const selector of ['#volume-slider', '#expand-volume-slider']) {
+      const slider = document.querySelector<HTMLInputElement>(selector);
+      if (slider) {
+        // Slider value automatically rounds to multiples of 5
+        slider.value = String(value > 0 && value < 5 ? 5 : value);
+      }
+    }
   });
 
   const isFullscreen = () => {


### PR DESCRIPTION
Fixes #4458.

### Problem

The API server's `/api/v1/volume` GET and POST work on different scales, so read-modify-write on volume is broken for external clients.

The two endpoints write and read at different layers:

- **POST** goes through `controller.setVolume()` → `peard:update-volume` → `ytmusic-player-bar.updateVolume()`, which applies its own curve before forwarding to the player.
- **GET** (and the WebSocket `VOLUME_CHANGED` event) reads the cache filled from `peard:volume-changed`, which reports `MusicPlayer.getVolume()` — the value after that curve.

So posting a volume and reading it back gives a different number.

### Fix

Write through the player API instead, which is what the `precise-volume` plugin already does, and sync the player bar sliders manually — the bar only updates them for changes it drives itself.

### Verification

Launched the app and drove both paths directly, setting the volume and reading `getVolume()` back:

| set | before (via player bar) | after (via player API) |
|----:|------------------------:|-----------------------:|
| 39  | 13                      | 39                     |
| 60  | 29                      | 60                     |
| 75  | 47                      | 75                     |

The "before" column reproduces the table in #4458 exactly. After the change the round-trip is an identity, so clients can do GET → adjust → POST without applying their own inverse transform.

This likely also covers #4431 (MPRIS reporting incorrect volume), since MPRIS writes through the same `peard:update-volume` path — but I have not verified that one.

`pnpm typecheck`, `pnpm lint`, `pnpm format:check` and `pnpm build` all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved volume adjustment accuracy by rounding values and respecting slider step limits.
  * Volume controls now remain synchronized after updates.
  * Volume changes are applied consistently across playback controls and external media controls.
  * Removed an outdated volume update path for more reliable playback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->