### PR TITLE
feat(win): also build a self-contained NSIS installer

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -30,6 +30,11 @@ win:
         - x64
         - ia32
         - arm64
+    - target: nsis
+      arch:
+        - x64
+        - ia32
+        - arm64
     - target: portable
       arch:
         - x64
@@ -37,6 +42,10 @@ win:
         - arm64
   compression: maximum
 nsisWeb:
+  runAfterFinish: false
+nsis:
+  oneClick: false
+  allowToChangeInstallationDirectory: true
   runAfterFinish: false
 linux:
   icon: assets/generated/icons/png


### PR DESCRIPTION
### Problem

The Windows installer is `nsis-web`, which downloads the application payload from the release while installing. That keeps the download small, but it means the installer does not work without network access to GitHub at install time — offline machines, locked-down corporate networks, or an installer copied onto a USB stick.

A few of the install reports in the tracker read like this (#4594 for instance, though I could not confirm the cause there).

### Change

Adds a plain `nsis` target alongside `nsis-web`, for the same three architectures.

- `nsis-web` stays and still produces `latest.yml`, so `electron-updater` is untouched.
- The artifacts are named differently by electron-builder (`... Web Setup <version>.exe` vs `... Setup <version>.exe`), so nothing collides.
- `oneClick: false` + `allowToChangeInstallationDirectory` matches the behaviour of the web installer flow.

### Cost, which is the real question here

This is not free: it adds three more full installers per Windows release. On my machine an x64 `nsis` build with `compression: maximum` took roughly 3 extra minutes and produced a ~112MB artifact, so expect something like +9 minutes of CI and ~330MB of release assets across the three arches.

If that is too much, an alternative that costs a third as much is building the offline installer for x64 only, which is where practically all of these reports come from. Happy to trim the PR to that — or to close it if the web installer is a deliberate "one installer only" decision.

### What I actually verified

I built the `nsis` target for x64 from this configuration and it produces the installer as expected (`YouTube Music Setup 3.12.0.exe`, ~112MB) with the packaged app running from `win-unpacked`.

To be clear about the limits: I did not run the installer on a disconnected machine, so the offline claim comes from how `nsis` differs from `nsis-web` by construction rather than from a test I ran. I also did not run the full three-arch release build locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Windows installer option for x64, ia32, and arm64 devices.
  * Users can choose the installation directory during setup.
  * The installer no longer launches the application automatically after installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->