### PR TITLE
feat(custom-theme): add folder-based theme engine with CLI, Tokyo Night and Catppuccin Mocha presets

### DIFF
--- a/electron.vite.config.mts
+++ b/electron.vite.config.mts
@@ -128,7 +128,14 @@ export default defineConfig(({ mode }) => {
       sourcemap: isDev ? 'inline' : undefined,
     },
     resolve: {
-      alias: resolveAlias,
+      alias: {
+        ...resolveAlias,
+        'custom-electron-prompt': join(
+          __dirname,
+          'vite-plugins',
+          'custom-electron-prompt-stub.ts',
+        ),
+      },
     },
     server: {
       cors: {

--- a/src/i18n/resources/en.json
+++ b/src/i18n/resources/en.json
@@ -236,6 +236,53 @@
       },
       "name": "Album Color Theme"
     },
+    "custom-theme": {
+      "description": "Applies a custom theme app-wide including colors, with a green-on-black CLI preset",
+      "menu": {
+        "colors": {
+          "label": "Colors",
+          "submenu": {
+            "accent-color": "Accent color",
+            "background-color": "Background color",
+            "surface-color": "Surface color",
+            "text-color": "Text color"
+          }
+        },
+        "reset": {
+          "label": "Reset colors"
+        },
+        "theme": {
+          "label": "Theme",
+          "submenu": {
+            "cli": {
+              "label": "CLI"
+            },
+            "custom": {
+              "label": "Custom"
+            }
+          }
+        }
+      },
+      "name": "Custom Theme",
+      "prompt": {
+        "accent-color": {
+          "label": "Accent color (hex)",
+          "title": "Accent color"
+        },
+        "background-color": {
+          "label": "Background color (hex)",
+          "title": "Background color"
+        },
+        "surface-color": {
+          "label": "Surface color (hex)",
+          "title": "Surface color"
+        },
+        "text-color": {
+          "label": "Text color (hex)",
+          "title": "Text color"
+        }
+      }
+    },
     "ambient-mode": {
       "description": "Applies a lighting effect by casting gentle colors from the video, into your screen’s background",
       "menu": {

--- a/src/plugins/custom-theme/README.md
+++ b/src/plugins/custom-theme/README.md
@@ -1,0 +1,31 @@
+# Custom Theme
+
+A theme engine for `pear-desktop`. Themes are **self-contained folders** dropped
+straight into this directory — no editing of plugin source is required.
+
+## Built-in themes
+
+| id               | colours         | layout                    |
+| ---------------- | --------------- | ------------------------- |
+| custom           | user-picked     | vanilla YT Music          |
+| cli              | green-on-black  | flat, monospace, terminal |
+| tokyo-night      | blue-on-navy    | vanilla + accent touches  |
+| catppuccin-mocha | pastel lavender | vanilla + accent touches  |
+
+On the `custom` theme the colours in **Colors ▸ …** apply as you pick them.
+Selecting a built-in theme applies its own palette instead — the user colours
+are ignored until you switch back to `custom`.
+
+## Adding a new theme
+
+Create a folder whose name is the id, add `index.ts` and `style.css`, done.
+See [`_template/theme.md`](./_template/theme.md) for a full walkthrough and
+a copy-paste starting point.
+
+## How it works
+
+`themes.ts` uses `import.meta.glob('./*/index.ts', { eager: true })` to
+discover every subfolder with an `index.ts` at build time. Each file must
+`export default` a `PearTheme` (from `./types`). The radio list in the menu
+and the active-theme logic both read from this loader, so adding or removing a
+folder is enough to register or deregister a theme.

--- a/src/plugins/custom-theme/_template/theme.md
+++ b/src/plugins/custom-theme/_template/theme.md
@@ -1,0 +1,86 @@
+# Writing a custom theme
+
+Themes are small ES modules. Each theme is a folder directly under
+`src/plugins/custom-theme/` whose folder name is the theme id (like the
+built-in `cli/`). There is nothing to register: the plugin discovers themes
+automatically.
+
+## Minimal structure
+
+```
+src/plugins/custom-theme/<your-theme-id>/
+  index.ts        # exports the theme definition (default export)
+  style.css       # your styles, imported with `?inline`
+```
+
+## index.ts
+
+```ts
+import type { PearTheme } from '../types';
+
+import style from './style.css?inline';
+
+const theme: PearTheme = {
+  id: '<your-theme-id>', // must match the folder name
+  name: 'My Theme', // shown in the Plugins > Options menu
+  description: 'What it does', // optional
+  author: 'You', // optional
+  palette: {
+    accentColor: '#ff0000',
+    backgroundColor: '#030303',
+    surfaceColor: '#1f1f1f',
+    textColor: '#ffffff',
+  },
+  css: style,
+  // Optional: DOM work that runs when the theme is activated.
+  // context.getConfig() resolves the live config; context.applyPalette()
+  // re-applies palette colors.
+  // Return a cleanup function; it runs when the theme is deactivated.
+  mount(context) {
+    document.body.classList.add('my-theme-marker');
+    const observer = new MutationObserver(() => {
+      document.body.classList.add('my-theme-marker');
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+    return () => {
+      observer.disconnect();
+      document.body.classList.remove('my-theme-marker');
+    };
+  },
+  // Optional: runs on deactivate, before the mount cleanup.
+  unmount() {},
+};
+
+export default theme;
+```
+
+The pointer `PearTheme` is defined in `src/plugins/custom-theme/types.ts`.
+
+## style.css
+
+Write plain CSS. It is injected into `<head>` only while your theme is active
+and removed afterwards, so you do not need to undo anything manually. The
+`custom-theme` plugin defines these CSS variables you can build on:
+
+- `--pear-theme-accent`, `--pear-theme-bg`, `--pear-theme-surface`,
+  `--pear-theme-text` (resolved from your `palette`)
+- The standard YT Music palette (`--ytmusic-color-black1`,
+  `--yt-spec-base-background`, ...) is remapped to the theme colors by the
+  base plugin stylesheet.
+
+Target known YT Music elements (`ytmusic-app-layout`, `ytmusic-player-bar`,
+`ytmusic-guide-renderer`, etc.) — see the built-in `cli/style.css` for
+examples of a full layout restyle.
+
+## Rules
+
+- Keep the module pure: no top-level DOM access. `index.ts` runs in the main
+  process too (the menu needs the theme list), so top-level `window` or
+  `document` would crash the app. Do DOM work inside `mount()` only.
+- If your `index.ts` is invalid or missing an id/palette/css, the theme is
+  skipped (a warning is logged in dev).
+
+## Result
+
+Your theme appears as a radio item under **Plugins > Custom Theme > Theme**
+right after saving, with zero edits to plugin code.

--- a/src/plugins/custom-theme/catppuccin-mocha/index.ts
+++ b/src/plugins/custom-theme/catppuccin-mocha/index.ts
@@ -1,0 +1,25 @@
+import style from './style.css?inline';
+
+import type { PearTheme } from '../types';
+
+const catppuccinMocha: PearTheme = {
+  id: 'catppuccin-mocha',
+  name: 'Catppuccin Mocha',
+  description: 'Cozy pastel palette from the Catppuccin Mocha flavor',
+  author: 'pear-desktop',
+  palette: {
+    accentColor: '#cba6f7',
+    backgroundColor: '#1e1e2e',
+    surfaceColor: '#313244',
+    textColor: '#cdd6f4',
+  },
+  css: style,
+  mount() {
+    document.body.classList.add('pear-catppuccin-theme');
+    return () => {
+      document.body.classList.remove('pear-catppuccin-theme');
+    };
+  },
+};
+
+export default catppuccinMocha;

--- a/src/plugins/custom-theme/catppuccin-mocha/style.css
+++ b/src/plugins/custom-theme/catppuccin-mocha/style.css
@@ -1,0 +1,36 @@
+/* Small accent touches for the Catppuccin Mocha palette. Applied only while
+   the theme is active; colors come from the --pear-theme-* vars. */
+
+body.pear-catppuccin-theme ::selection {
+  background: color-mix(in srgb, var(--pear-theme-accent) 30%, transparent);
+  color: var(--pear-theme-text);
+}
+
+body.pear-catppuccin-theme
+  ytmusic-guide-entry-renderer.is-active
+  #line.ytmusic-guide-entry-renderer {
+  background: var(--pear-theme-accent) !important;
+}
+
+body.pear-catppuccin-theme
+  ytmusic-guide-entry-renderer.is-active
+  tp-yt-paper-item {
+  color: var(--pear-theme-accent) !important;
+}
+
+body.pear-catppuccin-theme ytmusic-nav-bar .tab.selected {
+  color: var(--pear-theme-accent) !important;
+  border-bottom-color: var(--pear-theme-accent) !important;
+}
+
+body.pear-catppuccin-theme *::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--pear-theme-accent) 35%, transparent);
+  border-radius: 4px;
+}
+
+body.pear-catppuccin-theme
+  ytmusic-player-bar
+  #progress-bar.ytmusic-player-bar:hover
+  .paper-slider-knob {
+  box-shadow: 0 0 6px var(--pear-theme-accent);
+}

--- a/src/plugins/custom-theme/cli/index.ts
+++ b/src/plugins/custom-theme/cli/index.ts
@@ -1,0 +1,45 @@
+import style from './style.css?inline';
+
+import type { PearTheme } from '../types';
+
+const cli: PearTheme = {
+  id: 'cli',
+  name: 'CLI',
+  description: 'Terminal-style green-on-black layout',
+  author: 'pear-desktop',
+  palette: {
+    accentColor: '#22c55e',
+    backgroundColor: '#0a0a0a',
+    surfaceColor: '#141414',
+    textColor: '#e5e7eb',
+  },
+  css: style,
+  mount() {
+    document.body.classList.add('pear-cli-theme');
+
+    const layout = document.querySelector('ytmusic-app-layout');
+    if (!layout) {
+      return () => {
+        document.body.classList.remove('pear-cli-theme');
+      };
+    }
+
+    layout.classList.add('pear-cli-theme');
+
+    const apply = () => {
+      document.body.classList.add('pear-cli-theme');
+      layout.classList.add('pear-cli-theme');
+    };
+
+    const observer = new MutationObserver(apply);
+    observer.observe(layout, { childList: true, subtree: true });
+
+    return () => {
+      observer.disconnect();
+      layout.classList.remove('pear-cli-theme');
+      document.body.classList.remove('pear-cli-theme');
+    };
+  },
+};
+
+export default cli;

--- a/src/plugins/custom-theme/cli/style.css
+++ b/src/plugins/custom-theme/cli/style.css
@@ -1,0 +1,82 @@
+/* Terminal look, applied only while the cli theme is active
+   (this stylesheet is injected into <head> by the plugin). */
+
+/* Monospace everywhere (declared on containers so descendants inherit;
+   icon fonts override their own family and stay intact). */
+body.pear-cli-theme > ytmusic-app,
+body.pear-cli-theme ytmusic-app-layout,
+body.pear-cli-theme ytmusic-player-bar,
+body.pear-cli-theme ytmusic-nav-bar,
+body.pear-cli-theme ytmusic-player,
+body.pear-cli-theme ytmusic-browse-response {
+  font-family:
+    ui-monospace, 'SF Mono', 'Cascadia Mono', Consolas, 'Liberation Mono',
+    'DejaVu Sans Mono', monospace !important;
+}
+
+body.pear-cli-theme ytmusic-app-layout {
+  --ytmusic-nav-bar-offset: 0px;
+}
+
+body.pear-cli-theme ytmusic-app-layout > #content {
+  padding-top: 0 !important;
+  width: 100% !important;
+}
+
+body.pear-cli-theme ytmusic-app-layout > [slot='player-page'] {
+  margin-top: 0 !important;
+  height: calc(100vh - var(--ytmusic-player-bar-height, 72px)) !important;
+}
+
+/* Hide the chrome that a single-column terminal layout doesn't need. */
+body.pear-cli-theme ytmusic-guide-renderer,
+body.pear-cli-theme #mini-guide-spacer.ytmusic-app,
+body.pear-cli-theme #guide-spacer.ytmusic-app,
+body.pear-cli-theme ytmusic-nav-bar,
+body.pear-cli-theme #nav-bar-background.ytmusic-app-layout,
+body.pear-cli-theme #nav-bar-divider.ytmusic-app-layout,
+body.pear-cli-theme .background-gradient.style-scope,
+body.pear-cli-theme
+  ytmusic-app-layout
+  ytmusic-player-page[is-mweb-modernization-enabled]
+  .side-panel.ytmusic-player-page
+  .background-gradient.ytmusic-browse-response {
+  display: none !important;
+}
+
+/* Flat, box-drawn player bar. */
+body.pear-cli-theme ytmusic-player-bar {
+  border-radius: 0 !important;
+  border-top: 1px solid var(--pear-theme-accent) !important;
+  box-shadow: none !important;
+}
+
+/* Single-column reorder: art/title left, transport center, time far right. */
+body.pear-cli-theme ytmusic-player-bar #left-controls.ytmusic-player-bar {
+  order: 1 !important;
+}
+
+body.pear-cli-theme ytmusic-player-bar .middle-controls.ytmusic-player-bar {
+  order: 2 !important;
+}
+
+body.pear-cli-theme ytmusic-player-bar .right-controls.ytmusic-player-bar {
+  order: 3 !important;
+}
+
+body.pear-cli-theme ytmusic-player-bar .time-info.ytmusic-player-bar {
+  order: 4 !important;
+}
+
+/* Thin, square, accent progress bar. */
+body.pear-cli-theme ytmusic-player-bar #progress-bar.ytmusic-player-bar {
+  height: 2px !important;
+  border-radius: 0 !important;
+}
+
+body.pear-cli-theme
+  ytmusic-player-bar
+  #progress-bar.ytmusic-player-bar
+  [class*='knob'] {
+  border-radius: 0 !important;
+}

--- a/src/plugins/custom-theme/index.ts
+++ b/src/plugins/custom-theme/index.ts
@@ -1,0 +1,281 @@
+import prompt from 'custom-electron-prompt';
+
+import { t } from '@/i18n';
+import promptOptions from '@/providers/prompt-options';
+import { createPlugin } from '@/utils';
+
+import style from './style.css?inline';
+import { getTheme, themes } from './themes';
+import {
+  defaultColors,
+  defaultConfig,
+  type CustomThemeConfig,
+  type PearTheme,
+  type ThemePalette,
+} from './types';
+
+import type { MenuTemplate } from '@/menu';
+import type { MenuContext, RendererContext } from '@/types/contexts';
+
+export type { CustomThemeConfig } from './types';
+
+const CSS_VARIABLES = {
+  accent: '--pear-theme-accent',
+  background: '--pear-theme-bg',
+  surface: '--pear-theme-surface',
+  text: '--pear-theme-text',
+} as const;
+
+type RendererProperties = {
+  themeCssElement: HTMLStyleElement | null;
+  activeTheme: string | null;
+  themeCleanup: (() => void) | null;
+  context: RendererContext<CustomThemeConfig> | null;
+  applyColors(colors: ThemePalette): void;
+  applyConfig(config: CustomThemeConfig): void;
+  applyTheme(theme: PearTheme | undefined, config: CustomThemeConfig): void;
+  clearTheme(): void;
+};
+
+const isHexColor = (value: string): value is `#${string}` =>
+  /^#[0-9a-f]{6}$/i.test(value);
+
+const promptColor = async (
+  window: Electron.BrowserWindow,
+  title: string,
+  label: string,
+  current: string,
+) => {
+  const result = await prompt(
+    {
+      title,
+      label,
+      value: current,
+      type: 'input',
+      inputAttrs: {
+        type: 'text',
+        placeholder: '#rrggbb',
+        required: true,
+        maxLength: 7,
+      },
+      width: 380,
+      ...promptOptions(),
+    },
+    window,
+  );
+
+  return typeof result === 'string' && isHexColor(result) ? result : null;
+};
+
+export default createPlugin<
+  unknown,
+  unknown,
+  RendererProperties,
+  CustomThemeConfig
+>({
+  name: () => t('plugins.custom-theme.name'),
+  description: () => t('plugins.custom-theme.description'),
+  restartNeeded: false,
+  addedVersion: '3.13.X',
+  config: defaultConfig,
+  stylesheets: [style],
+  menu: async ({
+    getConfig,
+    setConfig,
+    window,
+  }: MenuContext<CustomThemeConfig>): Promise<MenuTemplate> => {
+    const config = await getConfig();
+
+    return [
+      {
+        label: t('plugins.custom-theme.menu.theme.label'),
+        submenu: [
+          {
+            label: t('plugins.custom-theme.menu.theme.submenu.custom.label'),
+            type: 'radio',
+            checked: config.theme === 'custom',
+            click() {
+              setConfig({ ...config, theme: 'custom' });
+            },
+          },
+          ...themes.map<MenuTemplate[number]>((theme) => ({
+            label: theme.name,
+            type: 'radio',
+            checked: config.theme === theme.id,
+            click() {
+              setConfig({ ...config, theme: theme.id });
+            },
+          })),
+        ],
+      },
+      {
+        label: t('plugins.custom-theme.menu.colors.label'),
+        submenu: [
+          {
+            label: t('plugins.custom-theme.menu.colors.submenu.accent-color'),
+            type: 'normal',
+            async click() {
+              const current = await getConfig();
+              const value = await promptColor(
+                window,
+                t('plugins.custom-theme.prompt.accent-color.title'),
+                t('plugins.custom-theme.prompt.accent-color.label'),
+                current.accentColor,
+              );
+              if (value) {
+                setConfig({ ...current, accentColor: value });
+              }
+            },
+          },
+          {
+            label: t(
+              'plugins.custom-theme.menu.colors.submenu.background-color',
+            ),
+            type: 'normal',
+            async click() {
+              const current = await getConfig();
+              const value = await promptColor(
+                window,
+                t('plugins.custom-theme.prompt.background-color.title'),
+                t('plugins.custom-theme.prompt.background-color.label'),
+                current.backgroundColor,
+              );
+              if (value) {
+                setConfig({ ...current, backgroundColor: value });
+              }
+            },
+          },
+          {
+            label: t('plugins.custom-theme.menu.colors.submenu.surface-color'),
+            type: 'normal',
+            async click() {
+              const current = await getConfig();
+              const value = await promptColor(
+                window,
+                t('plugins.custom-theme.prompt.surface-color.title'),
+                t('plugins.custom-theme.prompt.surface-color.label'),
+                current.surfaceColor,
+              );
+              if (value) {
+                setConfig({ ...current, surfaceColor: value });
+              }
+            },
+          },
+          {
+            label: t('plugins.custom-theme.menu.colors.submenu.text-color'),
+            type: 'normal',
+            async click() {
+              const current = await getConfig();
+              const value = await promptColor(
+                window,
+                t('plugins.custom-theme.prompt.text-color.title'),
+                t('plugins.custom-theme.prompt.text-color.label'),
+                current.textColor,
+              );
+              if (value) {
+                setConfig({ ...current, textColor: value });
+              }
+            },
+          },
+        ],
+      },
+      {
+        label: t('plugins.custom-theme.menu.reset.label'),
+        type: 'normal',
+        click() {
+          setConfig({ ...defaultColors });
+        },
+      },
+    ];
+  },
+  renderer: {
+    themeCssElement: null,
+    activeTheme: null,
+    themeCleanup: null,
+    context: null,
+    applyColors(colors) {
+      const root = document.documentElement;
+      root.style.setProperty(
+        CSS_VARIABLES.accent,
+        colors.accentColor,
+        'important',
+      );
+      root.style.setProperty(
+        CSS_VARIABLES.background,
+        colors.backgroundColor,
+        'important',
+      );
+      root.style.setProperty(
+        CSS_VARIABLES.surface,
+        colors.surfaceColor,
+        'important',
+      );
+      root.style.setProperty(CSS_VARIABLES.text, colors.textColor, 'important');
+    },
+    applyTheme(theme, config) {
+      const previous = this.activeTheme
+        ? getTheme(this.activeTheme)
+        : undefined;
+      previous?.unmount?.();
+      this.themeCleanup?.();
+      this.themeCleanup = null;
+      this.themeCssElement?.remove();
+      this.themeCssElement = null;
+
+      if (theme) {
+        this.applyColors(theme.palette);
+        this.activeTheme = theme.id;
+
+        if (theme.css) {
+          const element = document.createElement('style');
+          element.setAttribute('data-pear-theme-css', theme.id);
+          element.textContent = theme.css;
+          document.head.appendChild(element);
+          this.themeCssElement = element;
+        }
+
+        const cleanup = theme.mount?.({
+          ...(this.context as RendererContext<CustomThemeConfig>),
+          applyPalette: (palette) => this.applyColors(palette),
+        });
+        this.themeCleanup = typeof cleanup === 'function' ? cleanup : null;
+      } else {
+        this.applyColors(config);
+        this.activeTheme = null;
+      }
+    },
+    applyConfig(config) {
+      const theme =
+        config.theme === 'custom' ? undefined : getTheme(config.theme);
+
+      this.applyTheme(theme, config);
+    },
+    clearTheme() {
+      const previous = this.activeTheme
+        ? getTheme(this.activeTheme)
+        : undefined;
+      previous?.unmount?.();
+      this.themeCleanup?.();
+      this.themeCleanup = null;
+      this.themeCssElement?.remove();
+      this.themeCssElement = null;
+      this.activeTheme = null;
+
+      const root = document.documentElement;
+      root.style.removeProperty(CSS_VARIABLES.accent);
+      root.style.removeProperty(CSS_VARIABLES.background);
+      root.style.removeProperty(CSS_VARIABLES.surface);
+      root.style.removeProperty(CSS_VARIABLES.text);
+    },
+    async start(context: RendererContext<CustomThemeConfig>) {
+      this.context = context;
+      this.applyConfig(await context.getConfig());
+    },
+    onConfigChange(config: CustomThemeConfig) {
+      this.applyConfig(config);
+    },
+    stop() {
+      this.clearTheme();
+    },
+  },
+});

--- a/src/plugins/custom-theme/style.css
+++ b/src/plugins/custom-theme/style.css
@@ -1,0 +1,60 @@
+:root {
+  --pear-theme-accent: #ff0000;
+  --pear-theme-bg: #030303;
+  --pear-theme-surface: #1f1f1f;
+  --pear-theme-text: #ffffff;
+}
+
+/* Base colors */
+:root {
+  --ytmusic-color-black1: var(--pear-theme-surface) !important;
+  --ytmusic-color-black2: var(--pear-theme-surface) !important;
+  --ytmusic-color-black3: var(--pear-theme-bg) !important;
+  --ytmusic-color-black4: var(--pear-theme-bg) !important;
+  --ytmusic-color-blackpure: var(--pear-theme-bg) !important;
+  --dark-theme-background-color: var(--pear-theme-surface) !important;
+  --yt-spec-base-background: var(--pear-theme-bg) !important;
+  --yt-spec-raised-background: var(--pear-theme-surface) !important;
+  --yt-spec-menu-background: var(--pear-theme-surface) !important;
+  --yt-spec-general-background-a: var(--pear-theme-surface) !important;
+  --yt-spec-general-background-b: var(--pear-theme-bg) !important;
+  --yt-spec-general-background-c: var(--pear-theme-bg) !important;
+  --yt-spec-snackbar-background: var(--pear-theme-bg) !important;
+  --yt-spec-filled-button-text: var(--pear-theme-surface) !important;
+  --yt-spec-black-pure: var(--pear-theme-bg) !important;
+  --yt-spec-black-1-alpha-98: var(--pear-theme-bg) !important;
+  --yt-spec-static-brand-black: var(--pear-theme-surface) !important;
+  --yt-spec-static-overlay-background-solid: var(--pear-theme-bg) !important;
+  --ytmusic-search-background: var(--pear-theme-bg) !important;
+  --paper-toast-background-color: var(--pear-theme-surface) !important;
+  --paper-dialog-background-color: var(--pear-theme-surface) !important;
+  background: var(--pear-theme-bg) !important;
+  --ytmusic-background: var(--pear-theme-bg) !important;
+}
+
+/* Text color */
+:root {
+  --yt-spec-text-primary: var(--pear-theme-text) !important;
+  --yt-spec-text-secondary: var(--pear-theme-text) !important;
+  --ytmusic-text-primary: var(--pear-theme-text) !important;
+}
+
+ytmusic-app-layout {
+  color: var(--pear-theme-text) !important;
+}
+
+/* Accent color */
+.seekbar-theme #progress-bar.ytmusic-player-bar,
+#progress-bar.ytmusic-player-bar {
+  --paper-progress-active-color-1: var(--pear-theme-accent) !important;
+  --paper-progress-active-color-2: var(--pear-theme-accent) !important;
+  --paper-slider-knob-color: var(--pear-theme-accent) !important;
+  --paper-slider-knob-start-color: var(--pear-theme-accent) !important;
+}
+
+/* Fix local background gradient */
+.background-gradient.style-scope,
+ytmusic-app-layout[is-bauhaus-sidenav-enabled]
+  #mini-guide-background.ytmusic-app-layout {
+  background: var(--ytmusic-background) !important;
+}

--- a/src/plugins/custom-theme/themes.ts
+++ b/src/plugins/custom-theme/themes.ts
@@ -13,7 +13,11 @@ for (const module of Object.values(themeModules)) {
     typeof theme.id === 'string' &&
     typeof theme.name === 'string' &&
     typeof theme.css === 'string' &&
-    Boolean(theme.palette)
+    !!theme.palette &&
+    typeof theme.palette.accentColor === 'string' &&
+    typeof theme.palette.backgroundColor === 'string' &&
+    typeof theme.palette.surfaceColor === 'string' &&
+    typeof theme.palette.textColor === 'string'
   ) {
     themes.push(theme);
   }

--- a/src/plugins/custom-theme/themes.ts
+++ b/src/plugins/custom-theme/themes.ts
@@ -1,0 +1,23 @@
+import type { PearTheme } from './types';
+
+const themeModules: Record<string, unknown> = import.meta.glob('./*/index.ts', {
+  eager: true,
+});
+
+export const themes: PearTheme[] = [];
+
+for (const module of Object.values(themeModules)) {
+  const theme = (module as { default?: PearTheme }).default;
+  if (
+    theme &&
+    typeof theme.id === 'string' &&
+    typeof theme.name === 'string' &&
+    typeof theme.css === 'string' &&
+    Boolean(theme.palette)
+  ) {
+    themes.push(theme);
+  }
+}
+
+export const getTheme = (id?: string): PearTheme | undefined =>
+  themes.find((theme) => theme.id === id);

--- a/src/plugins/custom-theme/tokyo-night/index.ts
+++ b/src/plugins/custom-theme/tokyo-night/index.ts
@@ -1,0 +1,26 @@
+import style from './style.css?inline';
+
+import type { PearTheme } from '../types';
+
+const tokyoNight: PearTheme = {
+  id: 'tokyo-night',
+  name: 'Tokyo Night',
+  description:
+    'Blue-dominant night palette inspired by the Tokyo Night editor scheme',
+  author: 'pear-desktop',
+  palette: {
+    accentColor: '#7aa2f7',
+    backgroundColor: '#1a1b26',
+    surfaceColor: '#24283b',
+    textColor: '#c0caf5',
+  },
+  css: style,
+  mount() {
+    document.body.classList.add('pear-tokyo-night-theme');
+    return () => {
+      document.body.classList.remove('pear-tokyo-night-theme');
+    };
+  },
+};
+
+export default tokyoNight;

--- a/src/plugins/custom-theme/tokyo-night/style.css
+++ b/src/plugins/custom-theme/tokyo-night/style.css
@@ -1,0 +1,36 @@
+/* Small accent touches for the Tokyo Night palette. Applied only while the
+   theme is active; colors come from the --pear-theme-* vars. */
+
+body.pear-tokyo-night-theme ::selection {
+  background: color-mix(in srgb, var(--pear-theme-accent) 30%, transparent);
+  color: var(--pear-theme-text);
+}
+
+body.pear-tokyo-night-theme
+  ytmusic-guide-entry-renderer.is-active
+  #line.ytmusic-guide-entry-renderer {
+  background: var(--pear-theme-accent) !important;
+}
+
+body.pear-tokyo-night-theme
+  ytmusic-guide-entry-renderer.is-active
+  tp-yt-paper-item {
+  color: var(--pear-theme-accent) !important;
+}
+
+body.pear-tokyo-night-theme ytmusic-nav-bar .tab.selected {
+  color: var(--pear-theme-accent) !important;
+  border-bottom-color: var(--pear-theme-accent) !important;
+}
+
+body.pear-tokyo-night-theme *::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--pear-theme-accent) 35%, transparent);
+  border-radius: 4px;
+}
+
+body.pear-tokyo-night-theme
+  ytmusic-player-bar
+  #progress-bar.ytmusic-player-bar:hover
+  .paper-slider-knob {
+  box-shadow: 0 0 6px var(--pear-theme-accent);
+}

--- a/src/plugins/custom-theme/types.ts
+++ b/src/plugins/custom-theme/types.ts
@@ -1,0 +1,43 @@
+import type { RendererContext } from '@/types/contexts';
+
+export type CustomThemeConfig = {
+  enabled: boolean;
+  theme: string;
+  accentColor: string;
+  backgroundColor: string;
+  surfaceColor: string;
+  textColor: string;
+};
+
+export type ThemePalette = Pick<
+  CustomThemeConfig,
+  'accentColor' | 'backgroundColor' | 'surfaceColor' | 'textColor'
+>;
+
+export type ThemeMountContext = RendererContext<CustomThemeConfig> & {
+  applyPalette: (palette: ThemePalette) => void;
+};
+
+export type PearTheme = {
+  id: string;
+  name: string;
+  description?: string;
+  author?: string;
+  palette: ThemePalette;
+  css: string;
+  mount?: (context: ThemeMountContext) => (() => void) | void;
+  unmount?: () => void;
+};
+
+export const defaultColors: ThemePalette = {
+  accentColor: '#ff0000',
+  backgroundColor: '#030303',
+  surfaceColor: '#1f1f1f',
+  textColor: '#ffffff',
+};
+
+export const defaultConfig: CustomThemeConfig = {
+  enabled: false,
+  theme: 'custom',
+  ...defaultColors,
+};

--- a/vite-plugins/custom-electron-prompt-stub.ts
+++ b/vite-plugins/custom-electron-prompt-stub.ts
@@ -1,0 +1,7 @@
+const prompt = (_options: unknown, _parentWindow?: unknown): Promise<unknown> => {
+	throw new Error(
+		'custom-electron-prompt is only available in the main process',
+	);
+};
+
+export default prompt;


### PR DESCRIPTION
Hey, here's the custom-theme work from #4694, plus a small hardening fix.

What's in here:
- A folder-based theme engine under src/plugins/custom-theme - drop a theme folder with an index.ts and a style.css and it gets picked up automatically.
- Three starting themes: CLI, Tokyo Night, and Catppuccin Mocha.
- Theme validation now actually checks the palette. Before, it only made sure a palette object existed, so a theme could register with partially broken colors. Now it's rejected if any of accentColor, backgroundColor, surfaceColor, or textColor is missing or isn't a string.

Lint and typecheck both pass. The three bundled themes all have complete palettes, so nothing changes for them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a custom theme plugin with selectable accent, background, surface, and text colors.
  - Added theme reset controls and localized labels.
  - Added built-in Custom, CLI, Tokyo Night, and Catppuccin Mocha themes.
  - Added theme-specific styling, including terminal-inspired layouts and accent highlights.
  - Themes can be selected and applied dynamically without restarting the app.

- **Documentation**
  - Added guidance for creating and adding custom themes, including available styling options and configuration requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->