### PR TITLE
perf: show the window without waiting for the page to paint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,9 @@ unhandled({
   showDialog: false,
 });
 
+// How long to wait for the page to paint before showing the window anyway.
+const EARLY_SHOW_DELAY = 500;
+
 // Prevent window being garbage collected
 let mainWindow: Electron.BrowserWindow | null;
 electronUpdater.autoUpdater.autoDownload = false;
@@ -489,11 +492,20 @@ async function createMainWindow() {
     showUnresponsiveDialog(win, details);
   });
 
-  win.once('ready-to-show', () => {
+  // 'ready-to-show' only fires once the remote page has painted, which takes
+  // seconds on a cold start. The window paints its own background colour
+  // already, so show it as soon as either that or a short timer fires.
+  const showWindow = () => {
+    if (win.isDestroyed() || win.isVisible()) return;
     if (config.get('options.appVisible')) {
       win.show();
     }
-  });
+  };
+
+  win.once('ready-to-show', showWindow);
+  const earlyShowTimer = setTimeout(showWindow, EARLY_SHOW_DELAY);
+  win.once('show', () => clearTimeout(earlyShowTimer));
+  win.once('closed', () => clearTimeout(earlyShowTimer));
 
   removeContentSecurityPolicy();
 


### PR DESCRIPTION
### Problem

`win.once('ready-to-show', ...)` only fires once the remote page has painted its first frame. For a cold start that is several seconds after the window itself is ready, and during that gap there is nothing on screen at all — no window, no splash.

Measured on Windows 11, main process uptime:

| | |
|---|---:|
| `createMainWindow` done | 619ms |
| `ready-to-show` | 6889ms |
| `did-finish-load` | 8280ms |

So the window existed for 6.3s before the user could see anything.

### Change

The window is created with `backgroundColor: '#000'`, so it paints something sensible on its own before the page loads. It is now shown on whichever comes first: `ready-to-show`, or a 500ms timer. The `isVisible()` guard makes the later event a no-op, and the timer is cleared on `show` and on `closed`.

`options.appVisible` is still respected, so starting hidden to the tray is unaffected.

After the change, same machine: window visible at **1117ms** instead of 6889ms. Verified separately without the instrumentation by polling `BrowserWindow.isVisible()` from a test harness — first visible at 1.36s from launch.

### Trade-off

For the first moment the window is a black rectangle rather than the app. That is what most desktop players do, and it seemed clearly better than showing nothing for six seconds — but it is a UX call, so happy to drop this or make the delay configurable if you would rather keep the current behaviour.

`pnpm typecheck`, `pnpm lint` and `pnpm build` pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application startup so the main window appears more reliably.
  * Reduced delays when displaying the window during launch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->