### PR TITLE
perf: load only the active language at startup

### DIFF
--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,20 +1,37 @@
 import i18next, { init, t as i18t, changeLanguage } from 'i18next';
-import { languageResources } from 'virtual:i18n';
+import { loadLanguageResource } from 'virtual:i18n';
 
 export const APPLICATION_NAME =
   '\u0059\u006f\u0075\u0054\u0075\u0062\u0065\u0020\u004d\u0075\u0073\u0069\u0063';
 
-export const loadI18n = async () =>
-  await init({
-    resources: await languageResources(),
-    lng: 'en',
-    fallbackLng: 'en',
+const FALLBACK_LANGUAGE = 'en';
+
+export const loadI18n = async () => {
+  const fallback = await loadLanguageResource(FALLBACK_LANGUAGE);
+
+  return await init({
+    // Only the fallback is loaded up front; the active language is added by
+    // setLanguage. Loading all of them here costs a few hundred ms of startup.
+    resources: fallback
+      ? { [FALLBACK_LANGUAGE]: { translation: fallback } }
+      : {},
+    lng: FALLBACK_LANGUAGE,
+    fallbackLng: FALLBACK_LANGUAGE,
     interpolation: {
       escapeValue: false,
     },
   });
+};
 
-export const setLanguage = async (language: string) =>
-  await changeLanguage(language);
+export const setLanguage = async (language: string) => {
+  if (!i18next.hasResourceBundle(language, 'translation')) {
+    const resource = await loadLanguageResource(language);
+    if (resource) {
+      i18next.addResourceBundle(language, 'translation', resource);
+    }
+  }
+
+  return await changeLanguage(language);
+};
 
 export const t = i18t.bind(i18next);

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ import unhandled from 'electron-unhandled';
 import electronUpdater from 'electron-updater';
 import { deepEqual } from 'fast-equals';
 import { parse } from 'node-html-parser';
-import { languageResources } from 'virtual:i18n';
+import { availableLanguages } from 'virtual:i18n';
 import { allPlugins, mainPlugins } from 'virtual:plugins';
 
 import * as config from '@/config';
@@ -640,12 +640,12 @@ app.on('activate', async () => {
   }
 });
 
-const getDefaultLocale = async (locale: string) =>
-  Object.keys(await languageResources()).includes(locale) ? locale : null;
+const getDefaultLocale = (locale: string) =>
+  availableLanguages.includes(locale) ? locale : null;
 
 app.whenReady().then(async () => {
   if (!config.get('options.language')) {
-    const locale = await getDefaultLocale(app.getLocale());
+    const locale = getDefaultLocale(app.getLocale());
     if (locale) {
       config.set('options.language', locale);
     }

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -10,7 +10,7 @@ import {
 } from 'electron';
 import is from 'electron-is';
 import { satisfies } from 'semver';
-import { languageResources } from 'virtual:i18n';
+import { availableLanguages, languageLabels } from 'virtual:i18n';
 import { allPlugins } from 'virtual:plugins';
 
 import { APPLICATION_NAME, setLanguage, t } from '@/i18n';
@@ -31,10 +31,10 @@ const inAppMenuActive = await config.plugins.isEnabled('in-app-menu');
 const pluginEnabledMenu = async (
   plugin: string,
   label = '',
-  description?: string ,
+  description?: string,
   isNew = false,
   hasSubmenu = false,
-  refreshMenu?: (() => void) ,
+  refreshMenu?: () => void,
 ): Promise<Electron.MenuItemConstructorOptions> => ({
   label: label || plugin,
   sublabel: isNew ? t('main.menu.plugins.new') : undefined,
@@ -146,9 +146,6 @@ export const mainMenuTemplate = async (
         );
       }),
   );
-
-  const langResources = await languageResources();
-  const availableLanguages = Object.keys(langResources);
 
   return [
     {
@@ -494,7 +491,7 @@ export const mainMenuTemplate = async (
             availableLanguages
               .map(
                 (lang): Electron.MenuItemConstructorOptions => ({
-                  label: `${langResources[lang].translation.language?.name ?? 'Unknown'} (${langResources[lang].translation.language?.['local-name'] ?? 'Unknown'})`,
+                  label: `${languageLabels[lang].name} (${languageLabels[lang].localName})`,
                   type: 'checkbox',
                   checked: (config.get('options.language') ?? 'en') === lang,
                   click() {

--- a/src/virtual-module.d.ts
+++ b/src/virtual-module.d.ts
@@ -15,5 +15,13 @@ declare module 'virtual:plugins' {
 declare module 'virtual:i18n' {
   import type { LanguageResources } from '@/i18n/resources/@types';
 
+  export const languageLabels: Record<
+    string,
+    { name: string; localName: string }
+  >;
+  export const availableLanguages: string[];
+  export const loadLanguageResource: (
+    name: string,
+  ) => Promise<LanguageResources[string]['translation'] | undefined>;
   export const languageResources: () => Promise<LanguageResources>;
 }

--- a/vite-plugins/i18n-importer.mts
+++ b/vite-plugins/i18n-importer.mts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { basename, resolve, extname, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -21,22 +22,53 @@ export const i18nImporter = () => {
     return { name, path };
   });
 
+  // Display names are read at build time so that listing the languages does
+  // not require loading every translation bundle.
+  const labels: Record<string, { name: string; localName: string }> = {};
+  for (const { name, path } of plugins) {
+    const json = JSON.parse(readFileSync(path, 'utf8')) as {
+      language?: { name?: string; 'local-name'?: string };
+    };
+    labels[name] = {
+      name: json.language?.name ?? 'Unknown',
+      localName: json.language?.['local-name'] ?? 'Unknown',
+    };
+  }
+
   const src = globalProject.createSourceFile(
     'vm:i18n',
     (writer) => {
-      writer.writeLine('export const languageResources = async () => {');
-      writer.writeLine('  const entries = await Promise.all([');
+      writer.writeLine(
+        `export const languageLabels = ${JSON.stringify(labels)};`,
+      );
+      writer.writeLine(
+        'export const availableLanguages = Object.keys(languageLabels);',
+      );
+      writer.blankLine();
+
+      writer.writeLine('const loaders = {');
       for (const { name, path } of plugins) {
-        const absolutePath = resolve(srcPath, '..', path).replace(
-          /\\/g,
-          '/',
-        );
+        const absolutePath = resolve(srcPath, '..', path).replace(/\\/g, '/');
 
         writer.writeLine(
-          `    import('${absolutePath}').then((mod) => ({ "${name}": { translation: mod.default } })),`,
+          `  "${name}": () => import('${absolutePath}').then((mod) => mod.default),`,
         );
       }
-      writer.writeLine('  ]);');
+      writer.writeLine('};');
+      writer.blankLine();
+
+      writer.writeLine('export const loadLanguageResource = async (name) => {');
+      writer.writeLine('  const loader = loaders[name];');
+      writer.writeLine('  return loader ? await loader() : undefined;');
+      writer.writeLine('};');
+      writer.blankLine();
+
+      writer.writeLine('export const languageResources = async () => {');
+      writer.writeLine('  const entries = await Promise.all(');
+      writer.writeLine(
+        '    Object.entries(loaders).map(async ([name, load]) => ({ [name]: { translation: await load() } })),',
+      );
+      writer.writeLine('  );');
       writer.writeLine('  return Object.assign({}, ...entries);');
       writer.writeLine('};');
       writer.blankLine();


### PR DESCRIPTION
### Problem

`languageResources()` dynamically imports **all 67** translation bundles and passes every one of them to `i18next.init`. That happens in the main process, in preload and in the renderer. Only two are ever used: the active language and the `en` fallback.

`getDefaultLocale()` in `index.ts` also called it just to test whether a locale name exists, and `menu.ts` called it to read one field (`language.name`) out of each bundle to label the language list.

Measured on Windows 11, main process uptime:

| | before |
|---|---:|
| i18n loaded | 335ms of a 1009ms startup |
| menu ready | 1330ms |

### Change

`virtual:i18n` now exposes:

- `loadLanguageResource(name)` — one bundle, on demand
- `availableLanguages` — the names, no imports
- `languageLabels` — `{ name, localName }` per language, read from the JSON at build time
- `languageResources()` — kept, now built on top of the loaders

`loadI18n()` initialises with the fallback only; `setLanguage()` calls `addResourceBundle` for the requested language if it is not loaded yet, then `changeLanguage`. `menu.ts` labels the language list from `languageLabels`, and `getDefaultLocale()` became synchronous.

| | before | after |
|---|---:|---:|
| i18n loaded | 335ms | **14ms** |
| menu ready | 1330ms | **701ms** |

### Verification

Ran the app with a fresh profile in a `pt-BR` locale: the menus come up translated, so the on-demand language is applied, and the language submenu lists all 67 entries with correct native names.

7 of them render as `Unknown (Unknown)`. Those are the same 7 files that have no `language.name` / `language.local-name` today (`be-Latn`, `ckb`, `km`, `kmr`, `qu`, `sah`, `sq`), and the previous code produced the same fallback for them — no change in behaviour.

`pnpm typecheck`, `pnpm lint` and `pnpm build` pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved startup time by loading only the default language initially.
  * Additional languages now load on demand when selected.

* **Language Selection**
  * Language menus now display localized language names more consistently.
  * Available languages are detected and presented automatically.

* **Reliability**
  * Selecting an unavailable translation no longer prevents the app from changing languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->