### PR TITLE
feat(taskbar-mediacontrol): enable the thumbnail toolbar by default

### DIFF
--- a/src/plugins/taskbar-mediacontrol/index.ts
+++ b/src/plugins/taskbar-mediacontrol/index.ts
@@ -24,7 +24,7 @@ export default createPlugin({
   restartNeeded: true,
   platform: Platform.Windows,
   config: {
-    enabled: false,
+    enabled: true,
   },
 
   backend({ window }) {


### PR DESCRIPTION
The `taskbar-mediacontrol` plugin puts previous / play-pause / next buttons in the Windows taskbar thumbnail preview — the controls a Windows user expects from a media player. It currently ships with `enabled: false`, so they are only found by people who go looking through the plugin list.

This flips that default.

The plugin is already gated to `Platform.Windows`, and `setThumbar` returns early until a song has a title, so this costs nothing on the other platforms or before playback starts. The icons already follow `nativeTheme`.

I am aware this is a product decision rather than a fix, so no hard feelings if you would rather leave the default alone — I am opening it because it was the single change that made the app feel most native on Windows in my own build.

One thing I looked at and deliberately left out: the plugin has no `stop()`, so it carries `restartNeeded: true` and its buttons stay until a restart when it is turned off. Fixing that properly needs an `unregisterCallback` counterpart in `providers/song-info.ts`, which felt like it belonged in its own PR rather than bundled with a default change. Happy to open that separately if it is welcome.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Taskbar media controls are now enabled by default when the application starts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->